### PR TITLE
[Performance] This patch improves computation speed of log1p.

### DIFF
--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -1872,16 +1872,50 @@ EXPORT CONST vdouble xlog10(vdouble d) {
   return r;
 }
 
-EXPORT CONST vdouble xlog1p(vdouble a) {
-  vdouble2 d = logk2(ddadd2_vd2_vd_vd(a, vcast_vd_d(1)));
-  vdouble x = vadd_vd_vd_vd(d.x, d.y);
+EXPORT CONST vdouble xlog1p(vdouble d) {
+  vdouble2 x;
+  vdouble t, m, x2;
 
-  x = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(a, vcast_vd_d(1e+307)), vcast_vd_d(INFINITY), x);
-  x = vreinterpret_vd_vm(vor_vm_vo64_vm(vgt_vo_vd_vd(vcast_vd_d(-1.0), a), vreinterpret_vm_vd(x)));
-  x = vsel_vd_vo_vd_vd(veq_vo_vd_vd(a, vcast_vd_d(-1)), vcast_vd_d(-INFINITY), x);
-  x = vsel_vd_vo_vd_vd(visnegzero_vo_vd(a), vcast_vd_d(-0.0), x);
+  vdouble dp1 = vadd_vd_vd_vd(d, vcast_vd_d(1));
 
-  return x;
+#ifndef ENABLE_AVX512F
+  vopmask o = vlt_vo_vd_vd(dp1, vcast_vd_d(DBL_MIN));
+  dp1 = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(dp1, vcast_vd_d((double)(1LL << 32) * (double)(1LL << 32))), dp1);
+  vint e = vilogb2k_vi_vd(vmul_vd_vd_vd(dp1, vcast_vd_d(1.0/0.75)));
+  t = vldexp3_vd_vd_vi(vcast_vd_d(1), vneg_vi_vi(e));
+  m = vmla_vd_vd_vd_vd(d, t, vsub_vd_vd_vd(t, vcast_vd_d(1)));
+  e = vsel_vi_vo_vi_vi(vcast_vo32_vo64(o), vsub_vi_vi_vi(e, vcast_vi_i(64)), e);
+  vdouble2 s = ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17), vcast_vd_vi(e));
+#else
+  vdouble e = vgetexp_vd_vd(vmul_vd_vd_vd(dp1, vcast_vd_d(1.0/0.75)));
+  e = vsel_vd_vo_vd_vd(vispinf_vo_vd(e), vcast_vd_d(1024.0), e);
+  t = vldexp3_vd_vd_vi(vcast_vd_d(1), vneg_vi_vi(vrint_vi_vd(e)));
+  m = vmla_vd_vd_vd_vd(d, t, vsub_vd_vd_vd(t, vcast_vd_d(1)));
+  vdouble2 s = ddmul_vd2_vd2_vd(vcast_vd2_d_d(0.693147180559945286226764, 2.319046813846299558417771e-17), e);
+#endif
+
+  x = dddiv_vd2_vd2_vd2(vcast_vd2_vd_vd(m, vcast_vd_d(0)), ddadd_vd2_vd_vd(vcast_vd_d(2), m));
+  x2 = vmul_vd_vd_vd(x.x, x.x);
+
+  t = vcast_vd_d(0.1532076988502701353e+0);
+  t = vmla_vd_vd_vd_vd(t, x2, vcast_vd_d(0.1525629051003428716e+0));
+  t = vmla_vd_vd_vd_vd(t, x2, vcast_vd_d(0.1818605932937785996e+0));
+  t = vmla_vd_vd_vd_vd(t, x2, vcast_vd_d(0.2222214519839380009e+0));
+  t = vmla_vd_vd_vd_vd(t, x2, vcast_vd_d(0.2857142932794299317e+0));
+  t = vmla_vd_vd_vd_vd(t, x2, vcast_vd_d(0.3999999999635251990e+0));
+  t = vmla_vd_vd_vd_vd(t, x2, vcast_vd_d(0.6666666666667333541e+0));
+  
+  s = ddadd_vd2_vd2_vd2(s, ddscale_vd2_vd2_vd(x, vcast_vd_d(2)));
+  s = ddadd_vd2_vd2_vd(s, vmul_vd_vd_vd(vmul_vd_vd_vd(x2, x.x), t));
+
+  vdouble r = vadd_vd_vd_vd(s.x, s.y);
+  
+  r = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(d, vcast_vd_d(1e+307)), vcast_vd_d(INFINITY), r);
+  r = vsel_vd_vo_vd_vd(vor_vo_vo_vo(vlt_vo_vd_vd(d, vcast_vd_d(-1)), visnan_vo_vd(d)), vcast_vd_d(NAN), r);
+  r = vsel_vd_vo_vd_vd(veq_vo_vd_vd(d, vcast_vd_d(-1)), vcast_vd_d(-INFINITY), r);
+  r = vsel_vd_vo_vd_vd(visnegzero_vo_vd(d), vcast_vd_d(-0.0), r);
+  
+  return r;
 }
 
 //

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -1272,10 +1272,12 @@ EXPORT CONST vfloat xlogf_u1(vfloat d) {
   vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(d, vcast_vf_f(1.0f/0.75f)));
   m = vldexp3_vf_vf_vi2(d, vneg_vi2_vi2(e));
   e = vsel_vi2_vo_vi2_vi2(o, vsub_vi2_vi2_vi2(e, vcast_vi2_i(64)), e);
