### PR TITLE
This patch improves performance for asin and acos.

### DIFF
--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -338,6 +338,10 @@ static INLINE vdouble vsel_vd_vo_vd_vd(vopmask mask, vdouble x, vdouble y) {
   return vbslq_f64(vreinterpretq_u64_u32(mask), x, y);
 }
 
+static INLINE vdouble vrint_vd_vd(vdouble d) {
+  return vrndnq_f64(d);
+}
+
 /****************************************/
 /* int <--> float conversions           */
 /****************************************/

--- a/src/gencoef/dp.h
+++ b/src/gencoef/dp.h
@@ -179,3 +179,18 @@ void TARGET(mpfr_t ret, mpfr_t a) { mpfr_atan(ret, a, GMP_RNDN); }
 void CFUNC(mpfr_t dst, mpfr_t src) { mpfr_set(dst, src, GMP_RNDN); }
 #define FIXCOEF0 1.0
 #endif
+
+#if 0
+#define N 20
+#define S 100
+#define L 0
+#define P 1.54
+#define MIN 0.0
+#define MAX 0.708
+#define PMUL 2
+#define PADD 1
+
+void TARGET(mpfr_t ret, mpfr_t a) { mpfr_asin(ret, a, GMP_RNDN); }
+void CFUNC(mpfr_t dst, mpfr_t src) { mpfr_set(dst, src, GMP_RNDN); }
+#define FIXCOEF0 1.0
+#endif

--- a/src/libm-tester/tester2dp.c
+++ b/src/libm-tester/tester2dp.c
@@ -233,7 +233,7 @@ int main(int argc,char **argv)
 
       double u0 = countULP2(t = sc.x, frx);
 
-      if (u0 != 0 && ((fabs(d) <= rangemax2 && u0 > 0.505) || fabs(t) > 1 || !isnumber(t))) {
+      if (u0 != 0 && ((fabs(d) <= rangemax2 && u0 > 0.506) || fabs(t) > 1 || !isnumber(t))) {
 	printf("Pure C sincospi_u05 sin arg=%.20g ulp=%.20g\n", d, u0);
 	fflush(stdout); ecnt++;
       }
@@ -253,7 +253,7 @@ int main(int argc,char **argv)
 
       double u0 = countULP2(t = sc.y, frx);
 
-      if (u0 != 0 && ((fabs(d) <= rangemax2 && u0 > 0.505) || fabs(t) > 1 || !isnumber(t))) {
+      if (u0 != 0 && ((fabs(d) <= rangemax2 && u0 > 0.506) || fabs(t) > 1 || !isnumber(t))) {
 	printf("Pure C sincospi_u05 cos arg=%.20g ulp=%.20g\n", d, u0);
 	fflush(stdout); ecnt++;
       }
@@ -488,14 +488,16 @@ int main(int argc,char **argv)
       double u0 = countULP(t = xasin(zo), frx);
       
       if (u0 > 3.5) {
-	printf("Pure C asin arg=%.20g ulp=%.20g\n", d, u0);
+	printf("Pure C asin arg=%.20g ulp=%.20g\n", zo, u0);
+	printf("correct = %.20g, test = %.20g\n", mpfr_get_d(frx, GMP_RNDN), t);
 	fflush(stdout); ecnt++;
       }
 
       double u1 = countULP(t = xasin_u1(zo), frx);
       
       if (u1 > 1) {
-	printf("Pure C asin_u1 arg=%.20g ulp=%.20g\n", d, u1);
+	printf("Pure C asin_u1 arg=%.20g ulp=%.20g\n", zo, u1);
+	printf("correct = %.20g, test = %.20g\n", mpfr_get_d(frx, GMP_RNDN), t);
 	fflush(stdout); ecnt++;
       }
     }
@@ -507,14 +509,14 @@ int main(int argc,char **argv)
       double u0 = countULP(t = xacos(zo), frx);
       
       if (u0 > 3.5) {
-	printf("Pure C acos arg=%.20g ulp=%.20g\n", d, u0);
+	printf("Pure C acos arg=%.20g ulp=%.20g\n", zo, u0);
 	fflush(stdout); ecnt++;
       }
 
       double u1 = countULP(t = xacos_u1(zo), frx);
       
       if (u1 > 1) {
-	printf("Pure C acos_u1 arg=%.20g ulp=%.20g\n", d, u1);
+	printf("Pure C acos_u1 arg=%.20g ulp=%.20g\n", zo, u1);
 	fflush(stdout); ecnt++;
       }
     }

--- a/src/libm-tester/tester2simddp.c
+++ b/src/libm-tester/tester2simddp.c
@@ -322,7 +322,7 @@ int main(int argc,char **argv)
 
       double u0 = countULP2(t = vget(sc.x, e), frx);
 
-      if (u0 != 0 && ((fabs(d) <= rangemax2 && u0 > 0.505) || fabs(t) > 1 || !isnumber(t))) {
+      if (u0 != 0 && ((fabs(d) <= rangemax2 && u0 > 0.506) || fabs(t) > 1 || !isnumber(t))) {
 	printf(ISANAME " sincospi_u05 sin arg=%.20g ulp=%.20g\n", d, u0);
 	fflush(stdout); ecnt++;
       }
@@ -342,7 +342,7 @@ int main(int argc,char **argv)
 
       double u0 = countULP2(t = vget(sc.y, e), frx);
 
-      if (u0 != 0 && ((fabs(d) <= rangemax2 && u0 > 0.505) || fabs(t) > 1 || !isnumber(t))) {
+      if (u0 != 0 && ((fabs(d) <= rangemax2 && u0 > 0.506) || fabs(t) > 1 || !isnumber(t))) {
 	printf(ISANAME " sincospi_u05 cos arg=%.20g ulp=%.20g\n", d, u0);
 	fflush(stdout); ecnt++;
       }
@@ -575,14 +575,14 @@ int main(int argc,char **argv)
       double u0 = countULP(t = vget(xasin(vzo), e), frx);
       
       if (u0 > 3.5) {
-	printf(ISANAME " asin arg=%.20g ulp=%.20g\n", d, u0);
+	printf(ISANAME " asin arg=%.20g ulp=%.20g\n", zo, u0);
 	fflush(stdout); ecnt++;
       }
 
       double u1 = countULP(t = vget(xasin_u1(vzo), e), frx);
       
       if (u1 > 1) {
-	printf(ISANAME " asin_u1 arg=%.20g ulp=%.20g\n", d, u1);
+	printf(ISANAME " asin_u1 arg=%.20g ulp=%.20g\n", zo, u1);
 	fflush(stdout); ecnt++;
       }
     }
@@ -594,14 +594,14 @@ int main(int argc,char **argv)
       double u0 = countULP(t = vget(xacos(vzo), e), frx);
       
       if (u0 > 3.5) {
-	printf(ISANAME " acos arg=%.20g ulp=%.20g\n", d, u0);
+	printf(ISANAME " acos arg=%.20g ulp=%.20g\n", zo, u0);
 	fflush(stdout); ecnt++;
       }
 
       double u1 = countULP(t = vget(xacos_u1(vzo), e), frx);
       
       if (u1 > 1) {
-	printf(ISANAME " acos_u1 arg=%.20g ulp=%.20g\n", d, u1);
+	printf(ISANAME " acos_u1 arg=%.20g ulp=%.20g\n", zo, u1);
 	fflush(stdout); ecnt++;
       }
     }

--- a/src/libm-tester/tester2simdsp.c
+++ b/src/libm-tester/tester2simdsp.c
@@ -578,14 +578,14 @@ int main(int argc,char **argv)
       double u0 = countULP(t = vget(xasinf(vzo), e), frx);
       
       if (u0 > 3.5) {
-	printf(ISANAME " asinf arg=%.20g ulp=%.20g\n", d, u0);
+	printf(ISANAME " asinf arg=%.20g ulp=%.20g\n", zo, u0);
 	fflush(stdout); ecnt++;
       }
 
       double u1 = countULP(t = vget(xasinf_u1(vzo), e), frx);
       
       if (u1 > 1) {
-	printf(ISANAME " asinf_u1 arg=%.20g ulp=%.20g\n", d, u1);
+	printf(ISANAME " asinf_u1 arg=%.20g ulp=%.20g\n", zo, u1);
 	fflush(stdout); ecnt++;
       }
     }
@@ -597,14 +597,14 @@ int main(int argc,char **argv)
       double u0 = countULP(t = vget(xacosf(vzo), e), frx);
       
       if (u0 > 3.5) {
-	printf(ISANAME " acosf arg=%.20g ulp=%.20g\n", d, u0);
+	printf(ISANAME " acosf arg=%.20g ulp=%.20g\n", zo, u0);
 	fflush(stdout); ecnt++;
       }
 
       double u1 = countULP(t = vget(xacosf_u1(vzo), e), frx);
       
       if (u1 > 1) {
-	printf(ISANAME " acosf_u1 arg=%.20g ulp=%.20g\n", d, u1);
+	printf(ISANAME " acosf_u1 arg=%.20g ulp=%.20g\n", zo, u1);
 	fflush(stdout); ecnt++;
       }
     }

--- a/src/libm-tester/tester2sp.c
+++ b/src/libm-tester/tester2sp.c
@@ -496,14 +496,14 @@ int main(int argc,char **argv)
       double u0 = countULP(t = xasinf(zo), frx);
       
       if (u0 > 3.5) {
-	printf("Pure C asinf arg=%.20g ulp=%.20g\n", d, u0);
+	printf("Pure C asinf arg=%.20g ulp=%.20g\n", zo, u0);
 	fflush(stdout); ecnt++;
       }
 
       double u1 = countULP(t = xasinf_u1(zo), frx);
       
       if (u1 > 1) {
-	printf("Pure C asinf_u1 arg=%.20g ulp=%.20g\n", d, u1);
+	printf("Pure C asinf_u1 arg=%.20g ulp=%.20g\n", zo, u1);
 	fflush(stdout); ecnt++;
       }
     }
@@ -515,14 +515,14 @@ int main(int argc,char **argv)
       double u0 = countULP(t = xacosf(zo), frx);
       
       if (u0 > 3.5) {
-	printf("Pure C acosf arg=%.20g ulp=%.20g\n", d, u0);
+	printf("Pure C acosf arg=%.20g ulp=%.20g\n", zo, u0);
 	fflush(stdout); ecnt++;
       }
 
       double u1 = countULP(t = xacosf_u1(zo), frx);
       
       if (u1 > 1) {
-	printf("Pure C acosf_u1 arg=%.20g ulp=%.20g\n", d, u1);
+	printf("Pure C acosf_u1 arg=%.20g ulp=%.20g\n", zo, u1);
 	fflush(stdout); ecnt++;
       }
     }

--- a/src/libm/dd.h
+++ b/src/libm/dd.h
@@ -112,6 +112,15 @@ static INLINE CONST vdouble2 ddadd_vd2_vd2_vd(vdouble2 x, vdouble y) {
   return r;
 }
 
