### PR TITLE
Use sleef.lib on Windows. Export functions with extern "C"

### DIFF
--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -6,7 +6,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 # sleef.h
 # --------------------------------------------------------------------
 # File generated for the headers
-set(SLEEF_ORG_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/sleeflibm.h.org)
+set(SLEEF_ORG_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/sleeflibm_header.h.org)
+set(SLEEF_ORG_FOOTER ${CMAKE_CURRENT_SOURCE_DIR}/sleeflibm_footer.h.org)
 set(SLEEF_INCLUDE_HEADER ${CMAKE_BINARY_DIR}/include/sleef.h)
 
 set(SLEEF_HEADER_COMMANDS "")
@@ -16,18 +17,18 @@ foreach(SIMD ${SLEEF_HEADER_LIST})
   list(APPEND SLEEF_HEADER_COMMANDS COMMAND ${TARGET_MKRENAME} ${HEADER_PARAMS_${SIMD}} >> ${SLEEF_INCLUDE_HEADER})
 endforeach()
 
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/sleef_footer.h "#undef IMPORT\n#endif\n")
 if(MSVC)
-  string(REPLACE "/" "\\" sleef_footer_input_file "${CMAKE_CURRENT_BINARY_DIR}/sleef_footer.h")
+  string(REPLACE "/" "\\" sleef_footer_input_file "${SLEEF_ORG_FOOTER}")
   list(APPEND SLEEF_HEADER_COMMANDS COMMAND type ${sleef_footer_input_file} >> ${SLEEF_INCLUDE_HEADER})
 else()
-  list(APPEND SLEEF_HEADER_COMMANDS COMMAND cat ${CMAKE_CURRENT_BINARY_DIR}/sleef_footer.h >> ${SLEEF_INCLUDE_HEADER})
+  list(APPEND SLEEF_HEADER_COMMANDS COMMAND cat ${SLEEF_ORG_FOOTER} >> ${SLEEF_INCLUDE_HEADER})
 endif()
 
 add_custom_command(OUTPUT ${SLEEF_INCLUDE_HEADER}
   ${SLEEF_HEADER_COMMANDS}
   DEPENDS 
     ${SLEEF_ORG_HEADER}  
+    ${SLEEF_ORG_FOOTER}
     ${TARGET_MKRENAME}
 )
 

--- a/src/libm/Makefile
+++ b/src/libm/Makefile
@@ -78,7 +78,7 @@ ifeq ($(X86ARCH),1)
 sleef.h : mkrename
 	$(FLOCK) mkrename.lock -c 'echo Acquiring lock for mkrename'
 	$(eval RND := $(shell bash -c 'echo $$(( RANDOM ))' ))
-	cp sleeflibm.h.org sleef.h.$(RND)
+	cp sleeflibm_header.h.org sleef.h.$(RND)
 	./mkrename 2 4 __m128d __m128 __m128i __m128i __SSE2__ >> sleef.h.$(RND)
 	./mkrename 2 4 __m128d __m128 __m128i __m128i __SSE2__ sse2 >> sleef.h.$(RND)
 	./mkrename 2 4 __m128d __m128 __m128i __m128i __SSE2__ sse4 >> sleef.h.$(RND)
@@ -88,8 +88,7 @@ sleef.h : mkrename
 	./mkrename 4 8 __m256d __m256 __m128i 'struct { __m128i x, y; }' __AVX__ fma4 >> sleef.h.$(RND)
 	./mkrename 4 8 __m256d __m256 __m128i __m256i __AVX__ avx2 >> sleef.h.$(RND)
 	./mkrename 8 16 __m512d __m512 __m256i __m512i __AVX512F__ avx512f >> sleef.h.$(RND)
-	echo '#undef IMPORT' >> sleef.h.$(RND)
-	echo '#endif' >> sleef.h.$(RND)
+	cat sleeflibm_footer.h.org >> sleef.h.$(RND)
 	mv sleef.h.$(RND) sleef.h
 	cp sleef.h ../../include/sleef.h.$(RND)
 	mv ../../include/sleef.h.$(RND) ../../include/sleef.h
@@ -97,10 +96,9 @@ else ifeq ($(ARCH), arm)
 sleef.h : mkrename
 	$(FLOCK) mkrename.lock -c 'echo Acquiring lock for mkrename'
 	$(eval RND := $(shell bash -c 'echo $$(( RANDOM ))' ))
-	cp sleeflibm.h.org sleef.h.$(RND)
+	cp sleeflibm_header.h.org sleef.h.$(RND)
 	./mkrename 2 4 - float32x4_t int32x4_t int32x4_t __ARM_NEON__ neon >> sleef.h.$(RND)
