### PR TITLE
This patch introduces a conditional branch to argument reduction in t…

### DIFF
--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -44,11 +44,15 @@ static INLINE int vavailability_i(int name) { return 3; }
 static INLINE void vprefetch_v_p(const void *ptr) { }
 
 static INLINE int vtestallones_i_vo32(vopmask g) {
-  return vget_lane_u32(vpmin_u32(vand_u32(vget_low_u32(g), vget_high_u32(g)), vand_u32(vget_low_u32(g), vget_high_u32(g))), 0);
+  uint32x2_t x0 = vand_u32(vget_low_u32(g), vget_high_u32(g));
+  uint32x2_t x1 = vpmin_u32(x0, x0);
+  return vget_lane_u32(x1, 0);
 }
 
 static INLINE int vtestallones_i_vo64(vopmask g) {
-  return vget_lane_u32(vpmin_u32(vand_u32(vget_low_u32(g), vget_high_u32(g)), vand_u32(vget_low_u32(g), vget_high_u32(g))), 0);
+  uint32x2_t x0 = vand_u32(vget_low_u32(g), vget_high_u32(g));
+  uint32x2_t x1 = vpmin_u32(x0, x0);
+  return vget_lane_u32(x1, 0);
 }
 
 // Vector load / store

--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -43,6 +43,14 @@ typedef int32x2_t vint;
 static INLINE int vavailability_i(int name) { return 3; }
 static INLINE void vprefetch_v_p(const void *ptr) { }
 
+static INLINE int vtestallones_i_vo32(vopmask g) {
+  return vget_lane_u32(vpmin_u32(vand_u32(vget_low_u32(g), vget_high_u32(g)), vand_u32(vget_low_u32(g), vget_high_u32(g))), 0);
+}
+
+static INLINE int vtestallones_i_vo64(vopmask g) {
+  return vget_lane_u32(vpmin_u32(vand_u32(vget_low_u32(g), vget_high_u32(g)), vand_u32(vget_low_u32(g), vget_high_u32(g))), 0);
+}
+
 // Vector load / store
 static INLINE vdouble vload_vd_p(const double *ptr) { return vld1q_f64(ptr); }
 static INLINE vdouble vloadu_vd_p(const double *ptr) { return vld1q_f64(ptr); }

