### PR TITLE
[Performance] Speed improvement of log

### DIFF
--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -1357,7 +1357,7 @@ EXPORT CONST double xexp(double d) {
 }
 
 static INLINE CONST Sleef_double2 logk(double d) {
-  Sleef_double2 x, x2;
+  Sleef_double2 x, x2, s;
   double m, t;
   int e;
 
@@ -1383,14 +1383,15 @@ static INLINE CONST Sleef_double2 logk(double d) {
   t = mla(t, x2.x, 0.400000000000000077715612);
   Sleef_double2 c = dd(0.666666666666666629659233, 3.80554962542412056336616e-17);
 
-  return ddadd2_d2_d2_d2(ddmul_d2_d2_d(dd(0.693147180559945286226764, 2.319046813846299558417771e-17), e),
-			 ddadd2_d2_d2_d2(ddscale_d2_d2_d(x, 2),
-					 ddmul_d2_d2_d2(ddmul_d2_d2_d2(x2, x),
-							ddadd2_d2_d2_d2(ddmul_d2_d2_d(x2, t), c))));
+  s = ddmul_d2_d2_d(dd(0.693147180559945286226764, 2.319046813846299558417771e-17), e);
+  s = ddadd_d2_d2_d2(s, ddscale_d2_d2_d(x, 2));
+  s = ddadd_d2_d2_d2(s, ddmul_d2_d2_d2(ddmul_d2_d2_d2(x2, x),
+				       ddadd2_d2_d2_d2(ddmul_d2_d2_d(x2, t), c)));
+  return s;
 }
 
 EXPORT CONST double xlog_u1(double d) {
-  Sleef_double2 x;
+  Sleef_double2 x, s;
   double m, t, x2;
   int e;
 
@@ -1412,9 +1413,10 @@ EXPORT CONST double xlog_u1(double d) {
   t = mla(t, x2, 0.2857142932794299317e+0);
   t = mla(t, x2, 0.3999999999635251990e+0);
   t = mla(t, x2, 0.6666666666667333541e+0);
-  
-  Sleef_double2 s = ddadd2_d2_d2_d2(ddmul_d2_d2_d(dd(0.693147180559945286226764, 2.319046813846299558417771e-17), (double)e),
-				    ddadd2_d2_d2_d(ddscale_d2_d2_d(x, 2), t * x2 * x.x));
+
+  s = ddmul_d2_d2_d(dd(0.693147180559945286226764, 2.319046813846299558417771e-17), (double)e);
+  s = ddadd_d2_d2_d2(s, ddscale_d2_d2_d(x, 2));
+  s = ddadd_d2_d2_d(s, x2 * x.x * t);
 
   double r = s.x + s.y;
   
@@ -1551,7 +1553,7 @@ EXPORT CONST double xtanh(double x) {
 }
 
 static INLINE CONST Sleef_double2 logk2(Sleef_double2 d) {
-  Sleef_double2 x, x2, m;
+  Sleef_double2 x, x2, m, s;
   double t;
   int e;
   
@@ -1572,8 +1574,11 @@ static INLINE CONST Sleef_double2 logk2(Sleef_double2 d) {
   t = mla(t, x2.x, 0.400000000000914013309483);
   t = mla(t, x2.x, 0.666666666666664853302393);
 
-  return ddadd2_d2_d2_d2(ddmul_d2_d2_d(dd(0.693147180559945286226764, 2.319046813846299558417771e-17), e),
-			 ddadd2_d2_d2_d2(ddscale_d2_d2_d(x, 2), ddmul_d2_d2_d(ddmul_d2_d2_d2(x2, x), t)));
+  s = ddmul_d2_d2_d(dd(0.693147180559945286226764, 2.319046813846299558417771e-17), e);
+  s = ddadd_d2_d2_d2(s, ddscale_d2_d2_d(x, 2));
+  s = ddadd_d2_d2_d2(s, ddmul_d2_d2_d(ddmul_d2_d2_d2(x2, x), t));
+
+  return s;
 }
 
 EXPORT CONST double xasinh(double x) {

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -1358,7 +1358,7 @@ EXPORT CONST vdouble xexp(vdouble d) {
 }
 
 static INLINE CONST vdouble2 logk(vdouble d) {
-  vdouble2 x, x2;
+  vdouble2 x, x2, s;
   vdouble t, m;
 
 #ifndef ENABLE_AVX512F
@@ -1388,16 +1388,15 @@ static INLINE CONST vdouble2 logk(vdouble d) {
   vdouble2 c = vcast_vd2_d_d(0.666666666666666629659233, 3.80554962542412056336616e-17);
 
 #ifndef ENABLE_AVX512F
-  return ddadd2_vd2_vd2_vd2(ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17), vcast_vd_vi(e)),
-			    ddadd2_vd2_vd2_vd2(ddscale_vd2_vd2_vd(x, vcast_vd_d(2)),
-					       ddmul_vd2_vd2_vd2(ddmul_vd2_vd2_vd2(x2, x),
-								 ddadd2_vd2_vd2_vd2(ddmul_vd2_vd2_vd(x2, t), c))));
+  s = ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17), vcast_vd_vi(e));
 #else
-  return ddadd2_vd2_vd2_vd2(ddmul_vd2_vd2_vd(vcast_vd2_vd_vd(vcast_vd_d(0.693147180559945286226764), vcast_vd_d(2.319046813846299558417771e-17)), e),
-			    ddadd2_vd2_vd2_vd2(ddscale_vd2_vd2_vd(x, vcast_vd_d(2)),
-					       ddmul_vd2_vd2_vd2(ddmul_vd2_vd2_vd2(x2, x),
-								 ddadd2_vd2_vd2_vd2(ddmul_vd2_vd2_vd(x2, t), c))));
+  s = ddmul_vd2_vd2_vd(vcast_vd2_vd_vd(vcast_vd_d(0.693147180559945286226764), vcast_vd_d(2.319046813846299558417771e-17)), e);
 #endif
+
+  s = ddadd_vd2_vd2_vd2(s, ddscale_vd2_vd2_vd(x, vcast_vd_d(2)));
+  s = ddadd_vd2_vd2_vd2(s, ddmul_vd2_vd2_vd2(ddmul_vd2_vd2_vd2(x2, x),
+					     ddadd2_vd2_vd2_vd2(ddmul_vd2_vd2_vd(x2, t), c)));
+  return s;
 }
 
 EXPORT CONST vdouble xlog_u1(vdouble d) {
@@ -1428,12 +1427,13 @@ EXPORT CONST vdouble xlog_u1(vdouble d) {
   t = vmla_vd_vd_vd_vd(t, x2, vcast_vd_d(0.6666666666667333541e+0));
   
 #ifndef ENABLE_AVX512F
-  vdouble2 s = ddadd2_vd2_vd2_vd2(ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17), vcast_vd_vi(e)),
-				  ddadd2_vd2_vd2_vd(ddscale_vd2_vd2_vd(x, vcast_vd_d(2)), vmul_vd_vd_vd(vmul_vd_vd_vd(x2, x.x), t)));
+  vdouble2 s = ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17), vcast_vd_vi(e));
 #else
