### PR TITLE
[travis] Run tests in parallel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_install:
 before_script:
   - mkdir sleef.build
   - cd sleef.build
-  - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=1 -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 ..
+  - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 ..
 
 script:
-  - CTEST_OUTPUT_ON_FAILURE=TRUE make all test
+  - CTEST_OUTPUT_ON_FAILURE=TRUE make all test -j2 ARGS=-j2
   - make install


### PR DESCRIPTION
This patch runs the build and tests in parallel, with two parallel
runs which are available according to [1].

It also removes the verbose output.

[1] https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments