### PR TITLE
Build libsleefgnuabi.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ configure_file(
 # Generates object file (shared library) `libsleef`
 # Defined in src/libm/CMakeLists.txt via command add_library
 set(TARGET_LIBSLEEF "sleef")
+set(TARGET_LIBSLEEFGNUABI "sleefgnuabi")
 # Generates the sleef.h headers and all the rename headers
 # Defined in src/libm/CMakeLists.txt via custom commands and a custom target
 set(TARGET_HEADERS "headers")
@@ -64,6 +65,7 @@ set(TARGET_IUTADVSIMD "iutadvsimd")
 set(TARGET_TEST "test-libm")
 # Generates the helper executable file mkrename needed to write the sleef header
 set(TARGET_MKRENAME "mkrename")
+set(TARGET_MKRENAME_GNUABI "mkrename_gnuabi")
 # Generates the helper executable file mkdisp needed to write the sleef header
 set(TARGET_MKDISP "mkdisp")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 
 # Set output directories for the library files
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
-#set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 # Path for finding cmake modules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ set(TARGET_MKRENAME "mkrename")
 set(TARGET_MKRENAME_GNUABI "mkrename_gnuabi")
 # Generates the helper executable file mkdisp needed to write the sleef header
 set(TARGET_MKDISP "mkdisp")
+# Generates static library common
+# Defined in src/common/CMakeLists.txt via command add_library
+set(TARGET_LIBCOMMON_STATIC "common")
 
 # Check subdirectories
 add_subdirectory("src")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 # Set output directories for the library files
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+#set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 # Path for finding cmake modules

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -20,6 +20,12 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
   set(COMPILER_SUPPORTS_ADVSIMD 1)
 endif()
 
+# Enable building of the GNU ABI version for x86 and aarch64
+
+if(SLEEF_ARCH_X86 OR SLEEF_ARCH_AARCH64)
+  set(SLEEF_ENABLE_GNUABI ON CACHE INTERNAL "Build GNU ABI compatible version.")
+endif()
+
 # COMPILER DETECTION
 
 # All variables storing compiler flags should be prefixed with FLAGS_

--- a/cmake/Scripts/GenerateRenameHeader.cmake
+++ b/cmake/Scripts/GenerateRenameHeader.cmake
@@ -1,8 +1,9 @@
 include(${LOCATIONS_FILE})
 
 string(REPLACE " " ";" RENAME_HEADER_LIST  "${RENAME_HEADERS}")
+string(REPLACE " " ";" RENAME_HEADER_GNUABI_LIST  "${RENAME_HEADERS_GNUABI}")
 
-foreach(rename_header ${RENAME_HEADER_LIST})
+foreach(rename_header ${RENAME_HEADER_LIST} ${RENAME_HEADER_GNUABI_LIST})
   if(${rename_header} MATCHES "renamesse2.h")
     set(params 2 4 sse2)
   elseif(${rename_header} MATCHES "renamesse4.h")
@@ -19,10 +20,25 @@ foreach(rename_header ${RENAME_HEADER_LIST})
     set(params 8 16 avx512f)
   elseif(${rename_header} MATCHES "renameadvsimd.h")
     set(params 2 4 advsimd)
+  elseif(${rename_header} MATCHES "renamesse2_gnuabi.h")
+    set(params sse2 b 2 4 _mm128d _mm128 _mm128i _mm128i '__SSE2__')
+  elseif(${rename_header} MATCHES "renameavx_gnuabi.h")
+    set(params avx c 4 8 __m256d __m256 __m128i 'struct { __m128i x, y; }' __AVX__)
+  elseif(${rename_header} MATCHES "renameavx2_gnuabi.h")
+    set(params avx2 d 4 8 __m256d __m256 __m128i __m256i __AVX2__)
+  elseif(${rename_header} MATCHES "renameavx512f_gnuabi.h")
+    set(params avx512f e 8 16 __m512d __m512 __m256i __m512i __AVX512F__)
+  elseif(${rename_header} MATCHES "renameadvsimd_gnuabi.h")
+    set(params advsimd n 2 4 float64x2_t float32x4_t int32x2_t int32x4_t __ARM_NEON)
+  endif()
+
+  set(MKRENAME_EXE ${TARGET_MKRENAME})
+  if(${rename_header} MATCHES "gnuabi.h")
+    set(MKRENAME_EXE ${TARGET_MKRENAME_GNUABI})
   endif()
 
   execute_process(
-    COMMAND ${LOCATION_RUNTIME_DIR}/${TARGET_MKRENAME} ${params}
+    COMMAND ${LOCATION_RUNTIME_DIR}/${MKRENAME_EXE} ${params}
     OUTPUT_VARIABLE MKRENAME_OUTPUT)
   file(WRITE ${rename_header} "${MKRENAME_OUTPUT}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
 include_directories("common")
 include_directories("arch")
+
 add_subdirectory("libm")
 add_subdirectory("libm-tester")
+add_subdirectory("common")

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(common STATIC common.c)
+

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(common STATIC common.c)
+add_library(${TARGET_LIBCOMMON_STATIC} STATIC common.c)
 

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -7,10 +7,11 @@ include_directories(${CMAKE_SOURCE_DIR}/src/libm)         # rename.h
 include_directories(${CMAKE_BINARY_DIR}/src/libm/include) # rename headers
 
 set(LIB_SLEEF sleef)
+set(LIB_COMMON_STATIC common)
 find_library(LIB_MPFR mpfr)
 set(EXTRA_LIBS m
   ${LIB_MPFR}
-  common
+  ${LIB_COMMON_STATIC}
   )
 
 # Compile executable 'iut'

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -6,17 +6,15 @@ include_directories(${CMAKE_BINARY_DIR}/include)          # sleef.h
 include_directories(${CMAKE_SOURCE_DIR}/src/libm)         # rename.h
 include_directories(${CMAKE_BINARY_DIR}/src/libm/include) # rename headers
 
-set(LIB_SLEEF sleef)
-set(LIB_COMMON_STATIC common)
 find_library(LIB_MPFR mpfr)
 set(EXTRA_LIBS m
   ${LIB_MPFR}
-  ${LIB_COMMON_STATIC}
+  ${TARGET_LIBCOMMON_STATIC}
   )
 
 # Compile executable 'iut'
 add_executable(${TARGET_IUT} iut.c testerutil.c)
-target_link_libraries(${TARGET_IUT} ${LIB_SLEEF} ${EXTRA_LIBS})
+target_link_libraries(${TARGET_IUT} ${TARGET_LIBSLEEF} ${EXTRA_LIBS})
 set(IUT_LIST ${TARGET_IUT})
 
 # Add vector extension `iut`s
@@ -27,7 +25,7 @@ macro(test_extension SIMD)
       PRIVATE ${FLAGS_ENABLE_${SIMD}})
     target_compile_definitions(${TARGET_IUT${SIMD}}
       PRIVATE ENABLE_${SIMD}=1)
-    target_link_libraries(${TARGET_IUT${SIMD}} ${LIB_SLEEF} ${EXTRA_LIBS})
+    target_link_libraries(${TARGET_IUT${SIMD}} ${TARGET_LIBSLEEF} ${EXTRA_LIBS})
 
     list(APPEND IUT_LIST ${TARGET_IUT${SIMD}})
   endif(COMPILER_SUPPORTS_${SIMD})
@@ -50,7 +48,7 @@ endforeach()
 
 # Compile executable 'tester'
 add_executable(${TARGET_TESTER} tester.c testerutil.c)
-target_link_libraries(${TARGET_TESTER} ${EXTRA_LIBS} ${LIB_SLEEF})
+target_link_libraries(${TARGET_TESTER} ${EXTRA_LIBS} ${TARGET_LIBSLEEF})
 target_compile_definitions(${TARGET_TESTER}
   PRIVATE USEMPFR=1)
 target_compile_options(${TARGET_TESTER} PRIVATE -Wno-unused-result)

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Note: We are assuming SLEEF is the CMake root project.
 # TODO: Remove constraint: do not use CMAKE_BINARY_DIR and CMAKE_SOURCE_DIR
 link_directories(${CMAKE_BINARY_DIR}/lib)                 # libsleef
+link_directories(${CMAKE_BINARY_DIR}/src/common)          # common.a
 include_directories(${CMAKE_BINARY_DIR}/include)          # sleef.h
 include_directories(${CMAKE_SOURCE_DIR}/src/libm)         # rename.h
 include_directories(${CMAKE_BINARY_DIR}/src/libm/include) # rename headers
@@ -8,7 +9,9 @@ include_directories(${CMAKE_BINARY_DIR}/src/libm/include) # rename headers
 set(LIB_SLEEF sleef)
 find_library(LIB_MPFR mpfr)
 set(EXTRA_LIBS m
-  ${LIB_MPFR})
+  ${LIB_MPFR}
+  common
+  )
 
 # Compile executable 'iut'
 add_executable(${TARGET_IUT} iut.c testerutil.c)

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 # Helper executable: generates parts of the sleef header file
 add_executable(${TARGET_MKRENAME} mkrename.c)
