### PR TITLE
[cmake] Cmake uses ctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ before_script:
   - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 ..
 
 script:
-  - make test-libm
+  - CTEST_OUTPUT_ON_FAILURE=TRUE make all test
   - make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # See doc/build-with-cmake.md for instructions on how to build Sleef.
 cmake_minimum_required(VERSION 3.4.3)
 
+enable_testing()
+
 set(SLEEF_VERSION_MAJOR 3)
 set(SLEEF_VERSION_MINOR 1)
 set(SLEEF_SOVERSION ${SLEEF_VERSION_MAJOR})
@@ -57,10 +59,6 @@ set(TARGET_IUTAVX512F "iutavx512f")
 set(TARGET_IUTADVSIMD "iutadvsimd")
 # The target to generate LLVM bitcode only, available when SLEEF_ENABLE_LLVM_BITCODE is passed to cmake
 set(TARGET_LLVM_BITCODE "llvm-bitcode")
-# Runs the test suite
-# Depends on targets: iut, tester
-# Defined in src/libm-tester/CMakeLists.txt via command add_custom_target
-set(TARGET_TEST "test-libm")
 # Generates the helper executable file mkrename needed to write the sleef header
 set(TARGET_MKRENAME "mkrename")
 set(TARGET_MKRENAME_GNUABI "mkrename_gnuabi")

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -11,9 +11,6 @@ set(EXTRA_LIBS ${LIBM}
   ${TARGET_LIBCOMMON_STATIC}
   )
 
-# Test target
-add_custom_target(${TARGET_TEST})
-
 # Compile executable 'iut'
 add_executable(${TARGET_IUT} iut.c testerutil.c)
 target_link_libraries(${TARGET_IUT} ${TARGET_LIBSLEEF} ${EXTRA_LIBS})
@@ -32,7 +29,10 @@ macro(test_extension SIMD)
     target_link_libraries(${TARGET_IUT${SIMD}} ${TARGET_LIBSLEEF} ${EXTRA_LIBS})
 
     add_dependencies(${TARGET_IUT${SIMD}} ${TARGET_HEADERS})
-    add_dependencies(${TARGET_TEST} ${TARGET_IUT${SIMD}})
+    add_dependencies(${TARGET_IUT${SIMD}} ${TARGET_LIBSLEEF})
+
+    add_test(NAME ${TARGET_IUT${SIMD}}
+      COMMAND ${TARGET_TESTER} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TARGET_IUT${SIMD}})
     
     list(APPEND IUT_LIST ${TARGET_IUT${SIMD}})
   endif(COMPILER_SUPPORTS_${SIMD})
@@ -53,13 +53,5 @@ target_compile_options(${TARGET_TESTER} PRIVATE -Wno-unused-result)
 set_target_properties(${TARGET_TESTER} ${IUT_LIST} PROPERTIES
   C_STANDARD 99)
 
-# Target 'test-libm' runs the libm tests
-foreach(exe_iut ${IUT_LIST})
-  add_custom_command(TARGET ${TARGET_TEST}
-    COMMAND ${TARGET_TESTER} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${exe_iut}
-  )
-endforeach()
-
 # Tests depends on the library
 add_dependencies(${TARGET_IUT} ${TARGET_HEADERS})
-add_dependencies(${TARGET_TEST} ${TARGET_LIBSLEEF} ${TARGET_HEADERS} ${TARGET_IUT})


### PR DESCRIPTION
The old `test-libm` custom target have been replaced by the facilities provided with ctests.