### PR TITLE
This patch fixes potential problems in ulp 1 versions of trig functions.

### DIFF
--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -189,13 +189,31 @@ static INLINE CONST Sleef_double2 ddneg_d2_d2(Sleef_double2 d) {
   return r;
 }
 
+/*
+ * ddadd and ddadd2 are functions for double-double addition.  ddadd
+ * is simpler and faster than ddadd2, but it requires the absolute
+ * value of first argument to be larger than the second argument. The
+ * exact condition that should be met is checked if NDEBUG macro is
+ * not defined.
+ *
+ * Please note that if the results won't be used, it is no problem to
+ * feed arguments that do not meet this condition. You will see
+ * warning messages if you turn off NDEBUG macro and run tester2, but
+ * this is normal.
+ * 
+ * Please see :
+ * Jonathan Richard Shewchuk, Adaptive Precision Floating-Point
+ * Arithmetic and Fast Robust Geometric Predicates, Discrete &
+ * Computational Geometry 18:305-363, 1997.
+ */
+
 static INLINE CONST Sleef_double2 ddadd_d2_d_d(double x, double y) {
   // |x| >= |y|
 
   Sleef_double2 r;
 
 #ifndef NDEBUG
-  if (!(checkfp(x) || checkfp(y) || fabsk(x) >= fabsk(y))) {
+  if (!(checkfp(x) || checkfp(y) || fabsk(x) >= fabsk(y) || (fabs(x+y) <= fabs(x) && fabs(x+y) <= fabs(y)))) {
     fprintf(stderr, "[ddadd_d2_d_d : %g, %g]\n", x, y);
     fflush(stderr);
   }
@@ -223,7 +241,7 @@ static INLINE CONST Sleef_double2 ddadd_d2_d2_d(Sleef_double2 x, double y) {
   Sleef_double2 r;
 
 #ifndef NDEBUG
-  if (!(checkfp(x.x) || checkfp(y) || fabsk(x.x) >= fabsk(y))) {
+  if (!(checkfp(x.x) || checkfp(y) || fabsk(x.x) >= fabsk(y) || (fabs(x.x+y) <= fabs(x.x) && fabs(x.x+y) <= fabs(y)))) {
     fprintf(stderr, "[ddadd_d2_d2_d : %g %g]\n", x.x, y);
     fflush(stderr);
   }
@@ -254,7 +272,7 @@ static INLINE CONST Sleef_double2 ddadd_d2_d_d2(double x, Sleef_double2 y) {
   Sleef_double2 r;
 
 #ifndef NDEBUG
-  if (!(checkfp(x) || checkfp(y.x) || fabsk(x) >= fabsk(y.x))) {
+  if (!(checkfp(x) || checkfp(y.x) || fabsk(x) >= fabsk(y.x) || (fabs(x+y.x) <= fabs(x) && fabs(x+y.x) <= fabs(y.x)))) {
     fprintf(stderr, "[ddadd_d2_d_d2 : %g %g]\n", x, y.x);
     fflush(stderr);
   }
@@ -284,7 +302,7 @@ static INLINE CONST Sleef_double2 ddadd_d2_d2_d2(Sleef_double2 x, Sleef_double2 
   Sleef_double2 r;
 
 #ifndef NDEBUG
-  if (!(checkfp(x.x) || checkfp(y.x) || fabsk(x.x) >= fabsk(y.x))) {
+  if (!(checkfp(x.x) || checkfp(y.x) || fabsk(x.x) >= fabsk(y.x) || (fabs(x.x+y.x) <= fabs(x.x) && fabs(x.x+y.x) <= fabs(y.x)))) {
     fprintf(stderr, "[ddadd_d2_d2_d2 : %g %g]\n", x.x, y.x);
     fflush(stderr);
   }
@@ -315,7 +333,7 @@ static INLINE CONST Sleef_double2 ddsub_d2_d2_d2(Sleef_double2 x, Sleef_double2 
   Sleef_double2 r;
 
 #ifndef NDEBUG
-  if (!(checkfp(x.x) || checkfp(y.x) || fabsk(x.x) >= fabsk(y.x))) {
+  if (!(checkfp(x.x) || checkfp(y.x) || fabsk(x.x) >= fabsk(y.x) || (fabs(x-y) <= fabs(x) && fabs(x-y) <= fabs(y)))) {
     fprintf(stderr, "[ddsub_d2_d2_d2 : %g %g]\n", x.x, y.x);
     fflush(stderr);
   }
@@ -642,12 +660,12 @@ EXPORT CONST double xsin_u1(double d) {
   int qh = trunck(d * (M_1_PI / (1 << 24)));
   int ql = rintk(d * M_1_PI - qh * (double)(1 << 24));
 
-  s = ddadd_d2_d_d (d, qh * (-PI_A * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_A            ));
+  u = mla(qh, -PI_A * (1 << 24), d);
+  s = ddadd_d2_d_d(u, ql * (-PI_A            ));
   s = ddadd2_d2_d2_d(s, qh * (-PI_B * (1 << 24)));
   s = ddadd2_d2_d2_d(s, ql * (-PI_B            ));
-  s = ddadd_d2_d2_d(s, qh * (-PI_C * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_C            ));
+  s = ddadd2_d2_d2_d(s, qh * (-PI_C * (1 << 24)));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_C            ));
   s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * -PI_D);
   
   t = s;
@@ -715,12 +733,12 @@ EXPORT CONST double xcos_u1(double d) {
   int qh = trunck(d * (M_1_PI / (1LL << (23))) - 0.5 * (M_1_PI / (1LL << (23))));
   int ql = 2*rintk(d * M_1_PI - 0.5 - qh * (double)(1LL << (23)))+1;
 
-  s = ddadd_d2_d_d (d, qh * (-PI_A*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_A*0.5            ));
+  u = mla(qh, -PI_A*0.5 * (1 << 24), d);
+  s = ddadd2_d2_d_d(u, ql * (-PI_A*0.5            ));
   s = ddadd2_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
   s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5            ));
-  s = ddadd_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_C*0.5            ));
+  s = ddadd2_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5            ));
   s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));
   
   t = s;
@@ -804,12 +822,12 @@ EXPORT CONST Sleef_double2 xsincos_u1(double d) {
   int qh = trunck(d * ((2 * M_1_PI) / (1 << 24)));
   int ql = rintk(d * (2 * M_1_PI) - qh * (double)(1 << 24));
 
-  s = ddadd_d2_d_d (d, qh * (-PI_A*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_A*0.5            ));
+  u = mla(qh, -PI_A*0.5 * (1 << 24), d);
+  s = ddadd_d2_d_d(u, ql * (-PI_A*0.5            ));
   s = ddadd2_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
   s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5            ));