--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -88,6 +88,14 @@ static INLINE int vavailability_i(int name) {
 
 static INLINE void vprefetch_v_p(const void *ptr) { _mm_prefetch(ptr, _MM_HINT_T0); }
 
+static INLINE int vtestallones_i_vo32(vopmask g) {
+  return _mm_test_all_ones(_mm_and_si128(_mm256_extractf128_si256(g, 0), _mm256_extractf128_si256(g, 1)));
+}
+
+static INLINE int vtestallones_i_vo64(vopmask g) {
+  return _mm_test_all_ones(_mm_and_si128(_mm256_extractf128_si256(g, 0), _mm256_extractf128_si256(g, 1)));
+}
+
 //
 
 static INLINE vdouble vcast_vd_d(double d) { return _mm256_set1_pd(d); }

--- a/src/arch/helperavx2.h
+++ b/src/arch/helperavx2.h
@@ -68,6 +68,14 @@ static INLINE int vavailability_i(int name) {
 
 static INLINE void vprefetch_v_p(const void *ptr) { _mm_prefetch(ptr, _MM_HINT_T0); }
 
+static INLINE int vtestallones_i_vo32(vopmask g) {
+  return _mm_test_all_ones(_mm_and_si128(_mm256_extractf128_si256(g, 0), _mm256_extractf128_si256(g, 1)));
+}
+
+static INLINE int vtestallones_i_vo64(vopmask g) {
+  return _mm_test_all_ones(_mm_and_si128(_mm256_extractf128_si256(g, 0), _mm256_extractf128_si256(g, 1)));
+}
+
 //
 
 static INLINE vdouble vcast_vd_d(double d) { return _mm256_set1_pd(d); }

--- a/src/arch/helperavx512f.h
+++ b/src/arch/helperavx512f.h
@@ -62,6 +62,14 @@ static INLINE int vavailability_i(int name) {
 
 static INLINE void vprefetch_v_p(const void *ptr) { _mm_prefetch(ptr, _MM_HINT_T0); }
 
+#ifdef __INTEL_COMPILER
+static INLINE int vtestallones_i_vo64(vopmask g) { return _mm512_mask2int(g) == 0xff; }
+static INLINE int vtestallones_i_vo32(vopmask g) { return _mm512_mask2int(g) == 0xffff; }
+#else
+static INLINE int vtestallones_i_vo64(vopmask g) { return g == 0xff; }
+static INLINE int vtestallones_i_vo32(vopmask g) { return g == 0xffff; }
+#endif
+
 //
 
 static vint2 vloadu_vi2_p(int32_t *p) { return _mm512_loadu_si512((__m512i const *)p); }

--- a/src/arch/helperneon32.h
+++ b/src/arch/helperneon32.h
@@ -37,6 +37,10 @@ typedef int32x4_t vint2;
 
 static INLINE void vprefetch_v_p(const void *ptr) { }
 
+static INLINE int vtestallones_i_vo32(vopmask g) {
+  return vget_lane_u32(vpmin_u32(vand_u32(vget_low_u32(g), vget_high_u32(g))));
+}
+
 static vfloat vloaduf(float *p) { return vld1q_f32(p); }
 static void vstoreuf(float *p, vfloat v) { vst1q_f32(p, v); }
 

--- a/src/arch/helperneon32.h
+++ b/src/arch/helperneon32.h
@@ -38,7 +38,9 @@ typedef int32x4_t vint2;
 static INLINE void vprefetch_v_p(const void *ptr) { }
 
 static INLINE int vtestallones_i_vo32(vopmask g) {
-  return vget_lane_u32(vpmin_u32(vand_u32(vget_low_u32(g), vget_high_u32(g))));
+  uint32x2_t x0 = vand_u32(vget_low_u32(g), vget_high_u32(g));
+  uint32x2_t x1 = vpmin_u32(x0, x0);
+  return vget_lane_u32(x1, 0);
 }
 
 static vfloat vloaduf(float *p) { return vld1q_f32(p); }

--- a/src/arch/helperpurec.h
+++ b/src/arch/helperpurec.h
@@ -60,6 +60,14 @@ typedef quadVector vquad;
 static INLINE int vavailability_i(int name) { return -1; }
 static INLINE void vprefetch_v_p(const void *ptr) { }
 
+static INLINE int vtestallones_i_vo64(vopmask g) {
+  int ret = 1; for(int i=0;i<VECTLENDP;i++) ret = ret && g.x[i]; return ret;
+}
+
+static INLINE int vtestallones_i_vo32(vopmask g) {
+  int ret = 1; for(int i=0;i<VECTLENSP;i++) ret = ret && g.u[i]; return ret;
+}
+
 //
 
 static vint2 vloadu_vi2_p(int32_t *p) {
@@ -170,6 +178,8 @@ static INLINE vfloat vreva2_vf_vf(vfloat d0) {
   return r;
 }
 
+static INLINE vdouble vcast_vd_d(double d) { vdouble ret; for(int i=0;i<VECTLENDP;i++) ret.d[i] = d; return ret; }
+
 //
 
 static INLINE vopmask vand_vo_vo_vo   (vopmask x, vopmask y) { vopmask ret; for(int i=0;i<VECTLENDP*2;i++) ret.u[i] = x.u[i] &  y.u[i]; return ret; }
@@ -208,7 +218,6 @@ static INLINE vopmask veq64_vo_vm_vm(vmask x, vmask y) { vopmask ret; for(int i=
 
 //
 
-static INLINE vdouble vcast_vd_d(double d) { vdouble ret; for(int i=0;i<VECTLENDP;i++) ret.d[i] = d; return ret; }
 static INLINE vmask vreinterpret_vm_vd(vdouble vd) { union { vdouble vd; vmask vm; } cnv; cnv.vd = vd; return cnv.vm; }
 static INLINE vint2 vreinterpret_vi2_vd(vdouble vd) { union { vdouble vd; vint2 vi2; } cnv; cnv.vd = vd; return cnv.vi2; }
 static INLINE vdouble vreinterpret_vd_vi2(vint2 vi) { union { vint2 vi2; vdouble vd; } cnv; cnv.vi2 = vi; return cnv.vd; }

--- a/src/arch/helpersse2.h
+++ b/src/arch/helpersse2.h
@@ -107,6 +107,9 @@ static INLINE int vavailability_i(int name) {
 
 static INLINE void vprefetch_v_p(const void *ptr) { _mm_prefetch(ptr, _MM_HINT_T0); }
 
+static INLINE int vtestallones_i_vo32(vopmask g) { return _mm_movemask_epi8(g) == 0xFFFF; }
+static INLINE int vtestallones_i_vo64(vopmask g) { return _mm_movemask_epi8(g) == 0xFFFF; }
+
 //
 
 static vint2 vloadu_vi2_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }

--- a/src/arch/helpervecext.h
+++ b/src/arch/helpervecext.h
@@ -380,6 +380,14 @@ static INLINE vlongdouble vnegpos_vl_vl(vlongdouble d0) {
 static INLINE int vavailability_i(int name) { return -1; }
 static INLINE void vprefetch_v_p(const void *ptr) { }
 
+static INLINE int vtestallones_i_vo64(vopmask g) {
+  int ret = 1; for(int i=0;i<VECTLENDP*2;i++) ret = ret && g[i]; return ret;
+}
+
+static INLINE int vtestallones_i_vo32(vopmask g) {
+  int ret = 1; for(int i=0;i<VECTLENDP*2;i++) ret = ret && g[i]; return ret;
+}
+
 //
 
 static vint2 vloadu_vi2_p(int32_t *p) {

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -3,6 +3,8 @@
 //    (See accompanying file LICENSE.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+//
+
 #ifndef M_PI
 #define M_PI 3.141592653589793238462643383279502884
 #endif
@@ -26,6 +28,78 @@
 #ifndef M_2_PIl
 #define M_2_PIl 0.636619772367581343075535053490057448L
 #endif
+
+//
+
+/*
+  PI_A to PI_D are constants that satisfy the following two conditions.
+
+  * For PI_A, PI_B and PI_C, the last 28 bits are zero.
+  * PI_A + PI_B + PI_C + PI_D is close to PI as much as possible.
+
+  The argument of a trig function is multiplied by 1/PI, and the
+  integral part is divided into two parts, each has at most 28
+  bits. So, the maximum argument that could be correctly reduced
+  should be 2^(28*2-1) PI = 1.1e+17. However, due to internal
+  double precision calculation, the actual maximum argument that can
+  be correctly reduced is around 2^50 = 1.1e+15.
+ */
+
+#define PI_A 3.1415926218032836914
+#define PI_B 3.1786509424591713469e-08
+#define PI_C 1.2246467864107188502e-16
+#define PI_D 1.2736634327021899816e-24
+#define TRIGRANGEMAX 1e+15
+
+/*
+  PI_A2 and PI_B2 are constants that satisfy the following two conditions.
+
+  * The last 3 bits of PI_A2 are zero.
+  * PI_A2 + PI_B2 is close to PI as much as possible.
+
+  The argument of a trig function is multiplied by 1/PI, and the
+  integral part is multiplied by PI_A2. So, the maximum argument that
+  could be correctly reduced should be 2^(3-1) PI = 12.6. By testing,
+  we confirmed that it correctly reduces the argument up to around 15.
+ */
+
+#define PI_A2 3.141592653589793116
+#define PI_B2 1.2246467991473532072e-16
+#define TRIGRANGEMAX2 15
+
+#define M_2_PI_H 0.63661977236758138243
+#define M_2_PI_L -3.9357353350364971764e-17
+
+#define SQRT_DBL_MAX 1.3407807929942596355e+154
+
+#define TRIGRANGEMAX3 1e+9
+
+#define M_4_PI 1.273239544735162542821171882678754627704620361328125
+
+#define L2U .69314718055966295651160180568695068359375
+#define L2L .28235290563031577122588448175013436025525412068e-12
+#define R_LN2 1.442695040888963407359924681001892137426645954152985934135449406931
+
+//
+
+#define PI_Af 3.140625f
+#define PI_Bf 0.0009670257568359375f
+#define PI_Cf 6.2771141529083251953e-07f
+#define PI_Df 1.2154201256553420762e-10f
+
+#define PI_XDf 1.2141754268668591976e-10f
+#define PI_XEf 1.2446743939339977025e-13f
+
+#define TRIGRANGEMAXf 1e+7 // 39000
+#define SQRT_FLT_MAX 18446743523953729536.0
+
+#define L2Uf 0.693145751953125f
+#define L2Lf 1.428606765330187045e-06f
+
+#define R_LN2f 1.442695040888963407359924681001892137426645954152985934135449406931f
+#define M_PIf ((float)M_PI)
+
+//
 
 #ifndef MIN
 #define MIN(x, y) ((x) < (y) ? (x) : (y))

--- a/src/libm-tester/bench_s1.c
+++ b/src/libm-tester/bench_s1.c
@@ -125,7 +125,7 @@ static int cpuSupportsAVX2() {
 }
 
 int main(int argc, char **argv) {
-  const int niter1 = 10000, niter2 = 1000, niter = niter1 * niter2;
+  const int niter1 = 10000, niter2 = 10000, niter = niter1 * niter2;
   
   double a = 0.0, b = 6.28;
   if (argc >= 2) a = atof(argv[1]);

--- a/src/libm-tester/bench_s2.c
+++ b/src/libm-tester/bench_s2.c
@@ -109,7 +109,7 @@ Sleef___m128d_2 doNothing2_1_m128d(__m128d);
 Sleef___m256d_2 doNothing2_1_m256d(__m256d);
 
 int main(int argc, char **argv) {
-  const int niter1 = 10000, niter2 = 1000, niter = niter1 * niter2;
+  const int niter1 = 10000, niter2 = 10000, niter = niter1 * niter2;
   
   double a = 0.0, b = 6.28;
   if (argc >= 2) a = atof(argv[1]);

--- a/src/libm-tester/tester2dp.c
+++ b/src/libm-tester/tester2dp.c
@@ -785,7 +785,7 @@ int main(int argc,char **argv)
       double u0 = countULPdp(t = xfmod(d, d2), frx);
       long double c = mpfr_get_ld(frx, GMP_RNDN);
 
-      if (fabsl((long double)d / d2) < 1e+60 && u0 > 0.5) {
+      if (fabsl((long double)d / d2) < 1e+300 && u0 > 0.5) {
 	printf("Pure C fmod arg=%.20g, %.20g  ulp=%.20g\n", d, d2, u0);
 	printf("correct = %.20g, test = %.20g\n", mpfr_get_d(frx, GMP_RNDN), t);
 	fflush(stdout); ecnt++;

--- a/src/libm-tester/tester2simddp.c
+++ b/src/libm-tester/tester2simddp.c
@@ -881,7 +881,7 @@ int main(int argc,char **argv)
       double u0 = countULPdp(t = vget(xfmod(vd, vd2), e), frx);
       long double c = mpfr_get_ld(frx, GMP_RNDN);
 
-      if (fabsl((long double)d / d2) < 1e+60 && u0 > 0.5) {
+      if (fabsl((long double)d / d2) < 1e+300 && u0 > 0.5) {
 	printf(ISANAME " fmod arg=%.20g, %.20g  ulp=%.20g\n", d, d2, u0);
 	printf("correct = %.20g, test = %.20g\n", mpfr_get_d(frx, GMP_RNDN), t);
 	fflush(stdout); ecnt++;

--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -27,6 +27,9 @@
 #define PI_C 1.2246467864107188502e-16
 #define PI_D 1.2736634327021899816e-24
 
+#define PI_A2 3.141592653589793116
+#define PI_B2 1.2246467991473532072e-16
+
 #define M_2_PI_H 0.63661977236758138243
 #define M_2_PI_L -3.9357353350364971764e-17
 
@@ -743,7 +746,7 @@ EXPORT CONST double xsin(double d) {
   double u, s, t = d;
 
   double dqh = trunck(d * (M_1_PI / (1 << 24))) * (double)(1 << 24);
-  int ql = rintk(d * M_1_PI - dqh);
+  int ql = rintk(mla(d, M_1_PI, -dqh));
 
   d = mla(dqh, -PI_A, d);
   d = mla( ql, -PI_A, d);
@@ -777,18 +780,25 @@ EXPORT CONST double xsin(double d) {
 EXPORT CONST double xsin_u1(double d) {
   double u;
   Sleef_double2 s, t, x;
-
-  double dqh = trunck(d * (M_1_PI / (1 << 24))) * (double)(1 << 24);
-  int ql = rintk(d * M_1_PI - dqh);
-
-  u = mla(dqh, -PI_A, d);
-  s = ddadd_d2_d_d  (u,  ql * -PI_A);
-  s = ddadd2_d2_d2_d(s, dqh * -PI_B);
-  s = ddadd2_d2_d2_d(s,  ql * -PI_B);
-  s = ddadd2_d2_d2_d(s, dqh * -PI_C);
-  s = ddadd2_d2_d2_d(s,  ql * -PI_C);
-  s = ddadd_d2_d2_d(s, (dqh + ql) * -PI_D);
+  int ql;
   
+  if (fabsk(d) < 15) {
+    ql = rintk(d * M_1_PI);
+    u = mla(ql, -PI_A2, d);
+    s = ddadd_d2_d_d (u,  ql * -PI_B2);
+  } else {
+    double dqh = trunck(d * (M_1_PI / (1 << 24))) * (double)(1 << 24);
+    ql = rintk(mla(d, M_1_PI, -dqh));
+
+    u = mla(dqh, -PI_A, d);
+    s = ddadd_d2_d_d  (u,  ql * -PI_A);
+    s = ddadd2_d2_d2_d(s, dqh * -PI_B);
+    s = ddadd2_d2_d2_d(s,  ql * -PI_B);
+    s = ddadd2_d2_d2_d(s, dqh * -PI_C);
+    s = ddadd2_d2_d2_d(s,  ql * -PI_C);
+    s = ddadd_d2_d2_d (s, (dqh + ql) * -PI_D);
+  }
+
   t = s;
   s = ddsqu_d2_d2(s);
 
@@ -806,7 +816,7 @@ EXPORT CONST double xsin_u1(double d) {
   
   if ((ql & 1) != 0) u = -u;
   if (!xisinf(d) && (xisnegzero(d) || fabsk(d) > TRIGRANGEMAX)) u = -0.0;
-
+  
   return u;
 }
 
@@ -849,20 +859,27 @@ EXPORT CONST double xcos(double d) {
 EXPORT CONST double xcos_u1(double d) {
   double u;
   Sleef_double2 s, t, x;
-
+  int ql;
+  
   d = fabsk(d);
 
-  double dqh = trunck(d * (M_1_PI / (1LL << 23)) - 0.5 * (M_1_PI / (1LL << 23)));
-  int ql = 2*rintk(d * M_1_PI - 0.5 - dqh * (double)(1LL << 23))+1;
-  dqh *= 1 << 24;
+  if (d < 15) {
+    ql = mla(2, rintk(d * M_1_PI - 0.5), 1);
+    s = ddadd2_d2_d_d(d, ql * (-PI_A2*0.5));
+    s = ddadd_d2_d2_d(s, ql * (-PI_B2*0.5));
+  } else {
+    double dqh = trunck(d * (M_1_PI / (1LL << 23)) - 0.5 * (M_1_PI / (1LL << 23)));
+    ql = 2*rintk(d * M_1_PI - 0.5 - dqh * (double)(1LL << 23))+1;
+    dqh *= 1 << 24;
 
-  u = mla(dqh, -PI_A*0.5, d);
-  s = ddadd2_d2_d_d (u,  ql * (-PI_A*0.5));
-  s = ddadd2_d2_d2_d(s, dqh * (-PI_B*0.5));
-  s = ddadd2_d2_d2_d(s,  ql * (-PI_B*0.5));
-  s = ddadd2_d2_d2_d(s, dqh * (-PI_C*0.5));
-  s = ddadd2_d2_d2_d(s,  ql * (-PI_C*0.5));
-  s = ddadd_d2_d2_d(s, (dqh + ql) * (-PI_D*0.5));
+    u = mla(dqh, -PI_A*0.5, d);
+    s = ddadd2_d2_d_d (u,  ql * (-PI_A*0.5));
+    s = ddadd2_d2_d2_d(s, dqh * (-PI_B*0.5));
+    s = ddadd2_d2_d2_d(s,  ql * (-PI_B*0.5));
+    s = ddadd2_d2_d2_d(s, dqh * (-PI_C*0.5));
+    s = ddadd2_d2_d2_d(s,  ql * (-PI_C*0.5));
+    s = ddadd_d2_d2_d(s, (dqh + ql) * (-PI_D*0.5));
+  }
   
   t = s;
   s = ddsqu_d2_d2(s);
@@ -941,17 +958,24 @@ EXPORT CONST Sleef_double2 xsincos(double d) {
 EXPORT CONST Sleef_double2 xsincos_u1(double d) {
   double u;
   Sleef_double2 r, s, t, x;
+  int ql;
+  
+  if (fabsk(d) < 15) {
+    ql = rintk(d * (2 * M_1_PI));
+    u = mla(ql, -PI_A2*0.5, d);
+    s = ddadd_d2_d_d (u,  ql * (-PI_B2*0.5));
+  } else {
+    double dqh = trunck(d * ((2 * M_1_PI) / (1 << 24))) * (double)(1 << 24);
+    ql = rintk(d * (2 * M_1_PI) - dqh);
 
-  double dqh = trunck(d * ((2 * M_1_PI) / (1 << 24))) * (double)(1 << 24);
-  int ql = rintk(d * (2 * M_1_PI) - dqh);
-
-  u = mla(dqh, -PI_A*0.5, d);
-  s = ddadd_d2_d_d(u, ql * (-PI_A*0.5));
-  s = ddadd2_d2_d2_d(s, dqh * (-PI_B*0.5));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5));
-  s = ddadd2_d2_d2_d(s, dqh * (-PI_C*0.5));
-  s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5));
-  s = ddadd_d2_d2_d(s, (dqh + ql) * (-PI_D*0.5));
+    u = mla(dqh, -PI_A*0.5, d);
+    s = ddadd_d2_d_d(u, ql * (-PI_A*0.5));
+    s = ddadd2_d2_d2_d(s, dqh * (-PI_B*0.5));
+    s = ddadd2_d2_d2_d(s, ql * (-PI_B*0.5));
+    s = ddadd2_d2_d2_d(s, dqh * (-PI_C*0.5));
+    s = ddadd2_d2_d2_d(s, ql * (-PI_C*0.5));
+    s = ddadd_d2_d2_d(s, (dqh + ql) * (-PI_D*0.5));
+  }
   
   t = s;
 
@@ -1143,18 +1167,25 @@ EXPORT CONST double xtan(double d) {
 EXPORT CONST double xtan_u1(double d) {
   double u;
   Sleef_double2 s, t, x;
-
-  double dqh = trunck(d * (M_2_PI / (1 << 24))) * (double)(1 << 24);
-  s = ddadd2_d2_d2_d(ddmul_d2_d2_d(dd(M_2_PI_H, M_2_PI_L), d), (d < 0 ? -0.5 : 0.5) - dqh);
-  int ql = s.x + s.y;
+  int ql;
   
-  u = mla(dqh, -PI_A*0.5, d);
-  s = ddadd_d2_d_d  (u,  ql * (-PI_A*0.5));
-  s = ddadd2_d2_d2_d(s, dqh * (-PI_B*0.5));
-  s = ddadd2_d2_d2_d(s,  ql * (-PI_B*0.5));
-  s = ddadd2_d2_d2_d(s, dqh * (-PI_C*0.5));
-  s = ddadd2_d2_d2_d(s,  ql * (-PI_C*0.5));
-  s = ddadd_d2_d2_d(s, (dqh + ql) * (-PI_D*0.5));
+  if (fabsk(d) < 15) {
+    ql = rintk(d * (2 * M_1_PI));
+    u = mla(ql, -PI_A2*0.5, d);
+    s = ddadd_d2_d_d(u,  ql * (-PI_B2*0.5));
+  } else {
+    double dqh = trunck(d * (M_2_PI / (1 << 24))) * (double)(1 << 24);
+    s = ddadd2_d2_d2_d(ddmul_d2_d2_d(dd(M_2_PI_H, M_2_PI_L), d), (d < 0 ? -0.5 : 0.5) - dqh);
+    ql = s.x + s.y;
+
+    u = mla(dqh, -PI_A*0.5, d);
+    s = ddadd_d2_d_d  (u,  ql * (-PI_A*0.5));
+    s = ddadd2_d2_d2_d(s, dqh * (-PI_B*0.5));
+    s = ddadd2_d2_d2_d(s,  ql * (-PI_B*0.5));
+    s = ddadd2_d2_d2_d(s, dqh * (-PI_C*0.5));
+    s = ddadd2_d2_d2_d(s,  ql * (-PI_C*0.5));
+    s = ddadd_d2_d2_d(s, (dqh + ql) * (-PI_D*0.5));
+  }
   
   if ((ql & 1) != 0) s = ddneg_d2_d2(s);
 
@@ -1842,9 +1873,10 @@ EXPORT CONST double xfmod(double x, double y) {
   if (de < DBL_MIN) { nu *= 1ULL << 54; de *= 1ULL << 54; s = 1.0 / (1ULL << 54); }
   Sleef_double2 q, r = dd(nu, 0);
 
-  for(int i=0;i<4;i++) {
+  for(int i=0;i < 20;i++) {
     q = ddnormalize_d2_d2(dddiv_d2_d2_d2(r, dd(de, 0)));
     r = ddnormalize_d2_d2(ddadd2_d2_d2_d2(r, ddmul_d2_d_d(upper2(xtrunc(q.y < 0 ? nexttoward0(q.x) : q.x)), -de)));
+    if (r.x < y) break;
   }
   
   double ret = r.x * s;

--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -22,26 +22,6 @@
 #pragma fp_contract (off)
 #endif
 
-#define PI_A 3.1415926218032836914
-#define PI_B 3.1786509424591713469e-08
-#define PI_C 1.2246467864107188502e-16
-#define PI_D 1.2736634327021899816e-24
-
-#define PI_A2 3.141592653589793116
-#define PI_B2 1.2246467991473532072e-16
-
-#define M_2_PI_H 0.63661977236758138243
-#define M_2_PI_L -3.9357353350364971764e-17
-
-#define TRIGRANGEMAX 1e+14
-#define SQRT_DBL_MAX 1.3407807929942596355e+154
-
-#define M_4_PI 1.273239544735162542821171882678754627704620361328125
-
-#define L2U .69314718055966295651160180568695068359375
-#define L2L .28235290563031577122588448175013436025525412068e-12
-#define R_LN2 1.442695040888963407359924681001892137426645954152985934135449406931
-
 static INLINE CONST int64_t doubleToRawLongBits(double d) {
   union {
     double f;
@@ -782,12 +762,12 @@ EXPORT CONST double xsin_u1(double d) {
   Sleef_double2 s, t, x;
   int ql;
   
-  if (fabsk(d) < 15) {
+  if (fabsk(d) < TRIGRANGEMAX2) {
     ql = rintk(d * M_1_PI);
     u = mla(ql, -PI_A2, d);
     s = ddadd_d2_d_d (u,  ql * -PI_B2);
   } else {
-    double dqh = trunck(d * (M_1_PI / (1 << 24))) * (double)(1 << 24);
+    const double dqh = trunck(d * (M_1_PI / (1 << 24))) * (double)(1 << 24);
     ql = rintk(mla(d, M_1_PI, -dqh));
 
     u = mla(dqh, -PI_A, d);
@@ -863,7 +843,7 @@ EXPORT CONST double xcos_u1(double d) {
   
   d = fabsk(d);
 
-  if (d < 15) {
+  if (d < TRIGRANGEMAX2) {
     ql = mla(2, rintk(d * M_1_PI - 0.5), 1);
     s = ddadd2_d2_d_d(d, ql * (-PI_A2*0.5));
     s = ddadd_d2_d2_d(s, ql * (-PI_B2*0.5));
@@ -960,12 +940,12 @@ EXPORT CONST Sleef_double2 xsincos_u1(double d) {
   Sleef_double2 r, s, t, x;
   int ql;
   
-  if (fabsk(d) < 15) {
+  if (fabsk(d) < TRIGRANGEMAX2) {
     ql = rintk(d * (2 * M_1_PI));
     u = mla(ql, -PI_A2*0.5, d);
     s = ddadd_d2_d_d (u,  ql * (-PI_B2*0.5));
   } else {
-    double dqh = trunck(d * ((2 * M_1_PI) / (1 << 24))) * (double)(1 << 24);
+    const double dqh = trunck(d * ((2 * M_1_PI) / (1 << 24))) * (double)(1 << 24);
     ql = rintk(d * (2 * M_1_PI) - dqh);
 
     u = mla(dqh, -PI_A*0.5, d);
@@ -1016,8 +996,6 @@ EXPORT CONST Sleef_double2 xsincos_u1(double d) {
   return r;
 }
 
-#define TRIGRANGEMAX2 1e+9
-
 EXPORT CONST Sleef_double2 xsincospi_u05(double d) {
   double u, s, t;
   Sleef_double2 r, x, s2;
@@ -1066,7 +1044,7 @@ EXPORT CONST Sleef_double2 xsincospi_u05(double d) {
   if ((q & 4) != 0) { r.x = -r.x; }
   if (((q+2) & 4) != 0) { r.y = -r.y; }
 
-  if (fabsk(d) > TRIGRANGEMAX2/4) { r.x = r.y = 0; }
+  if (fabsk(d) > TRIGRANGEMAX3/4) { r.x = r.y = 0; }
   if (xisinf(d)) { r.x = r.y = NAN; }
 
   return r;
@@ -1114,7 +1092,7 @@ EXPORT CONST Sleef_double2 xsincospi_u35(double d) {
   if ((q & 4) != 0) { r.x = -r.x; }
   if (((q+2) & 4) != 0) { r.y = -r.y; }
 
-  if (fabsk(d) > TRIGRANGEMAX2/4) { r.x = r.y = 0; }
+  if (fabsk(d) > TRIGRANGEMAX3/4) { r.x = r.y = 0; }
   if (xisinf(d)) { r.x = r.y = NAN; }
 
   return r;
@@ -1169,12 +1147,12 @@ EXPORT CONST double xtan_u1(double d) {
   Sleef_double2 s, t, x;
   int ql;
   
-  if (fabsk(d) < 15) {
+  if (fabsk(d) < TRIGRANGEMAX2) {
     ql = rintk(d * (2 * M_1_PI));
     u = mla(ql, -PI_A2*0.5, d);
     s = ddadd_d2_d_d(u,  ql * (-PI_B2*0.5));
   } else {
-    double dqh = trunck(d * (M_2_PI / (1 << 24))) * (double)(1 << 24);
+    const double dqh = trunck(d * (M_2_PI / (1 << 24))) * (double)(1 << 24);
     s = ddadd2_d2_d2_d(ddmul_d2_d2_d(dd(M_2_PI_H, M_2_PI_L), d), (d < 0 ? -0.5 : 0.5) - dqh);
     ql = s.x + s.y;
 
@@ -1873,7 +1851,7 @@ EXPORT CONST double xfmod(double x, double y) {
   if (de < DBL_MIN) { nu *= 1ULL << 54; de *= 1ULL << 54; s = 1.0 / (1ULL << 54); }
   Sleef_double2 q, r = dd(nu, 0);
 
-  for(int i=0;i < 20;i++) {
+  for(int i=0;i < 20;i++) { // ceil(log2(DBL_MAX) / 52)
     q = ddnormalize_d2_d2(dddiv_d2_d2_d2(r, dd(de, 0)));
     r = ddnormalize_d2_d2(ddadd2_d2_d2_d2(r, ddmul_d2_d_d(upper2(xtrunc(q.y < 0 ? nexttoward0(q.x) : q.x)), -de)));
     if (r.x < y) break;

--- a/src/libm/sleefld.c
+++ b/src/libm/sleefld.c
@@ -315,8 +315,6 @@ static INLINE CONST Sleef_longdouble2 dlsqrt_l2_l2(Sleef_longdouble2 d) {
 
 //
 
-#define TRIGRANGEMAX2 1e+9
-
 EXPORT CONST Sleef_longdouble2 xsincospil_u05(long double d) {
   long double u, s, t;
   Sleef_longdouble2 r, x, s2;

--- a/src/libm/sleefqp.c
+++ b/src/libm/sleefqp.c
@@ -328,8 +328,6 @@ static INLINE CONST Sleef_quad2 dqsqrt_q2_q2(Sleef_quad2 d) {
 
 //
 
-#define TRIGRANGEMAX2 1e+9
-
 EXPORT CONST Sleef_quad2 xsincospiq_u05(Sleef_quad d) {
   Sleef_quad u, s, t;
   Sleef_quad2 r, x, s2;

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -83,29 +83,6 @@
 
 //
 
-#define PI_A 3.1415926218032836914
-#define PI_B 3.1786509424591713469e-08
-#define PI_C 1.2246467864107188502e-16
-#define PI_D 1.2736634327021899816e-24
-
-#define PI_A2 3.141592653589793116
-#define PI_B2 1.2246467991473532072e-16
-
-#define M_2_PI_H 0.63661977236758138243
-#define M_2_PI_L -3.9357353350364971764e-17
-
-#define TRIGRANGEMAX 1e+14
-#define TRIGRANGEMAX2 1e+9
-#define SQRT_DBL_MAX 1.3407807929942596355e+154
-
-#define M_4_PI 1.273239544735162542821171882678754627704620361328125
-
-#define L2U .69314718055966295651160180568695068359375
-#define L2L .28235290563031577122588448175013436025525412068e-12
-#define R_LN2 1.442695040888963407359924681001892137426645954152985934135449406931
-
-//
-
 static INLINE CONST vopmask vsignbit_vo_vd(vdouble d) {
   return veq64_vo_vm_vm(vand_vm_vm_vm(vreinterpret_vm_vd(d), vreinterpret_vm_vd(vcast_vd_d(-0.0))), vreinterpret_vm_vd(vcast_vd_d(-0.0)));
 }
@@ -254,15 +231,15 @@ EXPORT CONST vdouble xsin_u1(vdouble d) {
   vdouble2 s, t, x;
   vint ql;
   
-  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(15)))) {
-    vdouble dql = vrint_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)));
+  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(TRIGRANGEMAX2)))) {
+    const vdouble dql = vrint_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)));
     ql = vrint_vi_vd(dql);
     u = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A2), d);
     s = ddadd_vd2_vd_vd (u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B2)));
   } else {
     vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 24))));
     dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
-    vdouble dql = vrint_vd_vd(vmlapn_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI), dqh));
+    const vdouble dql = vrint_vd_vd(vmlapn_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI), dqh));
     ql = vrint_vi_vd(dql);
 
     u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A), d);
@@ -342,7 +319,7 @@ EXPORT CONST vdouble xcos_u1(vdouble d) {
   vdouble2 s, t, x;
   vint ql;
   
-  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(15)))) {
+  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(TRIGRANGEMAX2)))) {
     vdouble dql = vrint_vd_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI), vcast_vd_d(-0.5)));
     dql = vmla_vd_vd_vd_vd(vcast_vd_d(2), dql, vcast_vd_d(1));
     ql = vrint_vi_vd(dql);
@@ -354,7 +331,7 @@ EXPORT CONST vdouble xcos_u1(vdouble d) {
 					vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(1 << 23)), vcast_vd_d(-0.5))));
     dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
     ql = vadd_vi_vi_vi(vadd_vi_vi_vi(ql, ql), vcast_vi_i(1));
-    vdouble dql = vcast_vd_vi(ql);
+    const vdouble dql = vcast_vd_vi(ql);
 
     u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
     s = ddadd2_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5)));
@@ -458,15 +435,15 @@ EXPORT CONST vdouble2 xsincos_u1(vdouble d) {
   vdouble2 r, s, t, x;
   vint ql;
   
-  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(15)))) {
-    vdouble dql = vrint_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2 * M_1_PI)));
+  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(TRIGRANGEMAX2)))) {
+    const vdouble dql = vrint_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2 * M_1_PI)));
     ql = vrint_vi_vd(dql);
     u = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A2*0.5), d);
     s = ddadd_vd2_vd_vd (u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B2*0.5)));
   } else {
     vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI / (1 << 24))));
     dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
