### PR TITLE
Default to optimised build to enable full support.

### DIFF
--- a/Configure.cmake
+++ b/Configure.cmake
@@ -136,19 +136,13 @@ CHECK_C_SOURCE_COMPILES("
   #else
   #include <x86intrin.h>
   #endif
-  void f(void *p) {
-    _mm512_loadu_si512(p);
+  __m512 addConstant(__m512 arg) {
+    return _mm512_add_ps(arg, _mm512_set1_ps(1.f));
   }
   int main() {
     __m512i a = _mm512_set1_epi32(1);
     __m512i r = _mm512_andnot_si512(a, a); }"
   COMPILER_SUPPORTS_AVX512F)
-
- # Turn AVX512F off for MacOSX until the assembler issue is resolved
-if(APPLE)
-  set(COMPILER_SUPPORTS_AVX512F OFF CACHE INTERNAL "Compiler is able to compile AVX512F code.")
-  message(STATUS "Disabling AVX512F on MacOSX.")
-endif(APPLE)
 
 # AVX2 implies AVX2128
 if(COMPILER_SUPPORTS_AVX2)

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -144,6 +144,12 @@ CHECK_C_SOURCE_COMPILES("
     __m512i r = _mm512_andnot_si512(a, a);
   }" COMPILER_SUPPORTS_AVX512F)
 
+ # Turn AVX512F off for MacOSX until the assembler issue is resolved
+if(APPLE)
+  set(COMPILER_SUPPORTS_AVX512F OFF CACHE INTERNAL "Compiler is able to compile AVX512F code.")
+  message(STATUS "Disabling AVX512F on MacOSX.")
+endif(APPLE)
+
 # AVX2 implies AVX2128
 if(COMPILER_SUPPORTS_AVX2)
   set(COMPILER_SUPPORTS_AVX2128 1)

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -54,7 +54,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_WALL}")
 
 # Always compile sleef with -ffp-contract and log at configuration time
 if(SLEEF_SHOW_CONFIG)
-  message(STATUS "Using option `${FLAGS_STRICTMATH}` to compile libsleef.")
+  message(STATUS "Using option `${FLAGS_STRICTMATH}` to compile libsleef")
 endif(SLEEF_SHOW_CONFIG)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_STRICTMATH}")
@@ -72,7 +72,7 @@ CHECK_C_SOURCE_COMPILES("
 
 # Detect if sleef supported architectures are also supported by the compiler
 
-set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_SSE2})
+set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_SSE2})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -80,10 +80,10 @@ CHECK_C_SOURCE_COMPILES("
   #include <x86intrin.h>
   #endif
   int main() {
-    __m128d r = _mm_mul_pd(_mm_set1_pd(1), _mm_set1_pd(2));
-  }" COMPILER_SUPPORTS_SSE2)
+    __m128d r = _mm_mul_pd(_mm_set1_pd(1), _mm_set1_pd(2)); }"
+  COMPILER_SUPPORTS_SSE2)
 
-set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_SSE4})
+set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_SSE4})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -91,10 +91,10 @@ CHECK_C_SOURCE_COMPILES("
   #include <x86intrin.h>
   #endif
   int main() {
-    __m128d r = _mm_floor_sd(_mm_set1_pd(1), _mm_set1_pd(2));
-  }" COMPILER_SUPPORTS_SSE4)
+    __m128d r = _mm_floor_sd(_mm_set1_pd(1), _mm_set1_pd(2)); }"
+  COMPILER_SUPPORTS_SSE4)
 
-set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX})
+set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -105,7 +105,7 @@ CHECK_C_SOURCE_COMPILES("
     __m256d r = _mm256_add_pd(_mm256_set1_pd(1), _mm256_set1_pd(2));
   }" COMPILER_SUPPORTS_AVX)
 
-set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_FMA4})
+set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_FMA4})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -113,10 +113,10 @@ CHECK_C_SOURCE_COMPILES("
   #include <x86intrin.h>
   #endif
   int main() {
-    __m256d r = _mm256_macc_pd(_mm256_set1_pd(1), _mm256_set1_pd(2), _mm256_set1_pd(3));
-  }" COMPILER_SUPPORTS_FMA4)
+    __m256d r = _mm256_macc_pd(_mm256_set1_pd(1), _mm256_set1_pd(2), _mm256_set1_pd(3)); }"
+  COMPILER_SUPPORTS_FMA4)
 
-set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX2})
+set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX2})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -124,12 +124,12 @@ CHECK_C_SOURCE_COMPILES("
   #include <x86intrin.h>
   #endif
   int main() {
-    __m256i r = _mm256_abs_epi32(_mm256_set1_epi32(1));
-  }" COMPILER_SUPPORTS_AVX2)
+    __m256i r = _mm256_abs_epi32(_mm256_set1_epi32(1)); }"
+  COMPILER_SUPPORTS_AVX2)
 
 # AVX512F code requires optimisation flags -O3
-set(CMAKE_TRY_COMPILE_CONFIGURATION Release)
-set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX512F})
+set (CMAKE_TRY_COMPILE_CONFIGURATION Release)
+set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX512F})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -141,8 +141,8 @@ CHECK_C_SOURCE_COMPILES("
   }
   int main() {
     __m512i a = _mm512_set1_epi32(1);
-    __m512i r = _mm512_andnot_si512(a, a);
-  }" COMPILER_SUPPORTS_AVX512F)
+    __m512i r = _mm512_andnot_si512(a, a); }"
+  COMPILER_SUPPORTS_AVX512F)
 
  # Turn AVX512F off for MacOSX until the assembler issue is resolved
 if(APPLE)

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -10,6 +10,15 @@ set(SLEEF_SUPPORTED_EXTENSIONS
   CACHE STRING "List of SIMD architectures supported by libsleef."
   )
 