+static INLINE CONST vdouble2 ddsub_vd2_vd2_vd(vdouble2 x, vdouble y) {
+  vdouble2 r;
+
+  r.x = vsub_vd_vd_vd(x.x, y);
+  r.y = vadd_vd_vd_vd(vsub_vd_vd_vd(vsub_vd_vd_vd(x.x, r.x), y), x.y);
+
+  return r;
+}
+
 static INLINE CONST vdouble2 ddadd2_vd2_vd2_vd(vdouble2 x, vdouble y) {
   vdouble2 r;
 
@@ -366,4 +375,9 @@ static INLINE CONST vdouble2 ddrec_vd2_vd2(vdouble2 d) {
 static INLINE CONST vdouble2 ddsqrt_vd2_vd2(vdouble2 d) {
   vdouble t = vsqrt_vd_vd(vadd_vd_vd_vd(d.x, d.y));
   return ddscale_vd2_vd2_vd(ddmul_vd2_vd2_vd2(ddadd2_vd2_vd2_vd2(d, ddmul_vd2_vd_vd(t, t)), ddrec_vd2_vd(t)), vcast_vd_d(0.5));
+}
+
+static INLINE CONST vdouble2 ddsqrt_vd2_vd(vdouble d) {
+  vdouble t = vsqrt_vd_vd(d);
+  return ddscale_vd2_vd2_vd(ddmul_vd2_vd2_vd2(ddadd2_vd2_vd_vd2(d, ddmul_vd2_vd_vd(t, t)), ddrec_vd2_vd(t)), vcast_vd_d(0.5));
 }

--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -458,6 +458,11 @@ static INLINE CONST Sleef_double2 ddsqrt_d2_d2(Sleef_double2 d) {
   return ddscale_d2_d2_d(ddmul_d2_d2_d2(ddadd2_d2_d2_d2(d, ddmul_d2_d_d(t, t)), ddrec_d2_d(t)), 0.5);
 }
 
+static INLINE CONST Sleef_double2 ddsqrt_d2_d(double d) {
+  double t = sqrt(d);
+  return ddscale_d2_d2_d(ddmul_d2_d2_d2(ddadd2_d2_d_d2(d, ddmul_d2_d_d(t, t)), ddrec_d2_d(t)), 0.5);
+}
+
 //
 
 static INLINE CONST double atan2k(double y, double x) {
@@ -508,11 +513,63 @@ EXPORT CONST double xatan2(double y, double x) {
 }
 
 EXPORT CONST double xasin(double d) {
-  return mulsign(atan2k(fabsk(d), sqrt((1+d)*(1-d))), d);
+  int o = fabsk(d) < 0.707;
+  double x2 = o ? (d*d) : ((1-fabsk(d))*0.5), x = o ? fabsk(d) : sqrt(x2), u;
+
+  u = +0.1093739490681073789e+1;
+  u = mla(u, x2, -0.4285569429699107147e+1);
+  u = mla(u, x2, +0.7994496223397078438e+1);
+  u = mla(u, x2, -0.9235122556732529020e+1);
+  u = mla(u, x2, +0.7378804179755443116e+1);
+  u = mla(u, x2, -0.4284050251387537145e+1);
+  u = mla(u, x2, +0.1880302070400576397e+1);
+  u = mla(u, x2, -0.6197598013399243655e+0);
+  u = mla(u, x2, +0.1685313813037700725e+0);
+  u = mla(u, x2, -0.2364585657055901999e-1);
+  u = mla(u, x2, +0.1465340362631515313e-1);
+  u = mla(u, x2, +0.1098373140913713568e-1);
+  u = mla(u, x2, +0.1401416641102466373e-1);
+  u = mla(u, x2, +0.1734964278032805410e-1);
+  u = mla(u, x2, +0.2237229790045894284e-1);
+  u = mla(u, x2, +0.3038194033558650267e-1);
+  u = mla(u, x2, +0.4464285721743240648e-1);
+  u = mla(u, x2, +0.7499999999927489669e-1);
+  u = mla(u, x2, +0.1666666666666695718e+0);
+  u = mla(u * x, x2, x);
+  
+  double r = o ? u : (M_PI/2 - 2*u);
+  r = mulsign(r, d);
+
+  return r;
 }
 
 EXPORT CONST double xacos(double d) {
-  return mulsign(atan2k(sqrt((1+d)*(1-d)), fabsk(d)), d) + (sign(d) == -1 ? M_PI : 0);
+  double x2 = (1-fabsk(d))*0.5, x = sqrt(x2), u;
+  
+  u = +0.1093739490681073789e+1;
+  u = mla(u, x2, -0.4285569429699107147e+1);
+  u = mla(u, x2, +0.7994496223397078438e+1);
+  u = mla(u, x2, -0.9235122556732529020e+1);
+  u = mla(u, x2, +0.7378804179755443116e+1);
+  u = mla(u, x2, -0.4284050251387537145e+1);
+  u = mla(u, x2, +0.1880302070400576397e+1);
+  u = mla(u, x2, -0.6197598013399243655e+0);
+  u = mla(u, x2, +0.1685313813037700725e+0);
+  u = mla(u, x2, -0.2364585657055901999e-1);
+  u = mla(u, x2, +0.1465340362631515313e-1);
+  u = mla(u, x2, +0.1098373140913713568e-1);
+  u = mla(u, x2, +0.1401416641102466373e-1);
+  u = mla(u, x2, +0.1734964278032805410e-1);
+  u = mla(u, x2, +0.2237229790045894284e-1);
+  u = mla(u, x2, +0.3038194033558650267e-1);
+  u = mla(u, x2, +0.4464285721743240648e-1);
+  u = mla(u, x2, +0.7499999999927489669e-1);
+  u = mla(u, x2, +0.1666666666666695718e+0);
+  u = mla(u * x, x2, x);
+  
+  double r = 2*u;
+  
+  return d < 0 ? M_PI - r : r;
 }
 
 EXPORT CONST double xatan(double s) {
@@ -607,18 +664,72 @@ EXPORT CONST double xatan2_u1(double y, double x) {
 }
 
 EXPORT CONST double xasin_u1(double d) {
-  Sleef_double2 d2 = atan2k_u1(dd(fabsk(d), 0), ddsqrt_d2_d2(ddmul_d2_d2_d2(ddadd_d2_d_d(1, d), ddadd_d2_d_d(1,-d))));
-  double r = d2.x + d2.y;
-  if (fabsk(d) == 1) r = 1.570796326794896557998982;
-  return mulsign(r, d);
+  int o = fabsk(d) < 0.707;
+  double x2 = o ? (d*d) : ((1-fabsk(d))*0.5), u;
+  Sleef_double2 x = o ? dd(fabsk(d), 0) : ddsqrt_d2_d(x2);
+  x = fabs(d) == 1.0 ? dd(0, 0) : x;
+
+  u = +0.1093739490681073789e+1;
+  u = mla(u, x2, -0.4285569429699107147e+1);
+  u = mla(u, x2, +0.7994496223397078438e+1);
+  u = mla(u, x2, -0.9235122556732529020e+1);
+  u = mla(u, x2, +0.7378804179755443116e+1);
+  u = mla(u, x2, -0.4284050251387537145e+1);
+  u = mla(u, x2, +0.1880302070400576397e+1);
+  u = mla(u, x2, -0.6197598013399243655e+0);
+  u = mla(u, x2, +0.1685313813037700725e+0);
+  u = mla(u, x2, -0.2364585657055901999e-1);
+  u = mla(u, x2, +0.1465340362631515313e-1);
+  u = mla(u, x2, +0.1098373140913713568e-1);
+  u = mla(u, x2, +0.1401416641102466373e-1);
+  u = mla(u, x2, +0.1734964278032805410e-1);
+  u = mla(u, x2, +0.2237229790045894284e-1);
+  u = mla(u, x2, +0.3038194033558650267e-1);
+  u = mla(u, x2, +0.4464285721743240648e-1);
+  u = mla(u, x2, +0.7499999999927489669e-1);
+  u = mla(u, x2, +0.1666666666666695718e+0);
+  u = u * x2 * x.x;
+  
+  Sleef_double2 y = ddadd_d2_d2_d(ddsub_d2_d2_d2(dd(3.141592653589793116/4, 1.2246467991473532072e-16/4), x), -u);
+  double r = o ? (u + x.x) : ((y.x + y.y)*2);
+  r = mulsign(r, d);
+
+  return r;
 }
 
 EXPORT CONST double xacos_u1(double d) {
-  Sleef_double2 d2 = atan2k_u1(ddsqrt_d2_d2(ddmul_d2_d2_d2(ddadd_d2_d_d(1, d), ddadd_d2_d_d(1,-d))), dd(fabsk(d), 0));
-  d2 = ddscale_d2_d2_d(d2, mulsign(1, d));
-  if (fabsk(d) == 1) d2 = dd(0, 0);
-  if (sign(d) == -1) d2 = ddadd_d2_d2_d2(dd(3.141592653589793116, 1.2246467991473532072e-16), d2);
-  return d2.x + d2.y;
+  int o = fabs(d) < 0.707;
+  double x2 = o ? (d*d) : ((1-fabsk(d))*0.5), u;
+  Sleef_double2 x = o ? dd(fabsk(d), 0) : ddsqrt_d2_d(x2);
+  x = fabs(d) == 1.0 ? dd(0, 0) : x;
+  
+  u = +0.1093739490681073789e+1;
+  u = mla(u, x2, -0.4285569429699107147e+1);
+  u = mla(u, x2, +0.7994496223397078438e+1);
+  u = mla(u, x2, -0.9235122556732529020e+1);
+  u = mla(u, x2, +0.7378804179755443116e+1);
+  u = mla(u, x2, -0.4284050251387537145e+1);
+  u = mla(u, x2, +0.1880302070400576397e+1);
+  u = mla(u, x2, -0.6197598013399243655e+0);
+  u = mla(u, x2, +0.1685313813037700725e+0);
+  u = mla(u, x2, -0.2364585657055901999e-1);
+  u = mla(u, x2, +0.1465340362631515313e-1);
+  u = mla(u, x2, +0.1098373140913713568e-1);
+  u = mla(u, x2, +0.1401416641102466373e-1);
+  u = mla(u, x2, +0.1734964278032805410e-1);
+  u = mla(u, x2, +0.2237229790045894284e-1);
+  u = mla(u, x2, +0.3038194033558650267e-1);
+  u = mla(u, x2, +0.4464285721743240648e-1);
+  u = mla(u, x2, +0.7499999999927489669e-1);
+  u = mla(u, x2, +0.1666666666666695718e+0);
+  u = u * x.x * x2;
+
+  Sleef_double2 y = ddsub_d2_d2_d2(dd(3.141592653589793116/2, 1.2246467991473532072e-16/2), ddadd_d2_d_d(mulsign(x.x, d), mulsign(u, d)));
+  x = ddadd_d2_d2_d(x, u);
+  double r = o ? (y.x + y.y) : ((x.x + x.y)*2);
+  if (!o && d < 0) r = M_PI - r;
+  
+  return r;
 }
 
 EXPORT CONST double xatan_u1(double d) {
@@ -631,16 +742,16 @@ EXPORT CONST double xatan_u1(double d) {
 EXPORT CONST double xsin(double d) {
   double u, s, t = d;
 
-  int qh = trunck(d * (M_1_PI / (1 << 24)));
-  int ql = rintk(d * M_1_PI - qh * (double)(1 << 24));
+  double dqh = trunck(d * (M_1_PI / (1 << 24))) * (double)(1 << 24);
+  int ql = rintk(d * M_1_PI - dqh);
 
-  d = mla(qh, -PI_A * (1 << 24), d);
-  d = mla(ql, -PI_A,             d);
-  d = mla(qh, -PI_B * (1 << 24), d);
-  d = mla(ql, -PI_B,             d);
-  d = mla(qh, -PI_C * (1 << 24), d);
-  d = mla(ql, -PI_C,             d);
-  d = mla((double)qh * (1 << 24) + ql, -PI_D, d);
+  d = mla(dqh, -PI_A, d);
+  d = mla( ql, -PI_A, d);
+  d = mla(dqh, -PI_B, d);
+  d = mla( ql, -PI_B, d);
+  d = mla(dqh, -PI_C, d);
+  d = mla( ql, -PI_C, d);
+  d = mla(dqh + ql, -PI_D, d);
   
   s = d * d;
 
@@ -667,16 +778,16 @@ EXPORT CONST double xsin_u1(double d) {
   double u;
   Sleef_double2 s, t, x;
 
-  int qh = trunck(d * (M_1_PI / (1 << 24)));
-  int ql = rintk(d * M_1_PI - qh * (double)(1 << 24));
+  double dqh = trunck(d * (M_1_PI / (1 << 24))) * (double)(1 << 24);
+  int ql = rintk(d * M_1_PI - dqh);
 
-  u = mla(qh, -PI_A * (1 << 24), d);
-  s = ddadd_d2_d_d(u, ql * (-PI_A            ));
-  s = ddadd2_d2_d2_d(s, qh * (-PI_B * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_B            ));
-  s = ddadd2_d2_d2_d(s, qh * (-PI_C * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_C            ));
-  s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * -PI_D);
+  u = mla(dqh, -PI_A, d);
+  s = ddadd_d2_d_d  (u,  ql * -PI_A);
+  s = ddadd2_d2_d2_d(s, dqh * -PI_B);
+  s = ddadd2_d2_d2_d(s,  ql * -PI_B);
+  s = ddadd2_d2_d2_d(s, dqh * -PI_C);
+  s = ddadd2_d2_d2_d(s,  ql * -PI_C);
+  s = ddadd_d2_d2_d(s, (dqh + ql) * -PI_D);
   
   t = s;
   s = ddsqu_d2_d2(s);
@@ -702,16 +813,17 @@ EXPORT CONST double xsin_u1(double d) {
 EXPORT CONST double xcos(double d) {
   double u, s, t = d;
 
-  int qh = trunck(d * (M_1_PI / (1LL << 23)) - 0.5 * (M_1_PI / (1LL << 23)));
-  int ql = 2*rintk(d * M_1_PI - 0.5 - qh * (double)(1LL << 23))+1;
+  double dqh = trunck(d * (M_1_PI / (1LL << 23)) - 0.5 * (M_1_PI / (1LL << 23)));
+  int ql = 2*rintk(d * M_1_PI - 0.5 - dqh * (double)(1LL << 23))+1;
+  dqh *= 1 << 24;
 
-  d = mla(qh, -PI_A*0.5*(1LL << 24), d);
-  d = mla(ql, -PI_A*0.5,             d);
-  d = mla(qh, -PI_B*0.5*(1LL << 24), d);
-  d = mla(ql, -PI_B*0.5,             d);
-  d = mla(qh, -PI_C*0.5*(1LL << 24), d);
-  d = mla(ql, -PI_C*0.5,             d);
-  d = mla((double)qh*(1LL << 24) + ql , -PI_D*0.5, d);
+  d = mla(dqh, -PI_A*0.5, d);
+  d = mla( ql, -PI_A*0.5, d);
+  d = mla(dqh, -PI_B*0.5, d);
+  d = mla( ql, -PI_B*0.5, d);
+  d = mla(dqh, -PI_C*0.5, d);
+  d = mla( ql, -PI_C*0.5, d);
+  d = mla(dqh + ql , -PI_D*0.5, d);
   
   s = d * d;
 
@@ -740,16 +852,17 @@ EXPORT CONST double xcos_u1(double d) {
 
   d = fabsk(d);
 
-  int qh = trunck(d * (M_1_PI / (1LL << (23))) - 0.5 * (M_1_PI / (1LL << (23))));
-  int ql = 2*rintk(d * M_1_PI - 0.5 - qh * (double)(1LL << (23)))+1;
+  double dqh = trunck(d * (M_1_PI / (1LL << 23)) - 0.5 * (M_1_PI / (1LL << 23)));
+  int ql = 2*rintk(d * M_1_PI - 0.5 - dqh * (double)(1LL << 23))+1;
+  dqh *= 1 << 24;
 
-  u = mla(qh, -PI_A*0.5 * (1 << 24), d);
-  s = ddadd2_d2_d_d(u, ql * (-PI_A*0.5            ));
-  s = ddadd2_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5            ));
-  s = ddadd2_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5            ));
-  s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));
+  u = mla(dqh, -PI_A*0.5, d);
+  s = ddadd2_d2_d_d (u,  ql * (-PI_A*0.5));
+  s = ddadd2_d2_d2_d(s, dqh * (-PI_B*0.5));
+  s = ddadd2_d2_d2_d(s,  ql * (-PI_B*0.5));
+  s = ddadd2_d2_d2_d(s, dqh * (-PI_C*0.5));
+  s = ddadd2_d2_d2_d(s,  ql * (-PI_C*0.5));
+  s = ddadd_d2_d2_d(s, (dqh + ql) * (-PI_D*0.5));
   
   t = s;
   s = ddsqu_d2_d2(s);
@@ -778,16 +891,16 @@ EXPORT CONST Sleef_double2 xsincos(double d) {
 
   s = d;
 
-  int qh = trunck(d * ((2 * M_1_PI) / (1 << 24)));
-  int ql = rintk(d * (2 * M_1_PI) - qh * (double)(1 << 24));
+  double dqh = trunck(d * ((2 * M_1_PI) / (1 << 24))) * (double)(1 << 24);
+  int ql = rintk(d * (2 * M_1_PI) - dqh);
 
-  s = mla(qh, -PI_A * 0.5 * (1 << 24), s);
-  s = mla(ql, -PI_A * 0.5,             s);
-  s = mla(qh, -PI_B * 0.5 * (1 << 24), s);
-  s = mla(ql, -PI_B * 0.5,             s);
-  s = mla(qh, -PI_C * 0.5 * (1 << 24), s);
-  s = mla(ql, -PI_C * 0.5,             s);
-  s = mla((double)qh * (1 << 24) + ql, -PI_D * 0.5, s);
+  s = mla(dqh, -PI_A * 0.5, s);
+  s = mla( ql, -PI_A * 0.5, s);
+  s = mla(dqh, -PI_B * 0.5, s);
+  s = mla( ql, -PI_B * 0.5, s);
+  s = mla(dqh, -PI_C * 0.5, s);
+  s = mla( ql, -PI_C * 0.5, s);
+  s = mla(dqh + ql, -PI_D * 0.5, s);
   
   t = s;
 
@@ -829,16 +942,16 @@ EXPORT CONST Sleef_double2 xsincos_u1(double d) {
   double u;
   Sleef_double2 r, s, t, x;
 
-  int qh = trunck(d * ((2 * M_1_PI) / (1 << 24)));
-  int ql = rintk(d * (2 * M_1_PI) - qh * (double)(1 << 24));
+  double dqh = trunck(d * ((2 * M_1_PI) / (1 << 24))) * (double)(1 << 24);
+  int ql = rintk(d * (2 * M_1_PI) - dqh);
 
-  u = mla(qh, -PI_A*0.5 * (1 << 24), d);
-  s = ddadd_d2_d_d(u, ql * (-PI_A*0.5            ));
-  s = ddadd2_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5            ));
-  s = ddadd2_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5            ));
-  s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));
+  u = mla(dqh, -PI_A*0.5, d);
+  s = ddadd_d2_d_d(u, ql * (-PI_A*0.5));
+  s = ddadd2_d2_d2_d(s, dqh * (-PI_B*0.5));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5));
+  s = ddadd2_d2_d2_d(s, dqh * (-PI_C*0.5));
+  s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5));
+  s = ddadd_d2_d2_d(s, (dqh + ql) * (-PI_D*0.5));
   
   t = s;
 