-  vdouble2 s = ddadd2_vd2_vd2_vd2(ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17), e),
-				  ddadd2_vd2_vd2_vd(ddscale_vd2_vd2_vd(x, vcast_vd_d(2)), vmul_vd_vd_vd(vmul_vd_vd_vd(x2, x.x), t)));
+  vdouble2 s = ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17), e);
 #endif
+
+  s = ddadd_vd2_vd2_vd2(s, ddscale_vd2_vd2_vd(x, vcast_vd_d(2)));
+  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmul_vd_vd_vd(x2, x.x), t));
 
   vdouble r = vadd_vd_vd_vd(s.x, s.y);
 
@@ -1595,7 +1595,7 @@ EXPORT CONST vdouble xtanh(vdouble x) {
 }
 
 static INLINE CONST vdouble2 logk2(vdouble2 d) {
-  vdouble2 x, x2, m;
+  vdouble2 x, x2, m, s;
   vdouble t;
   vint e;
   
@@ -1616,9 +1616,11 @@ static INLINE CONST vdouble2 logk2(vdouble2 d) {
   t = vmla_vd_vd_vd_vd(t, x2.x, vcast_vd_d(0.400000000000914013309483));
   t = vmla_vd_vd_vd_vd(t, x2.x, vcast_vd_d(0.666666666666664853302393));
 
-  return ddadd2_vd2_vd2_vd2(ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17),
-					     vcast_vd_vi(e)),
-			    ddadd2_vd2_vd2_vd2(ddscale_vd2_vd2_vd(x, vcast_vd_d(2)), ddmul_vd2_vd2_vd(ddmul_vd2_vd2_vd2(x2, x), t)));
+  s = ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17), vcast_vd_vi(e));
+  s = ddadd_vd2_vd2_vd2(s, ddscale_vd2_vd2_vd(x, vcast_vd_d(2)));
+  s = ddadd_vd2_vd2_vd2(s, ddmul_vd2_vd2_vd(ddmul_vd2_vd2_vd2(x2, x), t));
+
+  return  s;
 }
 
 EXPORT CONST vdouble xasinh(vdouble x) {

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -1251,17 +1251,15 @@ static INLINE CONST vfloat2 logkf(vfloat d) {
   vfloat2 c = vcast_vf2_f_f(0.66666662693023681640625f, 3.69183861259614332084311e-09f);
 
 #ifndef ENABLE_AVX512F
-  return dfadd2_vf2_vf2_vf2(dfmul_vf2_vf2_vf(vcast_vf2_vf_vf(vcast_vf_f(0.69314718246459960938f), vcast_vf_f(-1.904654323148236017e-09f)),
-					     vcast_vf_vi2(e)),
-			    dfadd2_vf2_vf2_vf2(dfscale_vf2_vf2_vf(x, vcast_vf_f(2)),
-					       dfmul_vf2_vf2_vf2(dfmul_vf2_vf2_vf2(x2, x),
-								 dfadd2_vf2_vf2_vf2(dfmul_vf2_vf2_vf(x2, t), c))));
+  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), vcast_vf_vi2(e));
 #else