-  s = ddadd_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_C*0.5            ));
+  s = ddadd2_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5            ));
   s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));
   
   t = s;
@@ -1011,12 +1029,12 @@ EXPORT CONST double xtan_u1(double d) {
   s = ddadd2_d2_d2_d(ddmul_d2_d2_d(dd(M_2_PI_H, M_2_PI_L), d), (d < 0 ? -0.5 : 0.5) - qh * (double)(1 << 24));
   int ql = s.x + s.y;
   
-  s = ddadd_d2_d_d (d, qh * (-PI_A*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_A*0.5            ));
+  u = mla(qh, -PI_A*0.5 * (1 << 24), d);
+  s = ddadd_d2_d_d(u, ql * (-PI_A*0.5            ));
   s = ddadd2_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
   s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5            ));
-  s = ddadd_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_C*0.5            ));
+  s = ddadd2_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5            ));
   s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));
   
   if ((ql & 1) != 0) s = ddneg_d2_d2(s);

--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -643,9 +643,9 @@ EXPORT CONST double xsin_u1(double d) {
   int ql = rintk(d * M_1_PI - qh * (double)(1 << 24));
 
   s = ddadd_d2_d_d (d, qh * (-PI_A * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_A            ));
-  s = ddadd_d2_d2_d(s, qh * (-PI_B * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_B            ));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_A            ));
+  s = ddadd2_d2_d2_d(s, qh * (-PI_B * (1 << 24)));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_B            ));
   s = ddadd_d2_d2_d(s, qh * (-PI_C * (1 << 24)));
   s = ddadd_d2_d2_d(s, ql * (-PI_C            ));
   s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * -PI_D);
@@ -715,13 +715,13 @@ EXPORT CONST double xcos_u1(double d) {
   int qh = trunck(d * (M_1_PI / (1LL << (23))) - 0.5 * (M_1_PI / (1LL << (23))));
   int ql = 2*rintk(d * M_1_PI - 0.5 - qh * (double)(1LL << (23)))+1;
 
-  s = ddadd2_d2_d_d (d, qh * (-PI_A*0.5 * (1 << 24)));
+  s = ddadd_d2_d_d (d, qh * (-PI_A*0.5 * (1 << 24)));
   s = ddadd2_d2_d2_d(s, ql * (-PI_A*0.5            ));
   s = ddadd2_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
   s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5            ));