@@ -904,12 +1017,8 @@ EXPORT CONST Sleef_double2 xsincospi_u05(double d) {
   x = ddadd2_d2_d_d2(u * s, dd(-0.0807455121882807852484731, 3.61852475067037104849987e-18));
   x = ddadd2_d2_d2_d2(ddmul_d2_d2_d2(s2, x), dd(0.785398163397448278999491, 3.06287113727155002607105e-17));
 
-#if 1
   x = ddmul_d2_d2_d(x, t);
   r.x = x.x + x.y;
-#else
-  r.x = ddmul_d_d2_d(x, t);
-#endif
   
   if (xisnegzero(d)) r.x = -0.0;
   
@@ -990,16 +1099,16 @@ EXPORT CONST Sleef_double2 xsincospi_u35(double d) {
 EXPORT CONST double xtan(double d) {
   double u, s, x;
 
-  int qh = trunck(d * ((2 * M_1_PI) / (1 << 24)));
-  int ql = rintk(d * (2 * M_1_PI) - qh * (double)(1 << 24));
+  double dqh = trunck(d * ((2 * M_1_PI) / (1 << 24))) * (double)(1 << 24);
+  int ql = rintk(d * (2 * M_1_PI) - dqh);
 
-  x = mla(qh, -PI_A * 0.5 * (1 << 24), d);
-  x = mla(ql, -PI_A * 0.5,             x);
-  x = mla(qh, -PI_B * 0.5 * (1 << 24), x);
-  x = mla(ql, -PI_B * 0.5,             x);
-  x = mla(qh, -PI_C * 0.5 * (1 << 24), x);
-  x = mla(ql, -PI_C * 0.5,             x);
-  x = mla((double)qh * (1 << 24) + ql, -PI_D * 0.5, x);
+  x = mla(dqh, -PI_A * 0.5, d);
+  x = mla( ql, -PI_A * 0.5, x);
+  x = mla(dqh, -PI_B * 0.5, x);
+  x = mla( ql, -PI_B * 0.5, x);
+  x = mla(dqh, -PI_C * 0.5, x);
+  x = mla( ql, -PI_C * 0.5, x);
+  x = mla(dqh + ql, -PI_D * 0.5, x);
   
   s = x * x;
 
@@ -1035,17 +1144,17 @@ EXPORT CONST double xtan_u1(double d) {
   double u;
   Sleef_double2 s, t, x;
 
-  int qh = trunck(d * (M_2_PI / (1 << 24)));
-  s = ddadd2_d2_d2_d(ddmul_d2_d2_d(dd(M_2_PI_H, M_2_PI_L), d), (d < 0 ? -0.5 : 0.5) - qh * (double)(1 << 24));
+  double dqh = trunck(d * (M_2_PI / (1 << 24))) * (double)(1 << 24);
+  s = ddadd2_d2_d2_d(ddmul_d2_d2_d(dd(M_2_PI_H, M_2_PI_L), d), (d < 0 ? -0.5 : 0.5) - dqh);
   int ql = s.x + s.y;
   
-  u = mla(qh, -PI_A*0.5 * (1 << 24), d);
-  s = ddadd_d2_d_d(u, ql * (-PI_A*0.5            ));
-  s = ddadd2_d2_d2_d(s, qh * (-PI_B*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5            ));
-  s = ddadd2_d2_d2_d(s, qh * (-PI_C*0.5 * (1 << 24)));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5            ));
-  s = ddadd_d2_d2_d(s, ((double)qh * (1 << 24) + ql) * (-PI_D*0.5));
+  u = mla(dqh, -PI_A*0.5, d);
+  s = ddadd_d2_d_d  (u,  ql * (-PI_A*0.5));
+  s = ddadd2_d2_d2_d(s, dqh * (-PI_B*0.5));
+  s = ddadd2_d2_d2_d(s,  ql * (-PI_B*0.5));
+  s = ddadd2_d2_d2_d(s, dqh * (-PI_C*0.5));
+  s = ddadd2_d2_d2_d(s,  ql * (-PI_C*0.5));
+  s = ddadd_d2_d2_d(s, (dqh + ql) * (-PI_D*0.5));
   
   if ((ql & 1) != 0) s = ddneg_d2_d2(s);
 
@@ -1735,10 +1844,10 @@ EXPORT CONST double xfmod(double x, double y) {
 
   for(int i=0;i<4;i++) {
     q = ddnormalize_d2_d2(dddiv_d2_d2_d2(r, dd(de, 0)));
-    r = ddnormalize_d2_d2(ddadd2_d2_d2_d2(r, ddmul_d2_d_d(-upper2(xtrunc(q.y < 0 ? nexttoward0(q.x) : q.x)), de)));
+    r = ddnormalize_d2_d2(ddadd2_d2_d2_d2(r, ddmul_d2_d_d(upper2(xtrunc(q.y < 0 ? nexttoward0(q.x) : q.x)), -de)));
   }
   
-  double ret = (r.x + r.y) * s;
+  double ret = r.x * s;
   if (r.x + r.y == de) ret = 0;
   ret = mulsign(ret, x);
   if (fabsk(x) < fabsk(y)) ret = x;

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -214,29 +214,18 @@ EXPORT CONST vint xilogb(vdouble d) {
 
 EXPORT CONST vdouble xsin(vdouble d) {
   vdouble u, s, r = d;
-#if 0
-  vint ql = vrint_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)));
-
-  u = vcast_vd_vi(ql);
-  d = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_A*4), d);
-  d = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_B*4), d);
-  d = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_C*4), d);
-  d = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_D*4), d);
-#else
   vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 24))));