-  return dfadd2_vf2_vf2_vf2(dfmul_vf2_vf2_vf(vcast_vf2_vf_vf(vcast_vf_f(0.69314718246459960938f), vcast_vf_f(-1.904654323148236017e-09f)), e),
-			    dfadd2_vf2_vf2_vf2(dfscale_vf2_vf2_vf(x, vcast_vf_f(2)),
-					       dfmul_vf2_vf2_vf2(dfmul_vf2_vf2_vf2(x2, x),
-								 dfadd2_vf2_vf2_vf2(dfmul_vf2_vf2_vf(x2, t), c))));
+  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), e);
 #endif
+
+  s = dfadd_vf2_vf2_vf2(s, dfscale_vf2_vf2_vf(x, vcast_vf_f(2)));
+  s = dfadd_vf2_vf2_vf2(s, dfmul_vf2_vf2_vf2(dfmul_vf2_vf2_vf2(x2, x),
+					     dfadd2_vf2_vf2_vf2(dfmul_vf2_vf2_vf(x2, t), c)));
+  return s;
 }
 
 EXPORT CONST vfloat xlogf_u1(vfloat d) {
@@ -1288,12 +1286,13 @@ EXPORT CONST vfloat xlogf_u1(vfloat d) {
   t = vmla_vf_vf_vf_vf(t, x2, vcast_vf_f(+0.6666694880e+0f));
   
 #ifndef ENABLE_AVX512F
-  vfloat2 s = dfadd2_vf2_vf2_vf2(dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), vcast_vf_vi2(e)),
-				 dfadd2_vf2_vf2_vf(dfscale_vf2_vf2_vf(x, vcast_vf_f(2)), vmul_vf_vf_vf(vmul_vf_vf_vf(x2, x.x), t)));
+  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), vcast_vf_vi2(e));
 #else
-  vfloat2 s = dfadd2_vf2_vf2_vf2(dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), e),
-				 dfadd2_vf2_vf2_vf(dfscale_vf2_vf2_vf(x, vcast_vf_f(2)), vmul_vf_vf_vf(vmul_vf_vf_vf(x2, x.x), t)));
+  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), e);
 #endif
+
+  s = dfadd_vf2_vf2_vf2(s, dfscale_vf2_vf2_vf(x, vcast_vf_f(2)));
+  s = dfadd_vf2_vf2_vf(s, vmul_vf_vf_vf(vmul_vf_vf_vf(x2, x.x), t));
 
   vfloat r = vadd_vf_vf_vf(s.x, s.y);
 