-  s = ddadd2_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5            ));
-  s = ddadd2_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));
+  s = ddadd_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
+  s = ddadd_d2_d2_d(s, ql * (-PI_C*0.5            ));
+  s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));
   
   t = s;
   s = ddsqu_d2_d2(s);
@@ -805,9 +805,9 @@ EXPORT CONST Sleef_double2 xsincos_u1(double d) {
   int ql = rintk(d * (2 * M_1_PI) - qh * (double)(1 << 24));
 
   s = ddadd_d2_d_d (d, qh * (-PI_A*0.5 * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_A*0.5            ));
-  s = ddadd_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_B*0.5            ));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_A*0.5            ));
+  s = ddadd2_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5            ));
   s = ddadd_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
   s = ddadd_d2_d2_d(s, ql * (-PI_C*0.5            ));
   s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));
@@ -1012,9 +1012,9 @@ EXPORT CONST double xtan_u1(double d) {
   int ql = s.x + s.y;
   
   s = ddadd_d2_d_d (d, qh * (-PI_A*0.5 * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_A*0.5            ));
-  s = ddadd_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
-  s = ddadd_d2_d2_d(s, ql * (-PI_B*0.5            ));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_A*0.5            ));
+  s = ddadd2_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5            ));
   s = ddadd_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
   s = ddadd_d2_d2_d(s, ql * (-PI_C*0.5            ));
   s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -266,12 +266,12 @@ EXPORT CONST vdouble xsin_u1(vdouble d) {
   
   vdouble dql = vcast_vd_vi(ql);
 
-  s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_A * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A            )));
+  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * (1 << 24)), d);
+  s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A            )));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B * (1 << 24))));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C * (1 << 24))));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
 					vcast_vd_d(-PI_D)));
 #endif
@@ -367,12 +367,12 @@ EXPORT CONST vdouble xcos_u1(vdouble d) {
   ql = vadd_vi_vi_vi(vadd_vi_vi_vi(ql, ql), vcast_vi_i(1));
   vdouble dql = vcast_vd_vi(ql);
 
-  s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_A*0.5 * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
+  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5 * (1 << 24)), d);
+  s = ddadd2_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
 					vcast_vd_d(-PI_D*0.5)));
 #endif
@@ -493,12 +493,12 @@ EXPORT CONST vdouble2 xsincos_u1(vdouble d) {
 					 vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI))));
   vdouble dql = vcast_vd_vi(ql);
 
-  s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_A*0.5 * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
+  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5 * (1 << 24)), d);
+  s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
 					vcast_vd_d(-PI_D*0.5)));
 #endif
@@ -763,12 +763,12 @@ EXPORT CONST vdouble xtan_u1(vdouble d) {
   vint ql = vtruncate_vi_vd(vadd_vd_vd_vd(s.x, s.y));
   vdouble dql = vcast_vd_vi(ql);
   
-  s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_A*0.5 * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
+  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5 * (1 << 24)), d);
+  s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
 					vcast_vd_d(-PI_D*0.5)));
 #endif

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -267,9 +267,9 @@ EXPORT CONST vdouble xsin_u1(vdouble d) {
   vdouble dql = vcast_vd_vi(ql);
 
   s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_A * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B * (1 << 24))));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C * (1 << 24))));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
@@ -367,14 +367,14 @@ EXPORT CONST vdouble xcos_u1(vdouble d) {
   ql = vadd_vi_vi_vi(vadd_vi_vi_vi(ql, ql), vcast_vi_i(1));
   vdouble dql = vcast_vd_vi(ql);
 
-  s = ddadd2_vd2_vd_vd (d, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_A*0.5 * (1 << 24))));
+  s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_A*0.5 * (1 << 24))));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
-					 vcast_vd_d(-PI_D*0.5)));
+  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
+  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
+  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
+					vcast_vd_d(-PI_D*0.5)));
 #endif
   
   t = s;
@@ -494,9 +494,9 @@ EXPORT CONST vdouble2 xsincos_u1(vdouble d) {
   vdouble dql = vcast_vd_vi(ql);
 
   s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_A*0.5 * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
@@ -764,9 +764,9 @@ EXPORT CONST vdouble xtan_u1(vdouble d) {
   vdouble dql = vcast_vd_vi(ql);
   
   s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_A*0.5 * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
   s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),


### PR DESCRIPTION
ddadd and ddadd2 are functions for double-double addition.
ddadd is simpler and faster than ddadd2, but it requires the first argument to be larger the the second argument.
Through my testing, this condition only holds for the 1st, 5th, 6th and 7th addition in argument reduction.
In the previous source code, all additions are carried out by ddadd, which is potentially dangerous.