-  vint ql = vrint_vi_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(double)(1 << 24)),
-					 vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI))));
-  vdouble dql = vcast_vd_vi(ql);
+  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
+  vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)), dqh));
+  vint ql = vrint_vi_vd(dql);
 
-  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * (1 << 24)), d);
-  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A            ), d);
-  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_B * (1 << 24)), d);
-  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_B            ), d);
-  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_C * (1 << 24)), d);
-  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_C            ), d);
-  d = vmla_vd_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
-		       vcast_vd_d(-PI_D), d);
-#endif
+  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A), d);
+  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A), d);
+  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_B), d);
+  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_B), d);
+  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_C), d);
+  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_C), d);
+  d = vmla_vd_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D), d);
   
   s = vmul_vd_vd_vd(d, d);
 
@@ -265,30 +254,18 @@ EXPORT CONST vdouble xsin(vdouble d) {
 EXPORT CONST vdouble xsin_u1(vdouble d) {
   vdouble u;
   vdouble2 s, t, x;
-#if 0
-  vint ql = vrint_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)));
-  u = vcast_vd_vi(ql);
-
-  s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_A*4)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_B*4)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_C*4)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_D*4)));
-#else
   vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 24))));
-  vint ql = vrint_vi_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(double)(1 << 24)),
-					 vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI))));
-  
-  vdouble dql = vcast_vd_vi(ql);
+  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
+  vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)), dqh));
+  vint ql = vrint_vi_vd(dql);
 
-  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * (1 << 24)), d);
-  s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
-					vcast_vd_d(-PI_D)));
-#endif
+  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A), d);
+  s = ddadd_vd2_vd_vd  (u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C)));
+  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D)));
   
   t = s;
   s = ddsqu_vd2_vd2(s);
