### PR TITLE
Flush stdin / stdout in the tester.

### DIFF
--- a/src/libm-tester/tester.c
+++ b/src/libm-tester/tester.c
@@ -4517,6 +4517,9 @@ int main(int argc, char **argv) {
   int i, a2s;
 
   printf("\n\n*** Now testing %s\n", argv[1]);
+  // BUGFIX: this flush is to prevent incorrect syncing with the
+  // `iut*` executable that causes failures in the CPU detection on
+  // some CI systems.
   fflush(stdout);
 
   for(a2s=1;a2s<argc;a2s++) {
@@ -4533,7 +4536,11 @@ int main(int argc, char **argv) {
   mpfr_set_default_prec(128);
 
   startChild(argv2[0], argv2);
+  // BUGFIX: this flush is to prevent incorrect syncing with the
+  // `iut*` executable that causes failures in the CPU detection on
+  // some CI systems.
   fflush(stdin);
+
   {
     char str[256];
     int u;

--- a/src/libm-tester/tester.c
+++ b/src/libm-tester/tester.c
@@ -4517,7 +4517,8 @@ int main(int argc, char **argv) {
   int i, a2s;
 
   printf("\n\n*** Now testing %s\n", argv[1]);
-  
+  fflush(stdout);
+
   for(a2s=1;a2s<argc;a2s++) {
     if (strcmp(argv[a2s], "--flushtozero") == 0) {
       enableFlushToZero = 1;
@@ -4532,7 +4533,7 @@ int main(int argc, char **argv) {
   mpfr_set_default_prec(128);
 
   startChild(argv2[0], argv2);
-
+  fflush(stdin);
   {
     char str[256];
     int u;


### PR DESCRIPTION
This patch forces the fflushing of `stdin` and `stdout` in `tester.c` to prevent CPU feature detection failures.