-	echo '#undef IMPORT' >> sleef.h.$(RND)
-	echo '#endif' >> sleef.h.$(RND)
+	cat sleeflibm_footer.h.org >> sleef.h.$(RND)
 	mv sleef.h.$(RND) sleef.h
 	cp sleef.h ../../include/sleef.h.$(RND)
 	mv ../../include/sleef.h.$(RND) ../../include/sleef.h
@@ -108,10 +106,9 @@ else ifeq ($(ARCH), aarch64)
 sleef.h : mkrename
 	$(FLOCK) mkrename.lock -c 'echo Acquiring lock for mkrename'
 	$(eval RND := $(shell bash -c 'echo $$(( RANDOM ))' ))
-	cp sleeflibm.h.org sleef.h.$(RND)
+	cp sleeflibm_header.h.org sleef.h.$(RND)
 	./mkrename 2 4 float64x2_t float32x4_t int32x2_t int32x4_t __ARM_NEON advsimd >> sleef.h.$(RND)
-	echo '#undef IMPORT' >> sleef.h.$(RND)
-	echo '#endif' >> sleef.h.$(RND)
+	cat sleeflibm_footer.h.org >> sleef.h.$(RND)
 	mv sleef.h.$(RND) sleef.h
 	cp sleef.h ../../include/sleef.h.$(RND)
 	mv ../../include/sleef.h.$(RND) ../../include/sleef.h
@@ -119,9 +116,8 @@ else
 sleef.h :
 	$(FLOCK) mkrename.lock -c 'echo Acquiring lock for mkrename'
 	$(eval RND := $(shell bash -c 'echo $$(( RANDOM ))' ))
-	cp sleeflibm.h.org sleef.h.$(RND)
-	echo '#undef IMPORT' >> sleef.h.$(RND)
-	echo '#endif' >> sleef.h.$(RND)
+	cp sleeflibm_header.h.org sleef.h.$(RND)
+	cat sleeflibm_footer.h.org >> sleef.h.$(RND)
 	mv sleef.h.$(RND) sleef.h
 	cp sleef.h ../../include/sleef.h.$(RND)
 	mv ../../include/sleef.h.$(RND) ../../include/sleef.h

--- a/src/libm/Makefile.vc
+++ b/src/libm/Makefile.vc
@@ -27,7 +27,7 @@ OBJ2.txt : $(OBJ2)
 	for i in `echo $(OBJ2)`; do ../script/abspath.sh $(@D) $$i >> OBJ2.txt; done
 
 sleef.h : mkrename.exe
-	cp sleeflibm.h.org sleef.h
+	cp sleeflibm_header.h.org sleef.h
 	./mkrename.exe 2 4 __m128d __m128 __m128i __m128i __SSE2__ >> sleef.h
 	./mkrename.exe 2 4 __m128d __m128 __m128i __m128i __SSE2__ sse2 >> sleef.h
 	./mkrename.exe 2 4 __m128d __m128 __m128i __m128i __SSE2__ sse4 >> sleef.h
@@ -35,8 +35,7 @@ sleef.h : mkrename.exe
 	./mkrename.exe 4 8 __m256d __m256 __m128i 'struct { __m128i x, y; }' __AVX__ >> sleef.h
 	./mkrename.exe 4 8 __m256d __m256 __m128i 'struct { __m128i x, y; }' __AVX__ avx >> sleef.h
 	./mkrename.exe 4 8 __m256d __m256 __m128i __m256i __AVX__ avx2 >> sleef.h
-	echo '#undef IMPORT' >> sleef.h
-	echo '#endif' >> sleef.h
+	type sleeflibm_footer.h.org >> sleef.h
 	cp sleef.h ../../include
 
 #

--- a/src/libm/sleeflibm_footer.h.org
+++ b/src/libm/sleeflibm_footer.h.org
@@ -1,0 +1,6 @@
+#undef IMPORT
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/libm/sleeflibm_header.h.org
+++ b/src/libm/sleeflibm_header.h.org
@@ -21,7 +21,7 @@
 #else
 #define IMPORT __declspec(dllimport)
 #if (defined(_MSC_VER))
-#pragma comment(lib,"libsleef.lib")
+#pragma comment(lib,"sleef.lib")
 #endif
 #endif
 #else // #if defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__) || defined(_MSC_VER)
@@ -79,6 +79,11 @@ typedef __float128 Sleef_quad;
 typedef struct {
   __float128 x, y;
 } Sleef_quad2;
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
 #endif
 
 IMPORT CONST double Sleef_sin_u35(double);


### PR DESCRIPTION
This is a fix for Windows for importing correctly `sleef.lib` and exporting functions using extern "C" so that they are correctly exported in the DLL (without C++ mangling names)

I have updated the way the headers are concatenated with now a `sleeflibm_header.h.org` and `sleeflibm_footer.h.org`