+  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), vcast_vf_vi2(e));
 #else
   vfloat e = vgetexp_vf_vf(vmul_vf_vf_vf(d, vcast_vf_f(1.0f/0.75f)));
   e = vsel_vf_vo_vf_vf(vispinf_vo_vf(e), vcast_vf_f(128.0f), e);
   m = vgetmant_vf_vf(d);
+  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), e);
 #endif
 
   x = dfdiv_vf2_vf2_vf2(dfadd2_vf2_vf_vf(vcast_vf_f(-1), m), dfadd2_vf2_vf_vf(vcast_vf_f(1), m));
@@ -1285,12 +1287,6 @@ EXPORT CONST vfloat xlogf_u1(vfloat d) {
   t = vmla_vf_vf_vf_vf(t, x2, vcast_vf_f(+0.3996108174e+0f));
   t = vmla_vf_vf_vf_vf(t, x2, vcast_vf_f(+0.6666694880e+0f));
   
-#ifndef ENABLE_AVX512F
-  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), vcast_vf_vi2(e));
-#else
-  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), e);
-#endif
-
   s = dfadd_vf2_vf2_vf2(s, dfscale_vf2_vf2_vf(x, vcast_vf_f(2)));
   s = dfadd_vf2_vf2_vf(s, vmul_vf_vf_vf(vmul_vf_vf_vf(x2, x.x), t));
 