@@ -1450,7 +1449,7 @@ EXPORT CONST vfloat xtanhf(vfloat x) {
 }
 
 static INLINE CONST vfloat2 logk2f(vfloat2 d) {
-  vfloat2 x, x2, m;
+  vfloat2 x, x2, m, s;
   vfloat t;
   vint2 e;
 
@@ -1469,9 +1468,11 @@ static INLINE CONST vfloat2 logk2f(vfloat2 d) {
   t = vmla_vf_vf_vf_vf(t, x2.x, vcast_vf_f(0.400005877017974853515625f));
   t = vmla_vf_vf_vf_vf(t, x2.x, vcast_vf_f(0.666666686534881591796875f));
 
-  return dfadd2_vf2_vf2_vf2(dfmul_vf2_vf2_vf(vcast_vf2_vf_vf(vcast_vf_f(0.69314718246459960938f), vcast_vf_f(-1.904654323148236017e-09f)),
-					     vcast_vf_vi2(e)),
-			    dfadd2_vf2_vf2_vf2(dfscale_vf2_vf2_vf(x, vcast_vf_f(2)), dfmul_vf2_vf2_vf(dfmul_vf2_vf2_vf2(x2, x), t)));
+  s = dfmul_vf2_vf2_vf(vcast_vf2_vf_vf(vcast_vf_f(0.69314718246459960938f), vcast_vf_f(-1.904654323148236017e-09f)), vcast_vf_vi2(e));
+  s = dfadd_vf2_vf2_vf2(s, dfscale_vf2_vf2_vf(x, vcast_vf_f(2)));
+  s = dfadd_vf2_vf2_vf2(s, dfmul_vf2_vf2_vf(dfmul_vf2_vf2_vf2(x2, x), t));
+
+  return s;
 }
 
 EXPORT CONST vfloat xasinhf(vfloat x) {

--- a/src/libm/sleefsp.c
+++ b/src/libm/sleefsp.c
@@ -1105,7 +1105,7 @@ static INLINE CONST float expkf(Sleef_float2 d) {
 }
 
 static INLINE CONST Sleef_float2 logkf(float d) {
-  Sleef_float2 x, x2;
+  Sleef_float2 x, x2, s;
   float m, t;
   int e;
 
@@ -1125,14 +1125,15 @@ static INLINE CONST Sleef_float2 logkf(float d) {
   t = mlaf(t, x2.x, 0.400007992982864379882812);
   Sleef_float2 c = df(0.66666662693023681640625f, 3.69183861259614332084311e-09f);
 
-  return dfadd2_f2_f2_f2(dfmul_f2_f2_f(df(0.69314718246459960938f, -1.904654323148236017e-09f), e),
-			 dfadd2_f2_f2_f2(dfscale_f2_f2_f(x, 2),
-					 dfmul_f2_f2_f2(dfmul_f2_f2_f2(x2, x),
-							dfadd2_f2_f2_f2(dfmul_f2_f2_f(x2, t), c))));
+  s = dfmul_f2_f2_f(df(0.69314718246459960938f, -1.904654323148236017e-09f), e);
+  s = dfadd_f2_f2_f2(s, dfscale_f2_f2_f(x, 2));
+  s = dfadd_f2_f2_f2(s, dfmul_f2_f2_f2(dfmul_f2_f2_f2(x2, x),
+				       dfadd2_f2_f2_f2(dfmul_f2_f2_f(x2, t), c)));
+  return s;
 }
 
 EXPORT CONST float xlogf_u1(float d) {
-  Sleef_float2 x;
+  Sleef_float2 x, s;
   float m, t, x2;
   int e;
 
@@ -1150,9 +1151,10 @@ EXPORT CONST float xlogf_u1(float d) {
   t = +0.3027294874e+0f;
   t = mlaf(t, x2, +0.3996108174e+0f);
   t = mlaf(t, x2, +0.6666694880e+0f);
-  
-  Sleef_float2 s = dfadd2_f2_f2_f2(dfmul_f2_f2_f(df(0.69314718246459960938f, -1.904654323148236017e-09f), (float)e),
-				    dfadd2_f2_f2_f(dfscale_f2_f2_f(x, 2), t * x2 * x.x));
+
+  s = dfmul_f2_f2_f(df(0.69314718246459960938f, -1.904654323148236017e-09f), (float)e);
+  s = dfadd_f2_f2_f2(s, dfscale_f2_f2_f(x, 2));
+  s = dfadd_f2_f2_f(s, t * x2 * x.x);
 
   float r = s.x + s.y;
   
@@ -1250,7 +1252,7 @@ EXPORT CONST float xtanhf(float x) {
 }
 
 static INLINE CONST Sleef_float2 logk2f(Sleef_float2 d) {
-  Sleef_float2 x, x2, m;
+  Sleef_float2 x, x2, m, s;
   float t;
   int e;
 
@@ -1265,8 +1267,11 @@ static INLINE CONST Sleef_float2 logk2f(Sleef_float2 d) {
   t = mlaf(t, x2.x, 0.400005877017974853515625f);
   t = mlaf(t, x2.x, 0.666666686534881591796875f);
 
-  return dfadd2_f2_f2_f2(dfmul_f2_f2_f(df(0.69314718246459960938f, -1.904654323148236017e-09f), e),
-			 dfadd2_f2_f2_f2(dfscale_f2_f2_f(x, 2), dfmul_f2_f2_f(dfmul_f2_f2_f2(x2, x), t)));
+  s = dfmul_f2_f2_f(df(0.69314718246459960938f, -1.904654323148236017e-09f), e);
+  s = dfadd_f2_f2_f2(s, dfscale_f2_f2_f(x, 2));
+  s = dfadd_f2_f2_f2(s, dfmul_f2_f2_f(dfmul_f2_f2_f2(x2, x), t));
+
+  return s;
 }
 
 EXPORT CONST float xasinhf(float x) {


### PR DESCRIPTION
This patch improves computation speed of log.

This patch improves computation speed of log functions by simplifying calculation and adding more opportunity for out-of-order parallelization with CPU's pipeline.
With this patch, the computation speed of xlog_u1 is increased by 16%, which means the ratio between computation time of the previous implementation and the new implementation is 116%.