### PR TITLE
[gnuabi] Avoid GCC extensions for finite names.

### DIFF
--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -2312,23 +2312,23 @@ int main(int argc, char **argv) {
 
 #ifdef ENABLE_GNUABI
 /* "finite" aliases for compatibility with GLIBC */
-__extension__ __typeof(xacos     ) __acos_finite      __attribute__((weak, alias(str_xacos     )));
-__extension__ __typeof(xacosh    ) __acosh_finite     __attribute__((weak, alias(str_xacosh    )));
-__extension__ __typeof(xasin_u1  ) __asin_finite      __attribute__((weak, alias(str_xasin_u1  )));
-__extension__ __typeof(xatan2_u1 ) __atan2_finite     __attribute__((weak, alias(str_xatan2_u1 )));
-__extension__ __typeof(xatanh    ) __atanh_finite     __attribute__((weak, alias(str_xatanh    )));
-__extension__ __typeof(xcosh     ) __cosh_finite      __attribute__((weak, alias(str_xcosh     )));
-__extension__ __typeof(xsinh     ) __sinh_finite      __attribute__((weak, alias(str_xsinh     )));
-__extension__ __typeof(xsqrt_u05 ) __sqrt_u05_finite  __attribute__((weak, alias(str_xsqrt_u05 )));
-__extension__ __typeof(xexp      ) __exp_finite       __attribute__((weak, alias(str_xexp      )));
-__extension__ __typeof(xtgamma_u1) __tgamma_u1_finite __attribute__((weak, alias(str_xtgamma_u1)));
-__extension__ __typeof(xexp10    ) __exp10_finite     __attribute__((weak, alias(str_xexp10    )));
-__extension__ __typeof(xexp2     ) __exp2_finite      __attribute__((weak, alias(str_xexp2     )));
-__extension__ __typeof(xlog_u1   ) __log_finite       __attribute__((weak, alias(str_xlog_u1   )));
-__extension__ __typeof(xlog10    ) __log10_finite     __attribute__((weak, alias(str_xlog10    )));
-__extension__ __typeof(xpow      ) __pow_finite       __attribute__((weak, alias(str_xpow      )));
-__extension__ __typeof(xfmod     ) __fmod_finite      __attribute__((weak, alias(str_xfmod     )));
-__extension__ __typeof(xhypot_u05) __hypot_u05_finite __attribute__((weak, alias(str_xhypot_u05)));
-__extension__ __typeof(xlgamma_u1) __lgamma_u1_finite __attribute__((weak, alias(str_xlgamma_u1)));
+EXPORT CONST vdouble __acos_finite     (vdouble)          __attribute__((weak, alias(str_xacos     )));
+EXPORT CONST vdouble __acosh_finite    (vdouble)          __attribute__((weak, alias(str_xacosh    )));
+EXPORT CONST vdouble __asin_finite     (double)           __attribute__((weak, alias(str_xasin_u1  )));
+EXPORT CONST vdouble __atan2_finite    (vdouble, vdouble) __attribute__((weak, alias(str_xatan2_u1 )));
+EXPORT CONST vdouble __atanh_finite    (vdouble)          __attribute__((weak, alias(str_xatanh    )));
+EXPORT CONST vdouble __cosh_finite     (vdouble)          __attribute__((weak, alias(str_xcosh     )));
+EXPORT CONST vdouble __exp10_finite    (vdouble)          __attribute__((weak, alias(str_xexp10    )));
+EXPORT CONST vdouble __exp2_finite     (vdouble)          __attribute__((weak, alias(str_xexp2     )));
+EXPORT CONST vdouble __exp_finite      (vdouble)          __attribute__((weak, alias(str_xexp      )));
+EXPORT CONST vdouble __fmod_finite     (vdouble, vdouble) __attribute__((weak, alias(str_xfmod     )));
+EXPORT CONST vdouble __hypot_u05_finite(vdouble, vdouble) __attribute__((weak, alias(str_xhypot_u05)));
+EXPORT CONST vdouble __lgamma_u1_finite(vdouble)          __attribute__((weak, alias(str_xlgamma_u1)));
+EXPORT CONST vdouble __log10_finite    (vdouble)          __attribute__((weak, alias(str_xlog10    )));
+EXPORT CONST vdouble __log_finite      (vdouble)          __attribute__((weak, alias(str_xlog_u1   )));
+EXPORT CONST vdouble __pow_finite      (vdouble, vdouble) __attribute__((weak, alias(str_xpow      )));
+EXPORT CONST vdouble __sinh_finite     (vdouble)          __attribute__((weak, alias(str_xsinh     )));
+EXPORT CONST vdouble __sqrt_u05_finite (vdouble)          __attribute__((weak, alias(str_xsqrt_u05 )));
+EXPORT CONST vdouble __tgamma_u1_finite(vdouble)          __attribute__((weak, alias(str_xtgamma_u1)));
 
 #endif /* #ifdef ENABLE_GNUABI */

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -2113,23 +2113,22 @@ int main(int argc, char **argv) {
 #endif
 
 #ifdef ENABLE_GNUABI
-/* "finite" aliases for compatibility with GLIBC */
-__extension__ __typeof(xacosf     ) __acosf_finite      __attribute__((weak, alias(str_xacosf_u1  )));
-__extension__ __typeof(xacoshf    ) __acoshf_finite     __attribute__((weak, alias(str_xacoshf    )));
-__extension__ __typeof(xasinf_u1  ) __asinf_finite      __attribute__((weak, alias(str_xasinf_u1  )));
-__extension__ __typeof(xatan2f_u1 ) __atan2f_finite     __attribute__((weak, alias(str_xatan2f_u1 )));
-__extension__ __typeof(xatanhf    ) __atanhf_finite     __attribute__((weak, alias(str_xatanhf    )));
-__extension__ __typeof(xcoshf     ) __coshf_finite      __attribute__((weak, alias(str_xcoshf     )));
-__extension__ __typeof(xexp10f    ) __exp10f_finite     __attribute__((weak, alias(str_xexp10f    )));
-__extension__ __typeof(xexp2f     ) __exp2f_finite      __attribute__((weak, alias(str_xexp2f     )));
-__extension__ __typeof(xexpf      ) __expf_finite       __attribute__((weak, alias(str_xexpf      )));
-__extension__ __typeof(xfmodf     ) __fmodf_finite      __attribute__((weak, alias(str_xfmodf     )));
-__extension__ __typeof(xhypotf_u05) __hypotf_u05_finite __attribute__((weak, alias(str_xhypotf_u05)));
-__extension__ __typeof(xlgammaf_u1) __lgammaf_u1_finite __attribute__((weak, alias(str_xlgammaf_u1)));
-__extension__ __typeof(xlog10f    ) __log10f_finite     __attribute__((weak, alias(str_xlog10f    )));
-__extension__ __typeof(xlogf_u1   ) __logf_finite       __attribute__((weak, alias(str_xlogf_u1   )));
-__extension__ __typeof(xpowf      ) __powf_finite       __attribute__((weak, alias(str_xpowf      )));
-__extension__ __typeof(xsinhf     ) __sinhf_finite      __attribute__((weak, alias(str_xsinhf     )));
-__extension__ __typeof(xsqrtf_u05 ) __sqrtf_u05_finite  __attribute__((weak, alias(str_xsqrtf_u05 )));
-__extension__ __typeof(xtgammaf_u1) __tgammaf_u1_finite __attribute__((weak, alias(str_xtgammaf_u1)));
+EXPORT CONST vfloat __acosf_finite     (vfloat)         __attribute__((weak, alias(str_xacosf_u1  )));
+EXPORT CONST vfloat __acoshf_finite    (vfloat)         __attribute__((weak, alias(str_xacoshf    )));
+EXPORT CONST vfloat __asinf_finite     (double)         __attribute__((weak, alias(str_xasinf_u1  )));
+EXPORT CONST vfloat __atan2f_finite    (vfloat, vfloat) __attribute__((weak, alias(str_xatan2f_u1 )));
+EXPORT CONST vfloat __atanhf_finite    (vfloat)         __attribute__((weak, alias(str_xatanhf    )));
+EXPORT CONST vfloat __coshf_finite     (vfloat)         __attribute__((weak, alias(str_xcoshf     )));
+EXPORT CONST vfloat __exp10f_finite    (vfloat)         __attribute__((weak, alias(str_xexp10f    )));
+EXPORT CONST vfloat __exp2f_finite     (vfloat)         __attribute__((weak, alias(str_xexp2f     )));
+EXPORT CONST vfloat __expf_finite      (vfloat)         __attribute__((weak, alias(str_xexpf      )));
+EXPORT CONST vfloat __fmodf_finite     (vfloat, vfloat) __attribute__((weak, alias(str_xfmodf     )));
+EXPORT CONST vfloat __hypotf_u05_finite(vfloat, vfloat) __attribute__((weak, alias(str_xhypotf_u05)));
+EXPORT CONST vfloat __lgammaf_u1_finite(vfloat)         __attribute__((weak, alias(str_xlgammaf_u1)));
+EXPORT CONST vfloat __log10f_finite    (vfloat)         __attribute__((weak, alias(str_xlog10f    )));
+EXPORT CONST vfloat __logf_finite      (vfloat)         __attribute__((weak, alias(str_xlogf_u1   )));
+EXPORT CONST vfloat __powf_finite      (vfloat, vfloat) __attribute__((weak, alias(str_xpowf      )));
+EXPORT CONST vfloat __sinhf_finite     (vfloat)         __attribute__((weak, alias(str_xsinhf     )));
+EXPORT CONST vfloat __sqrtf_u05_finite (vfloat)         __attribute__((weak, alias(str_xsqrtf_u05 )));
+EXPORT CONST vfloat __tgammaf_u1_finite(vfloat)         __attribute__((weak, alias(str_xtgammaf_u1)));
 #endif /* #ifdef ENABLE_GNUABI */


### PR DESCRIPTION
This patch replaces the `__extension__ __typeof` keywords used to
define the GNUABI "finite" symbols with a explicit declaration of the
functions.

This is done to prevent two problems:

1. avoid using GCC specific extension like `__extension__ __typeof`
   that not all compiler support;

2. make sure that the "finite" symbols have global visibility in the
   shared library.