-    vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI)), dqh));
+    const vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI)), dqh));
     ql = vrint_vi_vd(dql);
     
     u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
@@ -583,7 +560,7 @@ EXPORT CONST vdouble2 xsincospi_u05(vdouble d) {
   o = vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(vadd_vi_vi_vi(q, vcast_vi_i(2)), vcast_vi_i(4)), vcast_vi_i(4)));
   r.y = vreinterpret_vd_vm(vxor_vm_vm_vm(vand_vm_vo64_vm(o, vreinterpret_vm_vd(vcast_vd_d(-0.0))), vreinterpret_vm_vd(r.y)));
 
-  o = vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(TRIGRANGEMAX2/4));
+  o = vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(TRIGRANGEMAX3/4));
   r.x = vreinterpret_vd_vm(vandnot_vm_vo64_vm(o, vreinterpret_vm_vd(r.x)));
   r.y = vreinterpret_vd_vm(vandnot_vm_vo64_vm(o, vreinterpret_vm_vd(r.y)));
 
@@ -643,7 +620,7 @@ EXPORT CONST vdouble2 xsincospi_u35(vdouble d) {
   o = vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(vadd_vi_vi_vi(q, vcast_vi_i(2)), vcast_vi_i(4)), vcast_vi_i(4)));
   r.y = vreinterpret_vd_vm(vxor_vm_vm_vm(vand_vm_vo64_vm(o, vreinterpret_vm_vd(vcast_vd_d(-0.0))), vreinterpret_vm_vd(r.y)));
 