+add_executable(${TARGET_MKRENAME_GNUABI} mkrename_gnuabi.c)
 # Helper executable: dispatcher for the vector extensions
 add_executable(${TARGET_MKDISP} mkdisp.c)
 # Set C standard requirement (-std=gnu99 for gcc)
@@ -57,28 +58,64 @@ foreach(SIMD ${SLEEF_SUPPORTED_EXTENSIONS})
     $<$<BOOL:${COMPILER_SUPPORTS_${SIMD}}>:$<TARGET_OBJECTS:${OBJECT_${SIMD}}>>)
 endforeach()
 
+macro(compile_object_gnuabi SIMD)
+  if(COMPILER_SUPPORTS_${SIMD})
+    # Need lowercase string for rename header
+    string(TOLOWER ${SIMD} vecarch)
+
+    set(OBJECT_${SIMD}_GNUABI "sleefgnuabi${vecarch}")
+    set(HEADER_${SIMD}_GNUABI ${CMAKE_CURRENT_BINARY_DIR}/include/rename${vecarch}_gnuabi.h)
+
+    add_library(${OBJECT_${SIMD}_GNUABI} OBJECT ${SIMD_SOURCES} ${HEADER_${SIMD}_GNUABI})
+    target_compile_definitions(${OBJECT_${SIMD}_GNUABI} PRIVATE
+      ENABLE_${SIMD}=1
+      DORENAME=1
+      ENABLE_GNUABI=1)
+    target_compile_options(${OBJECT_${SIMD}_GNUABI} PRIVATE
+      ${FLAGS_ENABLE_${SIMD}})
+
+    list(APPEND TARGET_OBJECTS_GNUABI ${OBJECT_${SIMD}_GNUABI})
+    list(APPEND RENAME_HEADERS_GNUABI ${HEADER_${SIMD}_GNUABI})
+  endif(COMPILER_SUPPORTS_${SIMD})
+endmacro(compile_object_gnuabi)
+
+# Build gnuabi version from just simd object files
+if(SLEEF_ENABLE_GNUABI)
+  set(SLEEF_SUPPORTED_GNUABI_EXTENSIONS SSE2 AVX AVX2 AVX512F ADVSIMD)
+  foreach(SIMD ${SLEEF_SUPPORTED_GNUABI_EXTENSIONS})
+    compile_object_gnuabi(${SIMD})
+    list(APPEND GNUABI_OBJ_SRC
+      $<$<BOOL:${COMPILER_SUPPORTS_${SIMD}}>:$<TARGET_OBJECTS:${OBJECT_${SIMD}_GNUABI}>>)
+  endforeach()
+
+  add_library(${TARGET_LIBSLEEFGNUABI} SHARED ${GNUABI_OBJ_SRC})
+endif(SLEEF_ENABLE_GNUABI)
+
 # All code that goes into the main library needs to be position independent code