@@ -315,31 +292,21 @@ EXPORT CONST vdouble xsin_u1(vdouble d) {
 
 EXPORT CONST vdouble xcos(vdouble d) {
   vdouble u, s, r = d;
-#if 0
-  vint ql = vrint_vi_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI), vcast_vd_d(-0.5)));
-  ql = vadd_vi_vi_vi(vadd_vi_vi_vi(ql, ql), vcast_vi_i(1));
-
-  u = vcast_vd_vi(ql);
-  d = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_A*2), d);
-  d = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_B*2), d);
-  d = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_C*2), d);
-  d = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_D*2), d);
-#else
-  vdouble dqh = vtruncate_vd_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 23)), vcast_vd_d(-0.5 * M_1_PI / (1 << 23))));
+  vdouble dqh = vtruncate_vd_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 23)), vcast_vd_d(-M_1_PI / (1 << 24))));
   vint ql = vrint_vi_vd(vadd_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)),
 				      vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(1 << 23)), vcast_vd_d(-0.5))));
+  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
   ql = vadd_vi_vi_vi(vadd_vi_vi_vi(ql, ql), vcast_vi_i(1));
   vdouble dql = vcast_vd_vi(ql);
 
-  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5 * (1 << 24)), d);
-  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A * 0.5            ), d);
-  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_B * 0.5 * (1 << 24)), d);
-  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_B * 0.5            ), d);
-  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_C * 0.5 * (1 << 24)), d);
-  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_C * 0.5            ), d);
-  d = vmla_vd_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
-		       vcast_vd_d(-PI_D * 0.5), d);
-#endif
+  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
+  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A * 0.5), d);
+  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_B * 0.5), d);
+  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_B * 0.5), d);
+  d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_C * 0.5), d);
+  d = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_C * 0.5), d);
+  d = vmla_vd_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D * 0.5), d);
+
   s = vmul_vd_vd_vd(d, d);
 
   d = vreinterpret_vd_vm(vxor_vm_vm_vm(vand_vm_vo64_vm(vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(ql, vcast_vi_i(2)), vcast_vi_i(0))), vreinterpret_vm_vd(vcast_vd_d(-0.0))), vreinterpret_vm_vd(d)));
@@ -365,31 +332,20 @@ EXPORT CONST vdouble xcos(vdouble d) {
 EXPORT CONST vdouble xcos_u1(vdouble d) {
   vdouble u;
   vdouble2 s, t, x;
-#if 0
-  vint ql = vrint_vi_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI), vcast_vd_d(-0.5)));
-  ql = vadd_vi_vi_vi(vadd_vi_vi_vi(ql, ql), vcast_vi_i(1));
-  u = vcast_vd_vi(ql);
-
-  s = ddadd2_vd2_vd_vd (d, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_A*2)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_B*2)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_C*2)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_D*2)));
-#else
-  vdouble dqh = vtruncate_vd_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 23)), vcast_vd_d(-0.5 * M_1_PI / (1 << 23))));
+  vdouble dqh = vtruncate_vd_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 23)), vcast_vd_d(-M_1_PI / (1 << 24))));
   vint ql = vrint_vi_vd(vadd_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)),
 				      vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(1 << 23)), vcast_vd_d(-0.5))));
+  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
   ql = vadd_vi_vi_vi(vadd_vi_vi_vi(ql, ql), vcast_vi_i(1));
   vdouble dql = vcast_vd_vi(ql);
 
-  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5 * (1 << 24)), d);
-  s = ddadd2_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
-					vcast_vd_d(-PI_D*0.5)));
-#endif
+  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
+  s = ddadd2_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5)));
+  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D*0.5)));
   
   t = s;
   s = ddsqu_vd2_vd2(s);
@@ -420,29 +376,18 @@ EXPORT CONST vdouble2 xsincos(vdouble d) {
   vdouble2 r;
 
   s = d;
-#if 0
-  vint ql = vrint_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_2_PI)));
-
-  u = vcast_vd_vi(ql);
-  s = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_A*2), s);
-  s = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_B*2), s);
-  s = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_C*2), s);
-  s = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_D*2), s);
-#else
   vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI / (1 << 24))));
-  vint ql = vrint_vi_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(double)(1 << 24)),
-					 vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI))));
-  vdouble dql = vcast_vd_vi(ql);
+  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
+  vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI)), dqh));
+  vint ql = vrint_vi_vd(dql);
 
-  s = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5 * (1 << 24)), s);
-  s = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A * 0.5            ), s);
-  s = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_B * 0.5 * (1 << 24)), s);
-  s = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_B * 0.5            ), s);
-  s = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_C * 0.5 * (1 << 24)), s);
-  s = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_C * 0.5            ), s);
-  s = vmla_vd_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
-		       vcast_vd_d(-PI_D * 0.5), s);
-#endif
+  s = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), s);
+  s = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A * 0.5), s);
+  s = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_B * 0.5), s);
+  s = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_B * 0.5), s);
+  s = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_C * 0.5), s);
+  s = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_C * 0.5), s);
+  s = vmla_vd_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D * 0.5), s);
   
   t = s;
 
@@ -493,29 +438,18 @@ EXPORT CONST vdouble2 xsincos_u1(vdouble d) {
   vopmask o;
   vdouble u, rx, ry;
   vdouble2 r, s, t, x;
-#if 0
-  vint ql = vrint_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(2 * M_1_PI)));
-  u = vcast_vd_vi(ql);
-
-  s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_A*2)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_B*2)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_C*2)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_D*2)));
-#else
   vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI / (1 << 24))));
-  vint ql = vrint_vi_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(double)(1 << 24)),
-					 vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI))));
-  vdouble dql = vcast_vd_vi(ql);
+  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
+  vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI)), dqh));
+  vint ql = vrint_vi_vd(dql);
 
-  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5 * (1 << 24)), d);
-  s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
-					vcast_vd_d(-PI_D*0.5)));
-#endif
+  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
+  s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5)));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5)));
+  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D*0.5)));
   
   t = s;
 
@@ -696,29 +630,18 @@ EXPORT CONST vdouble2 xsincospi_u35(vdouble d) {
 EXPORT CONST vdouble xtan(vdouble d) {
   vdouble u, s, x;
   vopmask o;
-#if 0
-  vint ql = vrint_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_2_PI)));
-
-  u = vcast_vd_vi(ql);
-  x = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_A*2), d);
-  x = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_B*2), x);
-  x = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_C*2), x);
-  x = vmla_vd_vd_vd_vd(u, vcast_vd_d(-PI4_D*2), x);
-#else
   vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI / (1 << 24))));
-  vint ql = vrint_vi_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(double)(1 << 24)),
-					 vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI))));
-  vdouble dql = vcast_vd_vi(ql);
+  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
+  vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI)), dqh));
+  vint ql = vrint_vi_vd(dql);
 
-  x = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5 * (1 << 24)), d);
-  x = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A * 0.5            ), x);
-  x = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_B * 0.5 * (1 << 24)), x);
-  x = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_B * 0.5            ), x);
-  x = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_C * 0.5 * (1 << 24)), x);
-  x = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_C * 0.5            ), x);
-  x = vmla_vd_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
-		       vcast_vd_d(-PI_D * 0.5), x);
-#endif
+  x = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
+  x = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A * 0.5), x);
+  x = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_B * 0.5), x);
+  x = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_B * 0.5), x);
+  x = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_C * 0.5), x);
+  x = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_C * 0.5), x);
+  x = vmla_vd_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D * 0.5), x);
   
   s = vmul_vd_vd_vd(x, x);
 