@@ -1537,7 +1533,7 @@ EXPORT CONST vfloat xexp2f(vfloat d) {
   u = vmla_vf_vf_vf_vf(u, s, vcast_vf_f(+0.2402264476e+0));
   u = vmla_vf_vf_vf_vf(u, s, vcast_vf_f(+0.6931471825e+0));
 
-#ifdef ENABLE_FMA_DP
+#ifdef ENABLE_FMA_SP
   u = vfma_vf_vf_vf_vf(u, s, vcast_vf_f(1));
 #else
   u = dfnormalize_vf2_vf2(dfadd_vf2_vf_vf2(vcast_vf_f(1), dfmul_vf2_vf_vf(u, s))).x;
@@ -1565,7 +1561,7 @@ EXPORT CONST vfloat xexp10f(vfloat d) {
   u = vmla_vf_vf_vf_vf(u, s, vcast_vf_f(+0.2650948763e+1));
   u = vmla_vf_vf_vf_vf(u, s, vcast_vf_f(+0.2302585125e+1));
 
-#ifdef ENABLE_FMA_DP
+#ifdef ENABLE_FMA_SP
   u = vfma_vf_vf_vf_vf(u, s, vcast_vf_f(1));
 #else
   u = dfnormalize_vf2_vf2(dfadd_vf2_vf_vf2(vcast_vf_f(1), dfmul_vf2_vf_vf(u, s))).x;
@@ -1633,16 +1629,46 @@ EXPORT CONST vfloat xlog10f(vfloat d) {
   return r;
 }
 
-EXPORT CONST vfloat xlog1pf(vfloat a) {
-  vfloat2 d = logk2f(dfadd2_vf2_vf_vf(a, vcast_vf_f(1)));
-  vfloat x = vadd_vf_vf_vf(d.x, d.y);
+EXPORT CONST vfloat xlog1pf(vfloat d) {
+  vfloat2 x;
+  vfloat t, m, x2;
 
-  x = vsel_vf_vo_vf_vf(vgt_vo_vf_vf(a, vcast_vf_f(1e+38)), vcast_vf_f(INFINITYf), x);
-  x = vreinterpret_vf_vm(vor_vm_vo32_vm(vgt_vo_vf_vf(vcast_vf_f(-1), a), vreinterpret_vm_vf(x)));
-  x = vsel_vf_vo_vf_vf(veq_vo_vf_vf(a, vcast_vf_f(-1)), vcast_vf_f(-INFINITYf), x);
-  x = vsel_vf_vo_vf_vf(visnegzero_vo_vf(a), vcast_vf_f(-0.0f), x);
+  vfloat dp1 = vadd_vf_vf_vf(d, vcast_vf_f(1));
 
-  return x;
+#ifndef ENABLE_AVX512F
+  vopmask o = vlt_vo_vf_vf(dp1, vcast_vf_f(FLT_MIN));
+  dp1 = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(dp1, vcast_vf_f((float)(1LL << 32) * (float)(1LL << 32))), dp1);
+  vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(dp1, vcast_vf_f(1.0f/0.75f)));
+  t = vldexp3_vf_vf_vi2(vcast_vf_f(1), vneg_vi2_vi2(e));
+  m = vmla_vf_vf_vf_vf(d, t, vsub_vf_vf_vf(t, vcast_vf_f(1)));
+  e = vsel_vi2_vo_vi2_vi2(o, vsub_vi2_vi2_vi2(e, vcast_vi2_i(64)), e);
+  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), vcast_vf_vi2(e));
+#else
+  vfloat e = vgetexp_vf_vf(vmul_vf_vf_vf(dp1, vcast_vf_f(1.0f/0.75f)));
+  e = vsel_vf_vo_vf_vf(vispinf_vo_vf(e), vcast_vf_f(128.0f), e);
+  t = vldexp3_vf_vf_vi2(vcast_vf_f(1), vneg_vi2_vi2(vrint_vi2_vf(e)));
+  m = vmla_vf_vf_vf_vf(d, t, vsub_vf_vf_vf(t, vcast_vf_f(1)));
+  vfloat2 s = dfmul_vf2_vf2_vf(vcast_vf2_f_f(0.69314718246459960938f, -1.904654323148236017e-09f), e);
+#endif
+
+  x = dfdiv_vf2_vf2_vf2(vcast_vf2_vf_vf(m, vcast_vf_f(0)), dfadd_vf2_vf_vf(vcast_vf_f(2), m));
+  x2 = vmul_vf_vf_vf(x.x, x.x);
+
+  t = vcast_vf_f(+0.3027294874e+0f);
+  t = vmla_vf_vf_vf_vf(t, x2, vcast_vf_f(+0.3996108174e+0f));
+  t = vmla_vf_vf_vf_vf(t, x2, vcast_vf_f(+0.6666694880e+0f));
+  
+  s = dfadd_vf2_vf2_vf2(s, dfscale_vf2_vf2_vf(x, vcast_vf_f(2)));
+  s = dfadd_vf2_vf2_vf(s, vmul_vf_vf_vf(vmul_vf_vf_vf(x2, x.x), t));
+
+  vfloat r = vadd_vf_vf_vf(s.x, s.y);
+  
+  r = vsel_vf_vo_vf_vf(vgt_vo_vf_vf(d, vcast_vf_f(1e+38)), vcast_vf_f(INFINITYf), r);
+  r = vreinterpret_vf_vm(vor_vm_vo32_vm(vgt_vo_vf_vf(vcast_vf_f(-1), d), vreinterpret_vm_vf(r)));
+  r = vsel_vf_vo_vf_vf(veq_vo_vf_vf(d, vcast_vf_f(-1)), vcast_vf_f(-INFINITYf), r);
+  r = vsel_vf_vo_vf_vf(visnegzero_vo_vf(d), vcast_vf_f(-0.0f), r);
+
+  return r;
 }
 
 //

--- a/src/libm/sleefsp.c
+++ b/src/libm/sleefsp.c
@@ -1155,7 +1155,7 @@ EXPORT CONST float xlogf_u1(float d) {
 
   s = dfmul_f2_f2_f(df(0.69314718246459960938f, -1.904654323148236017e-09f), (float)e);
   s = dfadd_f2_f2_f2(s, dfscale_f2_f2_f(x, 2));
-  s = dfadd_f2_f2_f(s, t * x2 * x.x);
+  s = dfadd_f2_f2_f(s, x2 * x.x * t);
 
   float r = s.x + s.y;
   
@@ -1164,7 +1164,6 @@ EXPORT CONST float xlogf_u1(float d) {
   if (d == 0) r = -INFINITYf;
 
   return r;
-
 }
 
 static INLINE CONST Sleef_float2 expk2f(Sleef_float2 d) {
@@ -1404,16 +1403,42 @@ EXPORT CONST float xlog10f(float d) {
   return r;
 }
 
-EXPORT CONST float xlog1pf(float a) {
-  Sleef_float2 d = logk2f(dfadd2_f2_f_f(a, 1));
-  float x = d.x + d.y;
+EXPORT CONST float xlog1pf(float d) {
+  Sleef_float2 x, s;
+  float m, t, x2;
+  int e;
 
-  if (a > 1e+38) x = INFINITYf;
-  if (a < -1) x = NANf;
-  if (a == -1) x = -INFINITYf;
-  if (xisnegzerof(a)) x = -0.0f;
+  float dp1 = d + 1;
+  
+  int o = dp1 < FLT_MIN;
+  if (o) dp1 *= (float)(1LL << 32) * (float)(1LL << 32);
+      
+  e = ilogb2kf(dp1 * (1.0f/0.75f));
 
-  return x;
+  t = ldexp3kf(1, -e);
+  m = mlaf(d, t, t-1);
+
+  if (o) e -= 64;
+  
+  x = dfdiv_f2_f2_f2(df(m, 0), dfadd_f2_f_f(2, m));
+  x2 = x.x * x.x;
+
+  t = +0.3027294874e+0f;
+  t = mlaf(t, x2, +0.3996108174e+0f);
+  t = mlaf(t, x2, +0.6666694880e+0f);
+
+  s = dfmul_f2_f2_f(df(0.69314718246459960938f, -1.904654323148236017e-09f), (float)e);
+  s = dfadd_f2_f2_f2(s, dfscale_f2_f2_f(x, 2));
+  s = dfadd_f2_f2_f(s, x2 * x.x * t);
+
+  float r = s.x + s.y;
+    
+  if (d > 1e+38) r = INFINITYf;
+  if (d < -1) r = NANf;
+  if (d == -1) r = -INFINITYf;
+  if (xisnegzerof(d)) r = -0.0f;
+
+  return r;
 }
 
 EXPORT CONST float xcbrtf(float d) {


### PR DESCRIPTION
Instead of calculating log1p with the generic log subroutine, the new functions calculate it using a new algorithm, which is a modification of generic log.
The ratio of computation time between the old and new log1p is 1.3.
This patch also includes some cosmetic changes and fixes of typos (ENABLE_FMA_DP was wrongly used in sleefsimdsp.c, and now replaced with ENABLE_FMA_SP).