### PR TITLE
[cleanup] Guard MSVC specific functions.

### DIFF
--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -97,8 +97,6 @@ static INLINE vint2 vreinterpret_vi2_vd(vdouble vd) {
 /****************************************/
 // Broadcast
 static INLINE vfloat vcast_vf_f(float f) { return vdupq_n_f32(f); }
-// Extract lane 0
-static INLINE float vcast_f_vf(vfloat v) { return vgetq_lane_f32(v, 0); }
 
 // Add, Sub, Mul, Reciprocal 1/x, Division, Square root
 static INLINE vfloat vadd_vf_vf_vf(vfloat x, vfloat y) {

--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -427,12 +427,14 @@ static INLINE vfloat vloadu_vf_p(const float *ptr) { return _mm256_loadu_ps(ptr)
 static INLINE void vstore_v_p_vf(float *ptr, vfloat v) { _mm256_store_ps(ptr, v); }
 static INLINE void vstoreu_v_p_vf(float *ptr, vfloat v) { _mm256_storeu_ps(ptr, v); }
 
+#ifdef _MSC_VER
+// This function is needed when debugging on MSVC.
 static INLINE float vcast_f_vf(vfloat v) {
   float a[VECTLENSP];
   vstoreu_v_p_vf(a, v);
   return a[0];
 }
-
+#endif
 //
 
 #define PNMASK ((vdouble) { +0.0, -0.0, +0.0, -0.0 })

--- a/src/arch/helperavx2.h
+++ b/src/arch/helperavx2.h
@@ -296,11 +296,14 @@ static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
 
+#ifdef _MSC_VER
+// This function is needed when debugging on MSVC.
 static INLINE float vcast_f_vf(vfloat v) {
   float s[8];
   _mm256_storeu_ps(s, v);
   return s[0];
 }
+#endif
 
 static INLINE vfloat vload_vf_p(const float *ptr) { return _mm256_load_ps(ptr); }
 static INLINE vfloat vloadu_vf_p(const float *ptr) { return _mm256_loadu_ps(ptr); }

--- a/src/arch/helperavx512f.h
+++ b/src/arch/helperavx512f.h
@@ -315,11 +315,14 @@ static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
 
 static INLINE vint2 vilogbk_vi2_vf(vfloat d) { return vrint_vi2_vf(_mm512_getexp_ps(d)); }
 
+#ifdef _MSC_VER
+// This function is needed when debugging on MSVC.
 static INLINE float vcast_f_vf(vfloat v) {
   float s[VECTLENSP];
   _mm512_storeu_ps(s, v);
   return s[0];
 }
+#endif
 
 static INLINE vfloat vload_vf_p(const float *ptr) { return _mm512_load_ps(ptr); }
 static INLINE vfloat vloadu_vf_p(const float *ptr) { return _mm512_loadu_ps(ptr); }

--- a/src/arch/helperneon32.h
+++ b/src/arch/helperneon32.h
@@ -170,11 +170,14 @@ static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
 
+#ifdef _MSC_VER
+// This function is needed when debugging on MSVC.
 static INLINE float vcast_f_vf(vfloat v) {
   float p[4];
   vst1q_f32 (p, v);
   return p[0];
 }
+#endif
 
 static INLINE int vavailability_i(int name) {
   if (name != 2) return 0;

--- a/src/arch/helperpurec.h
+++ b/src/arch/helperpurec.h
@@ -367,7 +367,10 @@ static INLINE vint2   vgt_vi2_vi2_vi2(vint2 x, vint2 y) { vopmask ret; for(int i
 
 static INLINE vfloat vsqrt_vf_vf(vfloat x) { vfloat ret; for(int i=0;i<VECTLENSP;i++) ret.f[i] = sqrtf(x.f[i]); return ret; }
 
+#ifdef _MSC_VER
+// This function is needed when debugging on MSVC.
 static INLINE float vcast_f_vf(vfloat v) { return v.f[0]; }
+#endif
 
 static INLINE vfloat vload_vf_p(const float *ptr) { return *(vfloat *)ptr; }
 static INLINE vfloat vloadu_vf_p(const float *ptr) {

--- a/src/arch/helpersse2.h
+++ b/src/arch/helpersse2.h
@@ -339,12 +339,14 @@ static INLINE vfloat vloadu_vf_p(const float *ptr) { return _mm_loadu_ps(ptr); }
 static INLINE void vstore_v_p_vf(float *ptr, vfloat v) { _mm_store_ps(ptr, v); }
 static INLINE void vstoreu_v_p_vf(float *ptr, vfloat v) { _mm_storeu_ps(ptr, v); }
 
+#ifdef _MSC_VER
+// This function is useful when debugging on MSVC.
 static INLINE float vcast_f_vf(vfloat v) {
   float a[VECTLENSP];
   vstoreu_v_p_vf(a, v);
   return a[0];
 }
-
+#endif
 //
 
 #define PNMASK ((vdouble) { +0.0, -0.0 })

--- a/src/arch/helpervecext.h
+++ b/src/arch/helpervecext.h
@@ -703,8 +703,6 @@ static INLINE vfloat vsqrt_vf_vf(vfloat d) {
   return x * q;
 }
 
-static INLINE float vcast_f_vf(vfloat v) { return v[0]; }
-
 static INLINE vfloat vload_vf_p(const float *ptr) { return *(vfloat *)ptr; }
 static INLINE vfloat vloadu_vf_p(const float *ptr) {
   vfloat vf;


### PR DESCRIPTION
The `vcastf_f_vf` routine is needed only when debugging with
MSVC. This patch enables the function when compiling with MSVC, for
those architectures that MSVC supports.