-  o = vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(TRIGRANGEMAX2/4));
+  o = vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(TRIGRANGEMAX3/4));
   r.x = vreinterpret_vd_vm(vandnot_vm_vo64_vm(o, vreinterpret_vm_vd(r.x)));
   r.y = vreinterpret_vd_vm(vandnot_vm_vo64_vm(o, vreinterpret_vm_vd(r.y)));
 
@@ -712,7 +689,7 @@ EXPORT CONST vdouble xtan_u1(vdouble d) {
   vopmask o;
   vint ql;
   
-  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(15)))) {
+  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(TRIGRANGEMAX2)))) {
     vdouble dql = vrint_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2 * M_1_PI)));
     ql = vrint_vi_vd(dql);
     u = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A2*0.5), d);
@@ -723,7 +700,7 @@ EXPORT CONST vdouble xtan_u1(vdouble d) {
     s = ddadd2_vd2_vd2_vd(ddmul_vd2_vd2_vd(vcast_vd2_d_d(M_2_PI_H, M_2_PI_L), d),
 			  vsub_vd_vd_vd(vsel_vd_vo_vd_vd(vlt_vo_vd_vd(d, vcast_vd_d(0)),
 							 vcast_vd_d(-0.5), vcast_vd_d(0.5)), dqh));
-    vdouble dql = vtruncate_vd_vd(vadd_vd_vd_vd(s.x, s.y));
+    const vdouble dql = vtruncate_vd_vd(vadd_vd_vd_vd(s.x, s.y));
     ql = vrint_vi_vd(dql);
 
     u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
@@ -1851,7 +1828,7 @@ EXPORT CONST vdouble xfmod(vdouble x, vdouble y) {
 
   vdouble2 q, r = vcast_vd2_vd_vd(nu, vcast_vd_d(0));
 
-  for(int i=0;i<20;i++) {
+  for(int i=0;i<20;i++) { // ceil(log2(DBL_MAX) / 52)
     q = ddnormalize_vd2_vd2(dddiv_vd2_vd2_vd2(r, vcast_vd2_vd_vd(de, vcast_vd_d(0))));
     r = ddnormalize_vd2_vd2(ddadd2_vd2_vd2_vd2(r, ddmul_vd2_vd_vd(upper2(xtrunc(vsel_vd_vo_vd_vd(vlt_vo_vd_vd(q.y, vcast_vd_d(0)), vnexttoward0(q.x), q.x))), vneg_vd_vd(de))));
     if (vtestallones_i_vo64(vlt_vo_vd_vd(r.x, y))) break;

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -88,10 +88,8 @@
 #define PI_C 1.2246467864107188502e-16
 #define PI_D 1.2736634327021899816e-24
 
-#define PI4_A 0.78539816290140151978
-#define PI4_B 4.9604678871439933374e-10
-#define PI4_C 1.1258708853173288931e-18
-#define PI4_D 1.7607799325916000908e-27
+#define PI_A2 3.141592653589793116
+#define PI_B2 1.2246467991473532072e-16
 
 #define M_2_PI_H 0.63661977236758138243
 #define M_2_PI_L -3.9357353350364971764e-17
@@ -216,7 +214,7 @@ EXPORT CONST vdouble xsin(vdouble d) {
   vdouble u, s, r = d;
   vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 24))));
   dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
-  vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)), dqh));
+  vdouble dql = vrint_vd_vd(vmlapn_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI), dqh));
   vint ql = vrint_vi_vd(dql);
 
   d = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A), d);