@@ -760,32 +683,21 @@ EXPORT CONST vdouble xtan_u1(vdouble d) {
   vdouble u;
   vdouble2 s, t, x;
   vopmask o;
-#if 0
-  vint ql = vrint_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_2_PI)));
-
-  u = vcast_vd_vi(ql);
-  s = ddadd_vd2_vd_vd (d, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_A*2)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_B*2)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_C*2)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(u, vcast_vd_d(-PI4_D*2)));
-#else
   vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI / (1 << 24))));
+  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
   s = ddadd2_vd2_vd2_vd(ddmul_vd2_vd2_vd(vcast_vd2_d_d(M_2_PI_H, M_2_PI_L), d),
-			vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(double)(1 << 24)),
-					 vsel_vd_vo_vd_vd(vlt_vo_vd_vd(d, vcast_vd_d(0)),
-							  vcast_vd_d(-0.5), vcast_vd_d(0.5))));
-  vint ql = vtruncate_vi_vd(vadd_vd_vd_vd(s.x, s.y));
-  vdouble dql = vcast_vd_vi(ql);
+			vsub_vd_vd_vd(vsel_vd_vo_vd_vd(vlt_vo_vd_vd(d, vcast_vd_d(0)),
+						       vcast_vd_d(-0.5), vcast_vd_d(0.5)), dqh));
+  vdouble dql = vtruncate_vd_vd(vadd_vd_vd_vd(s.x, s.y));
+  vint ql = vrint_vi_vd(dql);
   
-  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5 * (1 << 24)), d);
+  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
   s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5 * (1 << 24))));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5)));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5 * (1 << 24))));
+  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5)));
   s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmla_vd_vd_vd_vd(dqh, vcast_vd_d(1 << 24), dql),
-					vcast_vd_d(-PI_D*0.5)));
-#endif
+  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D*0.5)));
   
   o = vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(ql, vcast_vi_i(1)), vcast_vi_i(1)));
   vmask n = vand_vm_vo64_vm(o, vreinterpret_vm_vd(vcast_vd_d(-0.0)));
@@ -950,46 +862,134 @@ EXPORT CONST vdouble xatan2_u1(vdouble y, vdouble x) {
 }
 
 EXPORT CONST vdouble xasin(vdouble d) {
-  vdouble x, y;
-  x = vadd_vd_vd_vd(vcast_vd_d(1), d);
-  y = vsub_vd_vd_vd(vcast_vd_d(1), d);
-  x = vmul_vd_vd_vd(x, y);
-  x = vsqrt_vd_vd(x);
-  x = vreinterpret_vd_vm(vor_vm_vo64_vm(visnan_vo_vd(x), vreinterpret_vm_vd(atan2k(vabs_vd_vd(d), x))));
-  return vmulsign_vd_vd_vd(x, d);
+  vopmask o = vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(0.707));
+  vdouble x2 = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, d), vmul_vd_vd_vd(vsub_vd_vd_vd(vcast_vd_d(1), vabs_vd_vd(d)), vcast_vd_d(0.5)));
+  vdouble x = vsel_vd_vo_vd_vd(o, vabs_vd_vd(d), vsqrt_vd_vd(x2)), u;
+
+  u = vcast_vd_d(+0.1093739490681073789e+1);
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.4285569429699107147e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7994496223397078438e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.9235122556732529020e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7378804179755443116e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.4284050251387537145e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1880302070400576397e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.6197598013399243655e+0));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1685313813037700725e+0));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.2364585657055901999e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1465340362631515313e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1098373140913713568e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1401416641102466373e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1734964278032805410e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.2237229790045894284e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.3038194033558650267e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.4464285721743240648e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7499999999927489669e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1666666666666695718e+0));
+  u = vmla_vd_vd_vd_vd(vmul_vd_vd_vd(u, x), x2, x);
+
+  vdouble r = vsel_vd_vo_vd_vd(o, u, vmla_vd_vd_vd_vd(u, vcast_vd_d(-2), vcast_vd_d(M_PI/2)));
+  return vmulsign_vd_vd_vd(r, d);
 }
 
 EXPORT CONST vdouble xasin_u1(vdouble d) {
-  vdouble2 d2 = atan2k_u1(vcast_vd2_vd_vd(vabs_vd_vd(d), vcast_vd_d(0)), ddsqrt_vd2_vd2(ddmul_vd2_vd2_vd2(ddadd_vd2_vd_vd(vcast_vd_d(1), d), ddsub_vd2_vd_vd(vcast_vd_d(1), d))));
-  vdouble r = vadd_vd_vd_vd(d2.x, d2.y);
-  r = vsel_vd_vo_vd_vd(veq_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1)), vcast_vd_d(1.570796326794896557998982), r);
+  vopmask o = vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(0.707));
+  vdouble x2 = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, d), vmul_vd_vd_vd(vsub_vd_vd_vd(vcast_vd_d(1), vabs_vd_vd(d)), vcast_vd_d(0.5))), u;
+  vdouble2 x = vsel_vd2_vo_vd2_vd2(o, vcast_vd2_vd_vd(vabs_vd_vd(d), vcast_vd_d(0)), ddsqrt_vd2_vd(x2));
+  x = vsel_vd2_vo_vd2_vd2(veq_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1.0)), vcast_vd2_d_d(0, 0), x);
+
+  u = vcast_vd_d(+0.1093739490681073789e+1);
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.4285569429699107147e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7994496223397078438e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.9235122556732529020e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7378804179755443116e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.4284050251387537145e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1880302070400576397e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.6197598013399243655e+0));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1685313813037700725e+0));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.2364585657055901999e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1465340362631515313e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1098373140913713568e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1401416641102466373e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1734964278032805410e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.2237229790045894284e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.3038194033558650267e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.4464285721743240648e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7499999999927489669e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1666666666666695718e+0));
+  u = vmul_vd_vd_vd(vmul_vd_vd_vd(u, x2), x.x);
+
+  vdouble2 y = ddsub_vd2_vd2_vd(ddsub_vd2_vd2_vd2(vcast_vd2_d_d(3.141592653589793116/4, 1.2246467991473532072e-16/4), x), u);
+  
+  vdouble r = vsel_vd_vo_vd_vd(o, vadd_vd_vd_vd(u, x.x),
+			       vmul_vd_vd_vd(vadd_vd_vd_vd(y.x, y.y), vcast_vd_d(2)));
   return vmulsign_vd_vd_vd(r, d);
 }
 
 EXPORT CONST vdouble xacos(vdouble d) {
-  vdouble x, y;
-  x = vadd_vd_vd_vd(vcast_vd_d(1), d);
-  y = vsub_vd_vd_vd(vcast_vd_d(1), d);
-  x = vmul_vd_vd_vd(x, y);
-  x = vsqrt_vd_vd(x);
-  x = vmulsign_vd_vd_vd(atan2k(x, vabs_vd_vd(d)), d);
-  y = vreinterpret_vd_vm(vand_vm_vo64_vm(vsignbit_vo_vd(d), vreinterpret_vm_vd(vcast_vd_d(M_PI))));
-  x = vadd_vd_vd_vd(x, y);
-  return x;
+  vdouble x2 = vmul_vd_vd_vd(vsub_vd_vd_vd(vcast_vd_d(1), vabs_vd_vd(d)), vcast_vd_d(0.5));
+  vdouble x = vsqrt_vd_vd(x2), u;
+
+  u = vcast_vd_d(+0.1093739490681073789e+1);
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.4285569429699107147e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7994496223397078438e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.9235122556732529020e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7378804179755443116e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.4284050251387537145e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1880302070400576397e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.6197598013399243655e+0));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1685313813037700725e+0));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.2364585657055901999e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1465340362631515313e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1098373140913713568e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1401416641102466373e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1734964278032805410e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.2237229790045894284e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.3038194033558650267e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.4464285721743240648e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7499999999927489669e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1666666666666695718e+0));
+  u = vmla_vd_vd_vd_vd(vmul_vd_vd_vd(u, x), x2, x);
+
+  vdouble r = vmul_vd_vd_vd(vcast_vd_d(2), u);
+
+  return vsel_vd_vo_vd_vd(vsignbit_vo_vd(d), vsub_vd_vd_vd(vcast_vd_d(M_PI), r), r);
 }
 
 EXPORT CONST vdouble xacos_u1(vdouble d) {
-  vdouble2 d2 = atan2k_u1(ddsqrt_vd2_vd2(ddmul_vd2_vd2_vd2(ddadd_vd2_vd_vd(vcast_vd_d(1), d), ddsub_vd2_vd_vd(vcast_vd_d(1), d))), vcast_vd2_vd_vd(vabs_vd_vd(d), vcast_vd_d(0)));
-  d2 = ddscale_vd2_vd2_vd(d2, vmulsign_vd_vd_vd(vcast_vd_d(1), d));
+  vopmask o = vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(0.707));
+  vdouble x2 = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, d), vmul_vd_vd_vd(vsub_vd_vd_vd(vcast_vd_d(1), vabs_vd_vd(d)), vcast_vd_d(0.5))), u;
+  vdouble2 x = vsel_vd2_vo_vd2_vd2(o, vcast_vd2_vd_vd(vabs_vd_vd(d), vcast_vd_d(0)), ddsqrt_vd2_vd(x2));
+  x = vsel_vd2_vo_vd2_vd2(veq_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1.0)), vcast_vd2_d_d(0, 0), x);
 
