### PR TITLE
[build] Fix makefile.

### DIFF
--- a/src/libm-tester/Makefile
+++ b/src/libm-tester/Makefile
@@ -4,11 +4,11 @@ CFLAGS+=$(STRICTMATHFLAG) -O -g -I../common -I../arch -I../../include -I../libm 
 
 ifeq ($(OS), Darwin)
 CFLAGS += -I/opt/local/include -L/opt/local/lib
-ENVNAME_LD_LIBRARY_PATH=DYLD_LIBRARY_PATH
+ENVNAME_LD_LIBRARY_PATH=$(DYLD_LIBRARY_PATH)
 LIB=
 else
 CFLAGS += -I/opt/local/include -L/opt/local/lib
-ENVNAME_LD_LIBRARY_PATH=LD_LIBRARY_PATH
+ENVNAME_LD_LIBRARY_PATH=$(LD_LIBRARY_PATH)
 LIB=-lrt
 endif
 


### PR DESCRIPTION
The environment variables need to be read with $() in the makefile source.