@@ -254,18 +252,27 @@ EXPORT CONST vdouble xsin(vdouble d) {
 EXPORT CONST vdouble xsin_u1(vdouble d) {
   vdouble u;
   vdouble2 s, t, x;
-  vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 24))));
-  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
-  vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)), dqh));
-  vint ql = vrint_vi_vd(dql);
+  vint ql;
+  
+  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(15)))) {
+    vdouble dql = vrint_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)));
+    ql = vrint_vi_vd(dql);
+    u = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A2), d);
+    s = ddadd_vd2_vd_vd (u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B2)));
+  } else {
+    vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 24))));
+    dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
+    vdouble dql = vrint_vd_vd(vmlapn_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI), dqh));
+    ql = vrint_vi_vd(dql);
 
-  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A), d);
-  s = ddadd_vd2_vd_vd  (u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D)));
+    u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A), d);
+    s = ddadd_vd2_vd_vd  (u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C)));
+    s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D)));
+  }
   
   t = s;
   s = ddsqu_vd2_vd2(s);
@@ -282,11 +289,12 @@ EXPORT CONST vdouble xsin_u1(vdouble d) {
 
   u = ddmul_vd_vd2_vd2(t, x);
   
-  u = vreinterpret_vd_vm(vxor_vm_vm_vm(vand_vm_vo64_vm(vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(ql, vcast_vi_i(1)), vcast_vi_i(1))), vreinterpret_vm_vd(vcast_vd_d(-0.0))), vreinterpret_vm_vd(u)));
+  u = vreinterpret_vd_vm(vxor_vm_vm_vm(vand_vm_vo64_vm(vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(ql, vcast_vi_i(1)), vcast_vi_i(1))),
+						       vreinterpret_vm_vd(vcast_vd_d(-0.0))), vreinterpret_vm_vd(u)));
   u = vsel_vd_vo_vd_vd(vandnot_vo_vo_vo(visinf_vo_vd(d), vor_vo_vo_vo(visnegzero_vo_vd(d),
 								      vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(TRIGRANGEMAX)))),
 		       vcast_vd_d(-0.0), u);
-
+  
   return u;
 }
 
@@ -332,20 +340,30 @@ EXPORT CONST vdouble xcos(vdouble d) {
 EXPORT CONST vdouble xcos_u1(vdouble d) {
   vdouble u;
   vdouble2 s, t, x;
-  vdouble dqh = vtruncate_vd_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 23)), vcast_vd_d(-M_1_PI / (1 << 24))));
-  vint ql = vrint_vi_vd(vadd_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)),
-				      vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(1 << 23)), vcast_vd_d(-0.5))));
-  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
-  ql = vadd_vi_vi_vi(vadd_vi_vi_vi(ql, ql), vcast_vi_i(1));
-  vdouble dql = vcast_vd_vi(ql);
+  vint ql;
+  
+  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(15)))) {
+    vdouble dql = vrint_vd_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI), vcast_vd_d(-0.5)));
+    dql = vmla_vd_vd_vd_vd(vcast_vd_d(2), dql, vcast_vd_d(1));
+    ql = vrint_vi_vd(dql);
+    s = ddadd2_vd2_vd_vd(d, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A2*0.5)));
+    s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B2*0.5)));
+  } else {
+    vdouble dqh = vtruncate_vd_vd(vmla_vd_vd_vd_vd(d, vcast_vd_d(M_1_PI / (1 << 23)), vcast_vd_d(-M_1_PI / (1 << 24))));
+    ql = vrint_vi_vd(vadd_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(M_1_PI)),
+					vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-(1 << 23)), vcast_vd_d(-0.5))));
+    dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
+    ql = vadd_vi_vi_vi(vadd_vi_vi_vi(ql, ql), vcast_vi_i(1));
+    vdouble dql = vcast_vd_vi(ql);
 