+# Force set default build type if none was specified
+# Note: some sleef code requires the optimisation flags turned on
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "Setting build type to 'Release' (required for full support).")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "RelWithDebInfo" "MinSizeRel")
+endif()
+
 # PLATFORM DETECTION
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86")
@@ -118,6 +127,8 @@ CHECK_C_SOURCE_COMPILES("
     __m256i r = _mm256_abs_epi32(_mm256_set1_epi32(1)); }"
   COMPILER_SUPPORTS_AVX2)
 
+# AVX512F code requires optimisation flags -O3
+set (CMAKE_TRY_COMPILE_CONFIGURATION Release)
 set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX512F})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -54,7 +54,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_WALL}")
 
 # Always compile sleef with -ffp-contract and log at configuration time
 if(SLEEF_SHOW_CONFIG)
-  message(STATUS "Using option `${FLAGS_STRICTMATH}` to compile libsleef")
+  message(STATUS "Using option `${FLAGS_STRICTMATH}` to compile libsleef.")
 endif(SLEEF_SHOW_CONFIG)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_STRICTMATH}")
@@ -72,7 +72,7 @@ CHECK_C_SOURCE_COMPILES("
 
 # Detect if sleef supported architectures are also supported by the compiler
 
-set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_SSE2})
+set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_SSE2})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -80,10 +80,10 @@ CHECK_C_SOURCE_COMPILES("
   #include <x86intrin.h>
   #endif
   int main() {
-    __m128d r = _mm_mul_pd(_mm_set1_pd(1), _mm_set1_pd(2)); }"
-  COMPILER_SUPPORTS_SSE2)
+    __m128d r = _mm_mul_pd(_mm_set1_pd(1), _mm_set1_pd(2));
+  }" COMPILER_SUPPORTS_SSE2)
 
-set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_SSE4})
+set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_SSE4})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -91,10 +91,10 @@ CHECK_C_SOURCE_COMPILES("
   #include <x86intrin.h>
   #endif
   int main() {
-    __m128d r = _mm_floor_sd(_mm_set1_pd(1), _mm_set1_pd(2)); }"
-  COMPILER_SUPPORTS_SSE4)
+    __m128d r = _mm_floor_sd(_mm_set1_pd(1), _mm_set1_pd(2));
+  }" COMPILER_SUPPORTS_SSE4)
 
-set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX})
+set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -105,7 +105,7 @@ CHECK_C_SOURCE_COMPILES("
     __m256d r = _mm256_add_pd(_mm256_set1_pd(1), _mm256_set1_pd(2));
   }" COMPILER_SUPPORTS_AVX)
 
-set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_FMA4})
+set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_FMA4})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -113,10 +113,10 @@ CHECK_C_SOURCE_COMPILES("
   #include <x86intrin.h>
   #endif
   int main() {
-    __m256d r = _mm256_macc_pd(_mm256_set1_pd(1), _mm256_set1_pd(2), _mm256_set1_pd(3)); }"
-  COMPILER_SUPPORTS_FMA4)
+    __m256d r = _mm256_macc_pd(_mm256_set1_pd(1), _mm256_set1_pd(2), _mm256_set1_pd(3));
+  }" COMPILER_SUPPORTS_FMA4)
 
-set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX2})
+set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX2})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -124,12 +124,12 @@ CHECK_C_SOURCE_COMPILES("
   #include <x86intrin.h>
   #endif
   int main() {
-    __m256i r = _mm256_abs_epi32(_mm256_set1_epi32(1)); }"
-  COMPILER_SUPPORTS_AVX2)
+    __m256i r = _mm256_abs_epi32(_mm256_set1_epi32(1));
+  }" COMPILER_SUPPORTS_AVX2)
 
 # AVX512F code requires optimisation flags -O3
-set (CMAKE_TRY_COMPILE_CONFIGURATION Release)
-set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX512F})
+set(CMAKE_TRY_COMPILE_CONFIGURATION Release)
+set(CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_AVX512F})
 CHECK_C_SOURCE_COMPILES("
   #if defined(_MSC_VER)
   #include <intrin.h>
@@ -137,12 +137,12 @@ CHECK_C_SOURCE_COMPILES("
   #include <x86intrin.h>
   #endif
   void f(void *p) {
-    __mm_loadu_si512(p);
+    _mm512_loadu_si512(p);
   }
   int main() {
     __m512i a = _mm512_set1_epi32(1);
-    __m512i r = _mm512_andnot_si512(a, a); }"
-  COMPILER_SUPPORTS_AVX512F)
+    __m512i r = _mm512_andnot_si512(a, a);
+  }" COMPILER_SUPPORTS_AVX512F)
 
 # AVX2 implies AVX2128
 if(COMPILER_SUPPORTS_AVX2)


### PR DESCRIPTION
I think sleef should have "Release" as the default cmake build type because there is code that require the optimisation flags to be turned on.
I have wrote the code such that if a build type if specified, our default will not overwrite the user's preference.