-  vopmask o;
-  o = vneq_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1));
-  d2.x = vreinterpret_vd_vm(vand_vm_vo64_vm(o, vreinterpret_vm_vd(d2.x)));
-  d2.y = vreinterpret_vd_vm(vand_vm_vo64_vm(o, vreinterpret_vm_vd(d2.y)));
-  o = vsignbit_vo_vd(d);
-  d2 = vsel_vd2_vo_vd2_vd2(o, ddadd_vd2_vd2_vd2(vcast_vd2_d_d(3.141592653589793116, 1.2246467991473532072e-16), d2), d2);
+  u = vcast_vd_d(+0.1093739490681073789e+1);
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.4285569429699107147e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7994496223397078438e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.9235122556732529020e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7378804179755443116e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.4284050251387537145e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1880302070400576397e+1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.6197598013399243655e+0));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1685313813037700725e+0));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(-0.2364585657055901999e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1465340362631515313e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1098373140913713568e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1401416641102466373e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1734964278032805410e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.2237229790045894284e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.3038194033558650267e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.4464285721743240648e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.7499999999927489669e-1));
+  u = vmla_vd_vd_vd_vd(u, x2, vcast_vd_d(+0.1666666666666695718e+0));
+  u = vmul_vd_vd_vd(vmul_vd_vd_vd(u, x.x), x2);
 
-  return vadd_vd_vd_vd(d2.x, d2.y);
+  vdouble2 y = ddsub_vd2_vd2_vd2(vcast_vd2_d_d(3.141592653589793116/2, 1.2246467991473532072e-16/2),
+				 ddadd_vd2_vd_vd(vmulsign_vd_vd_vd(x.x, d), vmulsign_vd_vd_vd(u, d)));
+  x = ddadd_vd2_vd2_vd(x, u);
+  
+  vdouble r = vsel_vd_vo_vd_vd(o, vadd_vd_vd_vd(y.x, y.y),
+			       vmul_vd_vd_vd(vadd_vd_vd_vd(x.x, x.y), vcast_vd_d(2)));
+  
+  return vsel_vd_vo_vd_vd(vandnot_vo_vo_vo(o, vsignbit_vo_vd(d)), vsub_vd_vd_vd(vcast_vd_d(M_PI), r), r);
 }
 
 EXPORT CONST vdouble xatan_u1(vdouble d) {
@@ -1821,10 +1821,10 @@ EXPORT CONST vdouble xfmod(vdouble x, vdouble y) {
 
   for(int i=0;i<4;i++) {
     q = ddnormalize_vd2_vd2(dddiv_vd2_vd2_vd2(r, vcast_vd2_vd_vd(de, vcast_vd_d(0))));
-    r = ddnormalize_vd2_vd2(ddadd2_vd2_vd2_vd2(r, ddmul_vd2_vd_vd(upper2(xtrunc(vsel_vd_vo_vd_vd(vlt_vo_vd_vd(q.y, vcast_vd_d(0)), vnexttoward0(q.x), q.x))), vmul_vd_vd_vd(de, vcast_vd_d(-1)))));
+    r = ddnormalize_vd2_vd2(ddadd2_vd2_vd2_vd2(r, ddmul_vd2_vd_vd(upper2(xtrunc(vsel_vd_vo_vd_vd(vlt_vo_vd_vd(q.y, vcast_vd_d(0)), vnexttoward0(q.x), q.x))), vneg_vd_vd(de))));
   }
   
-  vdouble ret = vmul_vd_vd_vd(vadd_vd_vd_vd(r.x, r.y), s);
+  vdouble ret = vmul_vd_vd_vd(r.x, s);
   ret = vsel_vd_vo_vd_vd(veq_vo_vd_vd(vadd_vd_vd_vd(r.x, r.y), de), vcast_vd_d(0), ret);
 
   ret = vmulsign_vd_vd_vd(ret, x);
@@ -1835,18 +1835,19 @@ EXPORT CONST vdouble xfmod(vdouble x, vdouble y) {
 }
 
 #ifdef ENABLE_MAIN
-// gcc -Wno-attributes -I../common -I../arch -DENABLE_AVX2 -mavx2 -mfma sleefsimddp.c ../common/common.c -lm
+// gcc -DENABLE_MAIN -Wno-attributes -I../common -I../arch -DENABLE_AVX2 -mavx2 -mfma sleefsimddp.c ../common/common.c -lm
 #include <stdio.h>
 #include <stdlib.h>
 int main(int argc, char **argv) {
   vdouble d1 = vcast_vd_d(atof(argv[1]));
-  vdouble d2 = vcast_vd_d(atof(argv[2]));
-  vdouble d3 = vcast_vd_d(atof(argv[3]));
+  //vdouble d2 = vcast_vd_d(atof(argv[2]));
+  //vdouble d3 = vcast_vd_d(atof(argv[3]));
   //vdouble r = xnextafter(d1, d2);
   //int i;
   //double fr = frexp(atof(argv[1]), &i);
-  printf("%.20g\n", xfma(d1, d2, d3)[0]);;
-  //printf("%.20g\n", vnexttoward0(d1)[0]);;
+  //printf("%.20g\n", xfma(d1, d2, d3)[0]);;
+  printf("%.20g\n", xacos_u1(d1)[0]);
+  printf("%.20g\n", acos(d1[0]));
   //printf("%.20g\n", nextafter(d1[0], d2[0]));;
   //printf("%.20g\n", vcast_d_vd(xhypot_u05(d1, d2)));
   //printf("%.20g\n", fr);


### PR DESCRIPTION
The previous code calculates asin and acos via atan. The new code calculates them directly using a kernel function for asin.
The performance improvement is 100% for asin_u10, 20% for asin_u35, 90% for acos_u10, and 50% for acos_u35.
This patch also includes changes for trig functions that reduces register pressure and theoretically imrpoves performance, although I cannot see performance increase in the benchmark results.