-set_target_properties(${TARGET_OBJECTS} PROPERTIES
+set_target_properties(${TARGET_OBJECTS} ${TARGET_OBJECTS_GNUABI} PROPERTIES
   POSITION_INDEPENDENT_CODE ON   # -fPIC
   C_STANDARD 99)                 # -std=gnu99
 
 target_compile_definitions(${TARGET_LIBSLEEF}
   PRIVATE DORENAME=1)
-set_target_properties(${TARGET_LIBSLEEF} PROPERTIES
+set_target_properties(${TARGET_LIBSLEEF} ${TARGET_LIBSLEEFGNUABI} PROPERTIES
   VERSION ${SLEEF_VERSION_MAJOR}.${SLEEF_VERSION_MINOR}
   SOVERSION ${SLEEF_SOVERSION}
   C_STANDARD 99)
 
 # Generate the rename headers at build time
 add_custom_command(
-  OUTPUT ${RENAME_HEADERS}
+  OUTPUT ${RENAME_HEADERS} ${RENAME_HEADERS_GNUABI}
   COMMAND ${CMAKE_COMMAND}
     -DRENAME_HEADERS="${RENAME_HEADERS}"
+    -DRENAME_HEADERS_GNUABI="${RENAME_HEADERS_GNUABI}"
     -DLOCATIONS_FILE="${PROJECT_BINARY_DIR}/DefineLocations.cmake"
     -DTARGET_MKRENAME="${TARGET_MKRENAME}"
+    -DTARGET_MKRENAME_GNUABI="${TARGET_MKRENAME_GNUABI}"
     -P ${SLEEF_SCRIPT_PATH}/GenerateRenameHeader.cmake
   DEPENDS
-    ${TARGET_MKRENAME})
+    ${TARGET_MKRENAME}
+    ${TARGET_MKRENAME_GNUABI})
 
 # Generate the sleef header at build time
 set(SLEEF_INCLUDE_HEADER ${CMAKE_BINARY_DIR}/include/sleef.h)
@@ -96,10 +133,13 @@ add_custom_command(
     ${TARGET_MKDISP})
 
 # Always run the commands to generate the headers
-add_custom_target(headers ALL DEPENDS ${SLEEF_INCLUDE_HEADER} ${RENAME_HEADERS})
+add_custom_target(headers ALL DEPENDS
+  ${SLEEF_INCLUDE_HEADER}
+  ${RENAME_HEADERS}
+  ${RENAME_HEADERS_GNUABI})
 
 # Install libsleef and sleef.h
 install(FILES ${SLEEF_INCLUDE_HEADER}
   DESTINATION include)
-install(TARGETS ${TARGET_LIBSLEEF}
+install(TARGETS ${TARGET_LIBSLEEF} ${TARGET_LIBSLEEFGNUABI}
   DESTINATION lib)

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -7,7 +7,8 @@ add_executable(${TARGET_MKRENAME_GNUABI} mkrename_gnuabi.c)
 # Helper executable: dispatcher for the vector extensions
 add_executable(${TARGET_MKDISP} mkdisp.c)
 # Set C standard requirement (-std=gnu99 for gcc)
-set_target_properties(${TARGET_MKRENAME} ${TARGET_MKDISP} PROPERTIES
+set_target_properties(
+  ${TARGET_MKRENAME} ${TARGET_MKRENAME_GNUABI} ${TARGET_MKDISP} PROPERTIES
   C_STANDARD 99)
 
 # Build main library


### PR DESCRIPTION
This patch adds the gnuabi compatible version of sleef. It was tested on the downstream CI.
Note: libsleefgnuabi.so is installed alongside libsleef when invoking `make install`
