### PR TITLE
[cmake] Fix libm dependency

### DIFF
--- a/Configure.cmake
+++ b/Configure.cmake
@@ -4,6 +4,7 @@ include(CheckTypeSize)
 
 # Check that the library LIB_MPFR is available
 find_library(LIB_MPFR mpfr)
+find_library(LIBM m)
 
 # The library currently supports the following SIMD architectures
 set(SLEEF_SUPPORTED_EXTENSIONS

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${CMAKE_BINARY_DIR}/include)          # sleef.h
 include_directories(${CMAKE_SOURCE_DIR}/src/libm)         # rename.h
 include_directories(${CMAKE_BINARY_DIR}/src/libm/include) # rename headers
 
-set(EXTRA_LIBS m
+set(EXTRA_LIBS ${LIBM}
   ${LIB_MPFR}
   ${TARGET_LIBCOMMON_STATIC}
   )

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -168,6 +168,14 @@ foreach(SIMD ${SLEEF_SUPPORTED_EXTENSIONS})
   endif(COMPILER_SUPPORTS_${SIMD})
 endforeach()
 
+# On some systems we need to explicitly link libsleef against libm to
+# use some of the math functions used in the scalar code (for example
+# sqrt).
+if(LIBM)
+  target_link_libraries(${TARGET_LIBSLEEF} m)
+endif(LIBM)
+
+
 # --------------------------------------------------------------------
 # TARGET_LIBSLEEFGNUABI
 # Compile SIMD versions for GNU Abi
@@ -207,6 +215,13 @@ if(SLEEF_ENABLE_GNUABI)
     POSITION_INDEPENDENT_CODE ON   # -fPIC
     C_STANDARD 99                  # -std=gnu99
   ) 
+
+# On some systems we need to explicitly link libsleefgnuabi against
+# libm to use some of the math functions used in the scalar code (for
+# example sqrt).
+if(LIBM)
+  target_link_libraries(${TARGET_LIBSLEEFGNUABI} m)
+endif(LIBM)
 endif(SLEEF_ENABLE_GNUABI)
 
 # --------------------------------------------------------------------

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -172,7 +172,7 @@ endforeach()
 # use some of the math functions used in the scalar code (for example
 # sqrt).
 if(LIBM)
-  target_link_libraries(${TARGET_LIBSLEEF} m)
+  target_link_libraries(${TARGET_LIBSLEEF} ${LIBM})
 endif(LIBM)
 
 
@@ -220,7 +220,7 @@ if(SLEEF_ENABLE_GNUABI)
 # libm to use some of the math functions used in the scalar code (for
 # example sqrt).
 if(LIBM)
-  target_link_libraries(${TARGET_LIBSLEEFGNUABI} m)
+  target_link_libraries(${TARGET_LIBSLEEFGNUABI} ${LIBM})
 endif(LIBM)
 endif(SLEEF_ENABLE_GNUABI)
 


### PR DESCRIPTION
On some Unix systems the libm dependency of libsleef and
libsleefgnuabi needs to be made explicit to avoid runtime failures in
the tests reporting "missing symbol: sqrt".