-  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
-  s = ddadd2_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D*0.5)));
+    u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
+    s = ddadd2_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5)));
+    s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D*0.5)));
+  }
   
   t = s;
   s = ddsqu_vd2_vd2(s);
@@ -438,18 +456,27 @@ EXPORT CONST vdouble2 xsincos_u1(vdouble d) {
   vopmask o;
   vdouble u, rx, ry;
   vdouble2 r, s, t, x;
-  vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI / (1 << 24))));
-  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
-  vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI)), dqh));
-  vint ql = vrint_vi_vd(dql);
-
-  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
-  s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5)));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D*0.5)));
+  vint ql;
+  
+  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(15)))) {
+    vdouble dql = vrint_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2 * M_1_PI)));
+    ql = vrint_vi_vd(dql);
+    u = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A2*0.5), d);
+    s = ddadd_vd2_vd_vd (u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B2*0.5)));
+  } else {
+    vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI / (1 << 24))));
+    dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
+    vdouble dql = vrint_vd_vd(vsub_vd_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI)), dqh));
+    ql = vrint_vi_vd(dql);
+    
+    u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
+    s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5)));
+    s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D*0.5)));
+  }
   
   t = s;
 
@@ -683,21 +710,30 @@ EXPORT CONST vdouble xtan_u1(vdouble d) {
   vdouble u;
   vdouble2 s, t, x;
   vopmask o;
-  vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI / (1 << 24))));
-  dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
-  s = ddadd2_vd2_vd2_vd(ddmul_vd2_vd2_vd(vcast_vd2_d_d(M_2_PI_H, M_2_PI_L), d),
-			vsub_vd_vd_vd(vsel_vd_vo_vd_vd(vlt_vo_vd_vd(d, vcast_vd_d(0)),
-						       vcast_vd_d(-0.5), vcast_vd_d(0.5)), dqh));
-  vdouble dql = vtruncate_vd_vd(vadd_vd_vd_vd(s.x, s.y));
-  vint ql = vrint_vi_vd(dql);
+  vint ql;
   
-  u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
-  s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5)));
-  s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
-  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D*0.5)));
+  if (vtestallones_i_vo64(vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(15)))) {
+    vdouble dql = vrint_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2 * M_1_PI)));
+    ql = vrint_vi_vd(dql);
+    u = vmla_vd_vd_vd_vd(dql, vcast_vd_d(-PI_A2*0.5), d);
+    s = ddadd_vd2_vd_vd (u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B2*0.5)));
+  } else {
+    vdouble dqh = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(2*M_1_PI / (1 << 24))));
+    dqh = vmul_vd_vd_vd(dqh, vcast_vd_d(1 << 24));
+    s = ddadd2_vd2_vd2_vd(ddmul_vd2_vd2_vd(vcast_vd2_d_d(M_2_PI_H, M_2_PI_L), d),
+			  vsub_vd_vd_vd(vsel_vd_vo_vd_vd(vlt_vo_vd_vd(d, vcast_vd_d(0)),
+							 vcast_vd_d(-0.5), vcast_vd_d(0.5)), dqh));
+    vdouble dql = vtruncate_vd_vd(vadd_vd_vd_vd(s.x, s.y));
+    ql = vrint_vi_vd(dql);
+
+    u = vmla_vd_vd_vd_vd(dqh, vcast_vd_d(-PI_A * 0.5), d);
+    s = ddadd_vd2_vd_vd(u, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_A*0.5            )));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_B*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_B*0.5            )));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dqh, vcast_vd_d(-PI_C*0.5)));
+    s = ddadd2_vd2_vd2_vd(s, vmul_vd_vd_vd(dql, vcast_vd_d(-PI_C*0.5            )));
+    s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vadd_vd_vd_vd(dqh, dql), vcast_vd_d(-PI_D*0.5)));
+  }
   
   o = vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(ql, vcast_vi_i(1)), vcast_vi_i(1)));
   vmask n = vand_vm_vo64_vm(o, vreinterpret_vm_vd(vcast_vd_d(-0.0)));
