### PR TITLE
[Function attributes] This patch adds const attribute to the exported functions.

### DIFF
--- a/src/libm/dispavx.c.org
+++ b/src/libm/dispavx.c.org
@@ -15,6 +15,12 @@
 #include <x86intrin.h>
 #endif
 
+#if (defined(__GNUC__) || defined(__CLANG__)) && !defined(__INTEL_COMPILER)
+#define CONST const
+#else
+#define CONST
+#endif
+
 #define IMPORT_IS_EXPORT
 #include "sleef.h"
 
@@ -61,76 +67,75 @@ static int cpuSupportsFMA4() {
 #endif
 
 #define DISPATCH_d_d(fptype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static fptype (*pfn)(fptype arg0);					\
-  static fptype dfn(fptype arg0) {					\
-    fptype (*p)(fptype arg0) = funcavx;					\
+  static CONST fptype (*pfn)(fptype arg0);				\
+  static CONST fptype dfn(fptype arg0) {				\
+    fptype CONST (*p)(fptype arg0) = funcavx;				\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static fptype (*pfn)(fptype arg0) = dfn;				\
-  EXPORT fptype funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST fptype (*pfn)(fptype arg0) = dfn;			\
+  EXPORT CONST fptype funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_d_d_d(fptype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static fptype (*pfn)(fptype arg0, fptype arg1);			\
-  static fptype dfn(fptype arg0, fptype arg1) {				\
-    fptype (*p)(fptype arg0, fptype arg1) = funcavx;			\
+  static CONST fptype (*pfn)(fptype arg0, fptype arg1);			\
+  static CONST fptype dfn(fptype arg0, fptype arg1) {			\
+    fptype CONST (*p)(fptype arg0, fptype arg1) = funcavx;		\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1);						\
   }									\
-  static fptype (*pfn)(fptype arg0, fptype arg1) = dfn;			\
-  EXPORT fptype funcName(fptype arg0, fptype arg1) { return (*pfn)(arg0, arg1); }
+  static CONST fptype (*pfn)(fptype arg0, fptype arg1) = dfn;		\
+  EXPORT CONST fptype funcName(fptype arg0, fptype arg1) { return (*pfn)(arg0, arg1); }
 
 #define DISPATCH_d2_d(fptype, fptype2, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static fptype2 (*pfn)(fptype arg0);					\
-  static fptype2 dfn(fptype arg0) {					\
-    fptype2 (*p)(fptype arg0) = funcavx;				\
+  static CONST fptype2 (*pfn)(fptype arg0);				\
+  static CONST fptype2 dfn(fptype arg0) {				\
+    fptype2 CONST (*p)(fptype arg0) = funcavx;				\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static fptype2 (*pfn)(fptype arg0) = dfn;				\
-  EXPORT fptype2 funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST fptype2 (*pfn)(fptype arg0) = dfn;			\
+  EXPORT CONST fptype2 funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_d_d_i(fptype, itype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static fptype (*pfn)(fptype arg0, itype arg1);			\
-  static fptype dfn(fptype arg0, itype arg1) {				\
-    fptype (*p)(fptype arg0, itype arg1) = funcavx;			\
+  static CONST fptype (*pfn)(fptype arg0, itype arg1);			\
+  static CONST fptype dfn(fptype arg0, itype arg1) {			\
+    fptype CONST (*p)(fptype arg0, itype arg1) = funcavx;		\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1);						\
   }									\
-  static fptype (*pfn)(fptype arg0, itype arg1) = dfn;			\
-  EXPORT fptype funcName(fptype arg0, itype arg1) { return (*pfn)(arg0, arg1); }
+  static CONST fptype (*pfn)(fptype arg0, itype arg1) = dfn;		\
+  EXPORT CONST fptype funcName(fptype arg0, itype arg1) { return (*pfn)(arg0, arg1); }
 
 #define DISPATCH_i_d(fptype, itype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static itype (*pfn)(fptype arg0);					\
-  static itype dfn(fptype arg0) {					\
-    itype (*p)(fptype arg0) = funcavx;					\
+  static CONST itype (*pfn)(fptype arg0);				\
+  static CONST itype dfn(fptype arg0) {					\
+    itype CONST (*p)(fptype arg0) = funcavx;				\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static itype (*pfn)(fptype arg0) = dfn;				\
-  EXPORT itype funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST itype (*pfn)(fptype arg0) = dfn;				\
+  EXPORT CONST itype funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_d_d_d_d(fptype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2);		\
-  static fptype dfn(fptype arg0, fptype arg1, fptype arg2) {		\
-    fptype (*p)(fptype arg0, fptype arg1, fptype arg2) = funcavx;	\
+  static CONST fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2);	\
+  static CONST fptype dfn(fptype arg0, fptype arg1, fptype arg2) {	\
+    fptype CONST (*p)(fptype arg0, fptype arg1, fptype arg2) = funcavx;	\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1, arg2);					\
   }									\
-  static fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2) = dfn;	\
-  EXPORT fptype funcName(fptype arg0, fptype arg1, fptype arg2) { return (*pfn)(arg0, arg1, arg2); }
+  static CONST fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2) = dfn; \
+  EXPORT CONST fptype funcName(fptype arg0, fptype arg1, fptype arg2) { return (*pfn)(arg0, arg1, arg2); }
 
 //
-

--- a/src/libm/dispsse.c.org
+++ b/src/libm/dispsse.c.org
@@ -15,6 +15,12 @@
 #include <x86intrin.h>
 #endif
 
+#if (defined(__GNUC__) || defined(__CLANG__)) && !defined(__INTEL_COMPILER)
+#define CONST const
+#else
+#define CONST
+#endif
+
 #define IMPORT_IS_EXPORT
 #include "sleef.h"
 
@@ -56,77 +62,77 @@ static int cpuSupportsFMA() {
 #define SUBST_IF_AVX2(funcavx2)
 #endif
 
-#define DISPATCH_d_d(fptype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2)	\
-  static fptype (*pfn)(fptype arg0);					\
-  static fptype dfn(fptype arg0) {					\
-    fptype (*p)(fptype arg0) = funcsse2;				\
+#define DISPATCH_d_d(fptype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
+  static CONST fptype (*pfn)(fptype arg0);				\
+  static CONST fptype dfn(fptype arg0) {				\
+    fptype CONST (*p)(fptype arg0) = funcsse2;				\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static fptype (*pfn)(fptype arg0) = dfn;				\
-  EXPORT fptype funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST fptype (*pfn)(fptype arg0) = dfn;			\
+  EXPORT CONST fptype funcName(fptype arg0) { return (*pfn)(arg0); }
 
-#define DISPATCH_d_d_d(fptype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2)	\
-  static fptype (*pfn)(fptype arg0, fptype arg1);			\
-  static fptype dfn(fptype arg0, fptype arg1) {				\
-    fptype (*p)(fptype arg0, fptype arg1) = funcsse2;			\
+#define DISPATCH_d_d_d(fptype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
+  static CONST fptype (*pfn)(fptype arg0, fptype arg1);			\
+  static CONST fptype dfn(fptype arg0, fptype arg1) {			\
+    fptype CONST (*p)(fptype arg0, fptype arg1) = funcsse2;		\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1);						\
   }									\
-  static fptype (*pfn)(fptype arg0, fptype arg1) = dfn;			\
-  EXPORT fptype funcName(fptype arg0, fptype arg1) { return (*pfn)(arg0, arg1); }
+  static CONST fptype (*pfn)(fptype arg0, fptype arg1) = dfn;		\
+  EXPORT CONST fptype funcName(fptype arg0, fptype arg1) { return (*pfn)(arg0, arg1); }
 
 #define DISPATCH_d2_d(fptype, fptype2, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static fptype2 (*pfn)(fptype arg0);					\
-  static fptype2 dfn(fptype arg0) {					\
-    fptype2 (*p)(fptype arg0) = funcsse2;				\
+  static CONST fptype2 (*pfn)(fptype arg0);				\
+  static CONST fptype2 dfn(fptype arg0) {				\
+    fptype2 CONST (*p)(fptype arg0) = funcsse2;				\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static fptype2 (*pfn)(fptype arg0) = dfn;				\
-  EXPORT fptype2 funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST fptype2 (*pfn)(fptype arg0) = dfn;			\
+  EXPORT CONST fptype2 funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_d_d_i(fptype, itype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static fptype (*pfn)(fptype arg0, itype arg1);			\
-  static fptype dfn(fptype arg0, itype arg1) {				\
-    fptype (*p)(fptype arg0, itype arg1) = funcsse2;			\
+  static CONST fptype (*pfn)(fptype arg0, itype arg1);			\
+  static CONST fptype dfn(fptype arg0, itype arg1) {			\
+    fptype CONST (*p)(fptype arg0, itype arg1) = funcsse2;		\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1);						\
   }									\
-  static fptype (*pfn)(fptype arg0, itype arg1) = dfn;			\
-  EXPORT fptype funcName(fptype arg0, itype arg1) { return (*pfn)(arg0, arg1); }
+  static CONST fptype (*pfn)(fptype arg0, itype arg1) = dfn;		\
+  EXPORT CONST fptype funcName(fptype arg0, itype arg1) { return (*pfn)(arg0, arg1); }
 
 #define DISPATCH_i_d(fptype, itype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static itype (*pfn)(fptype arg0);					\
-  static itype dfn(fptype arg0) {					\
-    itype (*p)(fptype arg0) = funcsse2;					\
+  static CONST itype (*pfn)(fptype arg0);				\
+  static CONST itype dfn(fptype arg0) {					\
+    itype CONST (*p)(fptype arg0) = funcsse2;				\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static itype (*pfn)(fptype arg0) = dfn;				\
-  EXPORT itype funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST itype (*pfn)(fptype arg0) = dfn;				\
+  EXPORT CONST itype funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_d_d_d_d(fptype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2);		\
-  static fptype dfn(fptype arg0, fptype arg1, fptype arg2) {		\
-    fptype (*p)(fptype arg0, fptype arg1, fptype arg2) = funcsse2;	\
+  static CONST fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2);	\
+  static CONST fptype dfn(fptype arg0, fptype arg1, fptype arg2) {	\
+    fptype CONST (*p)(fptype arg0, fptype arg1, fptype arg2) = funcsse2; \
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1, arg2);					\
   }									\
-  static fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2) = dfn;	\
-  EXPORT fptype funcName(fptype arg0, fptype arg1, fptype arg2) { return (*pfn)(arg0, arg1, arg2); }
+  static CONST fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2) = dfn; \
+  EXPORT CONST fptype funcName(fptype arg0, fptype arg1, fptype arg2) { return (*pfn)(arg0, arg1, arg2); }
 
 //
 

--- a/src/libm/mkrename.c
+++ b/src/libm/mkrename.c
@@ -79,13 +79,13 @@ int main(int argc, char **argv) {
 	switch(funcList[i].funcType) {
 	case 0:
 	  if (funcList[i].ulp >= 0) {
-	    printf("IMPORT %s Sleef_%sd%d_u%02d%s(%s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d_u%02d%s(%s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   funcList[i].ulp, isaname,
 		   vdoublename);
 	  } else {
-	    printf("IMPORT %s Sleef_%sd%d%s%s(%s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d%s%s(%s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   isaub, isaname,
@@ -94,13 +94,13 @@ int main(int argc, char **argv) {
 	  break;
 	case 1:
 	  if (funcList[i].ulp >= 0) {
-	    printf("IMPORT %s Sleef_%sd%d_u%02d%s(%s, %s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d_u%02d%s(%s, %s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   funcList[i].ulp, isaname,
 		   vdoublename, vdoublename);
 	  } else {
-	    printf("IMPORT %s Sleef_%sd%d%s%s(%s, %s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d%s%s(%s, %s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   isaub, isaname,
@@ -110,13 +110,13 @@ int main(int argc, char **argv) {
 	case 2:
 	case 6:
 	  if (funcList[i].ulp >= 0) {
-	    printf("IMPORT Sleef_%s_2 Sleef_%sd%d_u%02d%s(%s);\n",
+	    printf("IMPORT CONST Sleef_%s_2 Sleef_%sd%d_u%02d%s(%s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   funcList[i].ulp, isaname,
 		   vdoublename);
 	  } else {
-	    printf("IMPORT Sleef_%s_2 Sleef_%sd%d%s%s(%s);\n",
+	    printf("IMPORT CONST Sleef_%s_2 Sleef_%sd%d%s%s(%s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   isaub, isaname,
@@ -125,13 +125,13 @@ int main(int argc, char **argv) {
 	  break;
 	case 3:
 	  if (funcList[i].ulp >= 0) {
-	    printf("IMPORT %s Sleef_%sd%d_u%02d%s(%s, %s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d_u%02d%s(%s, %s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   funcList[i].ulp, isaname,
 		   vdoublename, vintname);
 	  } else {
-	    printf("IMPORT %s Sleef_%sd%d%s%s(%s, %s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d%s%s(%s, %s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   isaub, isaname,
@@ -140,13 +140,13 @@ int main(int argc, char **argv) {
 	  break;
 	case 4:
 	  if (funcList[i].ulp >= 0) {
-	    printf("IMPORT %s Sleef_%sd%d_u%02d%s(%s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d_u%02d%s(%s);\n",
 		   vintname,
 		   funcList[i].name, wdp,
 		   funcList[i].ulp, isaname,
 		   vdoublename);
 	  } else {
-	    printf("IMPORT %s Sleef_%sd%d%s%s(%s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d%s%s(%s);\n",
 		   vintname,
 		   funcList[i].name, wdp,
 		   isaub, isaname,
@@ -155,13 +155,13 @@ int main(int argc, char **argv) {
 	  break;
 	case 5:
 	  if (funcList[i].ulp >= 0) {
-	    printf("IMPORT %s Sleef_%sd%d_u%02d%s(%s, %s, %s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d_u%02d%s(%s, %s, %s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   funcList[i].ulp, isaname,
 		   vdoublename, vdoublename, vdoublename);
 	  } else {
-	    printf("IMPORT %s Sleef_%sd%d%s%s(%s, %s, %s);\n",
+	    printf("IMPORT CONST %s Sleef_%sd%d%s%s(%s, %s, %s);\n",
 		   vdoublename,
 		   funcList[i].name, wdp,
 		   isaub, isaname,
@@ -188,13 +188,13 @@ int main(int argc, char **argv) {
       switch(funcList[i].funcType) {
       case 0:
 	if (funcList[i].ulp >= 0) {
-	  printf("IMPORT %s Sleef_%sf%d_u%02d%s(%s);\n",
+	  printf("IMPORT CONST %s Sleef_%sf%d_u%02d%s(%s);\n",
 		 vfloatname,
 		 funcList[i].name, wsp,
 		 funcList[i].ulp, isaname,
 		 vfloatname);
 	} else {
-	  printf("IMPORT %s Sleef_%sf%d%s%s(%s);\n",
+	  printf("IMPORT CONST %s Sleef_%sf%d%s%s(%s);\n",
 		 vfloatname,
 		 funcList[i].name, wsp,
 		 isaub, isaname,
@@ -203,13 +203,13 @@ int main(int argc, char **argv) {
 	break;
       case 1:
 	if (funcList[i].ulp >= 0) {
-	  printf("IMPORT %s Sleef_%sf%d_u%02d%s(%s, %s);\n",
+	  printf("IMPORT CONST %s Sleef_%sf%d_u%02d%s(%s, %s);\n",
 		 vfloatname,
 		 funcList[i].name, wsp,
 		 funcList[i].ulp, isaname,
 		 vfloatname, vfloatname);
 	} else {
-	  printf("IMPORT %s Sleef_%sf%d%s%s(%s, %s);\n",
+	  printf("IMPORT CONST %s Sleef_%sf%d%s%s(%s, %s);\n",
 		 vfloatname,
 		 funcList[i].name, wsp,
 		 isaub, isaname,
@@ -219,13 +219,13 @@ int main(int argc, char **argv) {
       case 2:
       case 6:
 	if (funcList[i].ulp >= 0) {
-	  printf("IMPORT Sleef_%s_2 Sleef_%sf%d_u%02d%s(%s);\n",
+	  printf("IMPORT CONST Sleef_%s_2 Sleef_%sf%d_u%02d%s(%s);\n",
 		 vfloatname,
 		 funcList[i].name, wsp,
 		 funcList[i].ulp, isaname,
 		 vfloatname);
 	} else {
-	  printf("IMPORT Sleef_%s_2 Sleef_%sf%d%s%s(%s);\n",
+	  printf("IMPORT CONST Sleef_%s_2 Sleef_%sf%d%s%s(%s);\n",
 		 vfloatname,
 		 funcList[i].name, wsp,
 		 isaub, isaname,
@@ -234,14 +234,14 @@ int main(int argc, char **argv) {
 	break;
 	/*
 	  case 3:
-	  printf("IMPORT %s Sleef_%sf%d_%s(%s, vint2_%s);\n",
+	  printf("IMPORT CONST %s Sleef_%sf%d_%s(%s, vint2_%s);\n",
 	  vfloatname,
 	  funcList[i].name, wsp,
 	  isaname,
 	  vfloatname, isaname);
 	  break;
 	  case 4:
-	  printf("IMPORT vint2_%s Sleef_%sf%d_%s(%s);\n",
+	  printf("IMPORT CONST vint2_%s Sleef_%sf%d_%s(%s);\n",
 	  isaname,
 	  funcList[i].name, wsp,
 	  isaname,
@@ -250,13 +250,13 @@ int main(int argc, char **argv) {
 	*/
       case 5:
 	if (funcList[i].ulp >= 0) {
-	  printf("IMPORT %s Sleef_%sf%d_u%02d%s(%s, %s, %s);\n",
+	  printf("IMPORT CONST %s Sleef_%sf%d_u%02d%s(%s, %s, %s);\n",
 		 vfloatname,
 		 funcList[i].name, wsp,
 		 funcList[i].ulp, isaname,
 		 vfloatname, vfloatname, vfloatname);
 	} else {
-	  printf("IMPORT %s Sleef_%sf%d%s%s(%s, %s, %s);\n",
+	  printf("IMPORT CONST %s Sleef_%sf%d%s%s(%s, %s, %s);\n",
 		 vfloatname,
 		 funcList[i].name, wsp,
 		 isaub, isaname,


### PR DESCRIPTION
Const attribute was missing in sleef.h.
It seems that this patch does not affect the gnuabi version of the functions, but please check.