### PR TITLE
Various cmake fixes

### DIFF
--- a/Configure.cmake
+++ b/Configure.cmake
@@ -70,7 +70,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
   set(SLEEF_HEADER_LIST
     ADVSIMD
   )
-  set(HEADER_PARAMS_ADVSIMD    "2 4 float64x2_t float32x4_t int32x2_t int32x4_t __ARM_NEON advsimd")
+  set(HEADER_PARAMS_ADVSIMD    2 4 float64x2_t float32x4_t int32x2_t int32x4_t __ARM_NEON advsimd)
 
 endif()
 

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -70,7 +70,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
   set(SLEEF_HEADER_LIST
     ADVSIMD
   )
-  set(HEADER_PARAMS_ADVSIMD    2 4 float64x2_t float32x4_t int32x2_t int32x4_t __ARM_NEON advsimd)
+  command_arguments(HEADER_PARAMS_ADVSIMD    2 4 float64x2_t float32x4_t int32x2_t int32x4_t __ARM_NEON advsimd)
 
 endif()
 

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -14,6 +14,9 @@ set(EXTRA_LIBS ${LIBM}
 # Compile executable 'iut'
 add_executable(${TARGET_IUT} iut.c testerutil.c)
 target_link_libraries(${TARGET_IUT} ${TARGET_LIBSLEEF} ${EXTRA_LIBS})
+add_test(NAME ${TARGET_IUT}
+  COMMAND ${TARGET_TESTER} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TARGET_IUT})
+
 set(IUT_LIST ${TARGET_IUT})
 
 set(IUT_SRC iutsimd.c iutsimdmain.c testerutil)


### PR DESCRIPTION
This patch-set implements fixes for the cmake build system, on aarch64, and also reactivate scalar testing for all architectures.