@@ -1815,9 +1851,10 @@ EXPORT CONST vdouble xfmod(vdouble x, vdouble y) {
 
   vdouble2 q, r = vcast_vd2_vd_vd(nu, vcast_vd_d(0));
 
-  for(int i=0;i<4;i++) {
+  for(int i=0;i<20;i++) {
     q = ddnormalize_vd2_vd2(dddiv_vd2_vd2_vd2(r, vcast_vd2_vd_vd(de, vcast_vd_d(0))));
     r = ddnormalize_vd2_vd2(ddadd2_vd2_vd2_vd2(r, ddmul_vd2_vd_vd(upper2(xtrunc(vsel_vd_vo_vd_vd(vlt_vo_vd_vd(q.y, vcast_vd_d(0)), vnexttoward0(q.x), q.x))), vneg_vd_vd(de))));
+    if (vtestallones_i_vo64(vlt_vo_vd_vd(r.x, y))) break;
   }
   
   vdouble ret = vmul_vd_vd_vd(r.x, s);

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -1647,9 +1647,10 @@ EXPORT CONST vfloat xfmodf(vfloat x, vfloat y) {
 
   vfloat2 q, r = vcast_vf2_vf_vf(nu, vcast_vf_f(0));
 
-  for(int i=0;i<6;i++) {
+  for(int i=0;i<10;i++) {
     q = dfnormalize_vf2_vf2(dfdiv_vf2_vf2_vf2(r, vcast_vf2_vf_vf(de, vcast_vf_f(0))));
     r = dfnormalize_vf2_vf2(dfadd2_vf2_vf2_vf2(r, dfmul_vf2_vf_vf(xtruncf(vsel_vf_vo_vf_vf(vlt_vo_vf_vf(q.y, vcast_vf_f(0)), vnexttoward0f(q.x), q.x)), vmul_vf_vf_vf(de, vcast_vf_f(-1)))));
+    if (vtestallones_i_vo32(vlt_vo_vf_vf(r.x, y))) break;
   }
   
   vfloat ret = vmul_vf_vf_vf(vadd_vf_vf_vf(r.x, r.y), s);

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -97,29 +97,6 @@ void Sleef_x86CpuID(int32_t out[4], uint32_t eax, uint32_t ecx);
 
 //
 
-#define PI4_Af 0.78515625f
-#define PI4_Bf 0.00024187564849853515625f
-#define PI4_Cf 3.7747668102383613586e-08f
-#define PI4_Df 1.2816720341285448015e-12f
-
-#define PI_Af 3.140625f
-#define PI_Bf 0.0009670257568359375f
-#define PI_Cf 6.2771141529083251953e-07f
-#define PI_Df 1.2154201256553420762e-10f
-
-#define PI_XDf 1.2141754268668591976e-10f
-#define PI_XEf 1.2446743939339977025e-13f
-
-#define TRIGRANGEMAXf 1e+7 // 39000
-#define SQRT_FLT_MAX 18446743523953729536.0
-
-#define L2Uf 0.693145751953125f
-#define L2Lf 1.428606765330187045e-06f
-#define R_LN2f 1.442695040888963407359924681001892137426645954152985934135449406931f
-#define M_PIf ((float)M_PI)
-
-//
-
 static INLINE CONST vopmask visnegzero_vo_vf(vfloat d) {
   return veq_vo_vi2_vi2(vreinterpret_vi2_vf(d), vreinterpret_vi2_vf(vcast_vf_f(-0.0)));
 }
@@ -1647,7 +1624,7 @@ EXPORT CONST vfloat xfmodf(vfloat x, vfloat y) {
 
   vfloat2 q, r = vcast_vf2_vf_vf(nu, vcast_vf_f(0));
 
-  for(int i=0;i<10;i++) {
+  for(int i=0;i<6;i++) { // ceil(log2(FLT_MAX) / 23)
     q = dfnormalize_vf2_vf2(dfdiv_vf2_vf2_vf2(r, vcast_vf2_vf_vf(de, vcast_vf_f(0))));
     r = dfnormalize_vf2_vf2(dfadd2_vf2_vf2_vf2(r, dfmul_vf2_vf_vf(xtruncf(vsel_vf_vo_vf_vf(vlt_vo_vf_vf(q.y, vcast_vf_f(0)), vnexttoward0f(q.x), q.x)), vmul_vf_vf_vf(de, vcast_vf_f(-1)))));
     if (vtestallones_i_vo32(vlt_vo_vf_vf(r.x, y))) break;

--- a/src/libm/sleefsp.c
+++ b/src/libm/sleefsp.c
@@ -1532,9 +1532,10 @@ EXPORT CONST float xfmodf(float x, float y) {
   if (de < FLT_MIN) { nu *= 1ULL << 25; de *= 1ULL << 25; s = 1.0f / (1ULL << 25); }
   Sleef_float2 q, r = df(nu, 0);
 
-  for(int i=0;i<6;i++) {
+  for(int i=0;i<10;i++) {
     q = dfnormalize_f2_f2(dfdiv_f2_f2_f2(r, df(de, 0)));
     r = dfnormalize_f2_f2(dfadd2_f2_f2_f2(r, dfmul_f2_f_f(-xtruncf(q.y < 0 ? nexttoward0f(q.x) : q.x), de)));
+    if (r.x < y) break;
   }
   
   float ret = (r.x + r.y) * s;

--- a/src/libm/sleefsp.c
+++ b/src/libm/sleefsp.c
@@ -22,23 +22,6 @@
 #pragma fp_contract (off)
 #endif
 
-#define PI_Af 3.140625f
-#define PI_Bf 0.0009670257568359375f
-#define PI_Cf 6.2771141529083251953e-07f
-#define PI_Df 1.2154201256553420762e-10f
-
-#define PI_XDf 1.2141754268668591976e-10f
-#define PI_XEf 1.2446743939339977025e-13f
-
-#define TRIGRANGEMAXf 1e+7 // 39000
-#define SQRT_FLT_MAX 18446743523953729536.0
-
-#define L2Uf 0.693145751953125f
-#define L2Lf 1.428606765330187045e-06f
-
-#define R_LN2f 1.442695040888963407359924681001892137426645954152985934135449406931f
-#define M_PIf ((float)M_PI)
-
 static INLINE CONST int32_t floatToRawIntBits(float d) {
   union {
     float f;
@@ -1532,7 +1515,7 @@ EXPORT CONST float xfmodf(float x, float y) {
   if (de < FLT_MIN) { nu *= 1ULL << 25; de *= 1ULL << 25; s = 1.0f / (1ULL << 25); }
   Sleef_float2 q, r = df(nu, 0);
 
-  for(int i=0;i<10;i++) {
+  for(int i=0;i<6;i++) { // ceil(log2(FLT_MAX) / 23)
     q = dfnormalize_f2_f2(dfdiv_f2_f2_f2(r, df(de, 0)));
     r = dfnormalize_f2_f2(dfadd2_f2_f2_f2(r, dfmul_f2_f_f(-xtruncf(q.y < 0 ? nexttoward0f(q.x) : q.x), de)));
     if (r.x < y) break;


### PR DESCRIPTION
…rig functions.

When all the elements in the argument vector are less than 15, a simpler and faster reduction is used.
With this patch, the computation speed of AVX2 ulp 1 trig functions is very close to SVML when the arguments are small.
Please see https://www.dropbox.com/s/66pwjhhjl4glfab/i7-6700-170422.xlsx?dl=0 for the performance graphs.

The ratio of the execution time of the previous code to the new code is 1.8x for Sleef_sind4_u10avx2, 1.7x for Sleef_cosd4_u10avx2, 1.5x for Sleef_sincosd4_u10avx2, and 1.8x  for Sleef_tand4_u10avx2, when the argument is in [0, 6.28].

This patch also improves performance and argument domains of xfmod and xfmodf.