### PR TITLE
[gnuabi] Add finite names for single precision.

### DIFF
--- a/src/libm-tester/Makefile
+++ b/src/libm-tester/Makefile
@@ -115,6 +115,27 @@ test :: ../../lib/libsleefgnuabi.$(DLLSUFFIX)
 	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__hypot_finite"
 	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__lgamma_finite"
 
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__acosf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__acoshf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__asinf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__atan2f_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__atanhf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__coshf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__exp10f_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__exp2f_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__expf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__expf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__fmodf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__hypotf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__lgammaf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__log10f_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__logf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__logf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__powf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__sinhf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__sqrtf_finite"
+	nm ../../lib/libsleefgnuabi.$(DLLSUFFIX) | grep -e "__tgammaf_finite"
+
 endif
 test :: $(TARGET_IUT) tester
 	$(foreach var,$(TARGET_IUT), $(ENVNAME_LD_LIBRARY_PATH)=../../lib:$$$(ENVNAME_LD_LIBRARY_PATH) ./tester ./$(var) || exit;)

--- a/src/libm/mkrename_gnuabi.c
+++ b/src/libm/mkrename_gnuabi.c
@@ -61,15 +61,31 @@ int main(int argc, char **argv) {
   for(int i=0;funcList[i].name != NULL;i++) {
     if (funcList[i].ulp < 0) {
       printf("#define x%sf _ZGV%sN%d%s_%sf\n", funcList[i].name,
-	     mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name);
+             mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name);
+      printf("#define str_x%sf \"_ZGV%sN%d%s_%sf\"\n", funcList[i].name,
+             mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name);
+      printf("#define __%sf_finite _ZGV%sN%d%s___%sf_finite\n", funcList[i].name,
+             mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name);
     } else if (funcList[i].ulp < 20) {
-      printf("#define x%sf%s _ZGV%sN%d%s_%sf\n", 
-	     funcList[i].name, ulpSuffixStr[funcList[i].ulpSuffix],
-	     mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name);
+      printf("#define x%sf%s _ZGV%sN%d%s_%sf\n",
+             funcList[i].name, ulpSuffixStr[funcList[i].ulpSuffix],
+             mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name);
+      printf("#define str_x%sf%s \"_ZGV%sN%d%s_%sf\"\n",
+             funcList[i].name, ulpSuffixStr[funcList[i].ulpSuffix],
+             mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name);
+      printf("#define __%sf%s_finite _ZGV%sN%d%s___%sf_finite\n",
+             funcList[i].name, ulpSuffixStr[funcList[i].ulpSuffix],
+             mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name);
     } else {
-      printf("#define x%sf%s _ZGV%sN%d%s_%sf_u%d\n", 
-	     funcList[i].name, ulpSuffixStr[funcList[i].ulpSuffix],
-	     mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name, funcList[i].ulp);
+      printf("#define x%sf%s _ZGV%sN%d%s_%sf_u%d\n",
+             funcList[i].name, ulpSuffixStr[funcList[i].ulpSuffix],
+             mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name, funcList[i].ulp);
+      printf("#define str_x%sf%s \"_ZGV%sN%d%s_%sf_u%d\"\n",
+             funcList[i].name, ulpSuffixStr[funcList[i].ulpSuffix],
+             mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name, funcList[i].ulp);
+      printf("#define __%sf%s_finite _ZGV%sN%d%s___%sf_finite\n",
+             funcList[i].name, ulpSuffixStr[funcList[i].ulpSuffix],
+             mangledisa, wsp, vparameterStrSP[funcList[i].funcType], funcList[i].name);
     }
   }
   

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -2101,3 +2101,25 @@ int main(int argc, char **argv) {
   
 }
 #endif
+
+#ifdef ENABLE_GNUABI
+/* "finite" aliases for compatibility with GLIBC */
+__extension__ __typeof(xacosf     ) __acosf_finite      __attribute__((weak, alias(str_xacosf_u1  )));
+__extension__ __typeof(xacoshf    ) __acoshf_finite     __attribute__((weak, alias(str_xacoshf    )));
+__extension__ __typeof(xasinf_u1  ) __asinf_finite      __attribute__((weak, alias(str_xasinf_u1  )));
+__extension__ __typeof(xatan2f_u1 ) __atan2f_finite     __attribute__((weak, alias(str_xatan2f_u1 )));
+__extension__ __typeof(xatanhf    ) __atanhf_finite     __attribute__((weak, alias(str_xatanhf    )));
+__extension__ __typeof(xcoshf     ) __coshf_finite      __attribute__((weak, alias(str_xcoshf     )));
+__extension__ __typeof(xexp10f    ) __exp10f_finite     __attribute__((weak, alias(str_xexp10f    )));
+__extension__ __typeof(xexp2f     ) __exp2f_finite      __attribute__((weak, alias(str_xexp2f     )));
+__extension__ __typeof(xexpf      ) __expf_finite       __attribute__((weak, alias(str_xexpf      )));
+__extension__ __typeof(xfmodf     ) __fmodf_finite      __attribute__((weak, alias(str_xfmodf     )));
+__extension__ __typeof(xhypotf_u05) __hypotf_u05_finite __attribute__((weak, alias(str_xhypotf_u05)));
+__extension__ __typeof(xlgammaf_u1) __lgammaf_u1_finite __attribute__((weak, alias(str_xlgammaf_u1)));
+__extension__ __typeof(xlog10f    ) __log10f_finite     __attribute__((weak, alias(str_xlog10f    )));
+__extension__ __typeof(xlogf_u1   ) __logf_finite       __attribute__((weak, alias(str_xlogf_u1   )));
+__extension__ __typeof(xpowf      ) __powf_finite       __attribute__((weak, alias(str_xpowf      )));
+__extension__ __typeof(xsinhf     ) __sinhf_finite      __attribute__((weak, alias(str_xsinhf     )));
+__extension__ __typeof(xsqrtf_u05 ) __sqrtf_u05_finite  __attribute__((weak, alias(str_xsqrtf_u05 )));
+__extension__ __typeof(xtgammaf_u1) __tgammaf_u1_finite __attribute__((weak, alias(str_xtgammaf_u1)));
+#endif /* #ifdef ENABLE_GNUABI */


### PR DESCRIPTION
This patch added the missing GNU ABI "finite" names for single precision computation.