### PR TITLE
* add single- and double-precision vmaxnum()/vminnum() adhering to IE…

### DIFF
--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -28,6 +28,16 @@
 
 #define ISANAME "AArch64 AdvSIMD"
 
+#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
+
+#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
+
 // Mask definition
 typedef uint32x4_t vmask;
 typedef uint32x4_t vopmask;
@@ -149,6 +159,14 @@ static INLINE vfloat vmax_vf_vf_vf(vfloat x, vfloat y) {
 }
 static INLINE vfloat vmin_vf_vf_vf(vfloat x, vfloat y) {
   return vminq_f32(x, y);
+}
+
+// max number, min number
+static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) {
+  return vmaxnmq_f32(x, y);
+}
+static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) {
+  return vminnmq_f32(x, y);
 }
 
 // Comparisons
@@ -288,6 +306,14 @@ static INLINE vdouble vmax_vd_vd_vd(vdouble x, vdouble y) {
 }
 static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) {
   return vminq_f64(x, y);
+}
+
+// max number, min number
+static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) {
+  return vmaxnmq_f64(x, y);
+}
+static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) {
+  return vminnmq_f64(x, y);
 }
 
 // Multiply accumulate: z = z + x * y

--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -29,6 +29,16 @@
 
 #define FULL_FP_ROUNDING
 
+#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
+
+#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
+
 #if defined(_MSC_VER)
 #include <intrin.h>
 #else
@@ -283,6 +293,9 @@ static INLINE vopmask visnan_vo_vd(vdouble d) {
   return vreinterpret_vm_vd(_mm256_cmp_pd(d, d, _CMP_NEQ_UQ));
 }
 
+static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmax_vd_vd_vd(x, y)); }
+static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmin_vd_vd_vd(x, y)); }
+
 static INLINE vdouble vload_vd_p(const double *ptr) { return _mm256_load_pd(ptr); }
 static INLINE vdouble vloadu_vd_p(const double *ptr) { return _mm256_loadu_pd(ptr); }
 
@@ -467,6 +480,9 @@ static INLINE vopmask visinf_vo_vf(vfloat d) { return veq_vo_vf_vf(vabs_vf_vf(d)
 static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(INFINITYf)); }
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
+
+static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmax_vf_vf_vf(x, y)); }
+static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmin_vf_vf_vf(x, y)); }
 
 //
 

--- a/src/arch/helperavx2.h
+++ b/src/arch/helperavx2.h
@@ -26,6 +26,16 @@
 #define FULL_FP_ROUNDING
 #define SPLIT_KERNEL
 
+#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
+
+#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
+
 #if defined(_MSC_VER)
 #include <intrin.h>
 #else
@@ -239,6 +249,9 @@ static INLINE vopmask visnan_vo_vd(vdouble d) {
   return vreinterpret_vm_vd(_mm256_cmp_pd(d, d, _CMP_NEQ_UQ));
 }
 
+static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmax_vd_vd_vd(x, y)); }
+static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmin_vd_vd_vd(x, y)); }
+
 #if defined(_MSC_VER)
 // This function is needed when debugging on MSVC.
 static INLINE double vcast_d_vd(vdouble v) {
@@ -342,6 +355,9 @@ static INLINE vopmask visinf_vo_vf(vfloat d) { return veq_vo_vf_vf(vabs_vf_vf(d)
 static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(INFINITYf)); }
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
+
+static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmax_vf_vf_vf(x, y)); }
+static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmin_vf_vf_vf(x, y)); }
 
 #ifdef _MSC_VER
 // This function is needed when debugging on MSVC.

--- a/src/arch/helperavx2_128.h
+++ b/src/arch/helperavx2_128.h
@@ -26,6 +26,16 @@
 #define FULL_FP_ROUNDING
 #define SPLIT_KERNEL
 
+#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
+
+#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
+
 #if defined(_MSC_VER)
 #include <intrin.h>
 #else
@@ -221,6 +231,9 @@ static INLINE vopmask visnan_vo_vd(vdouble d) {
   return vreinterpret_vm_vd(_mm_cmp_pd(d, d, _CMP_NEQ_UQ));
 }
 
+static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmax_vd_vd_vd(x, y)); }
+static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmin_vd_vd_vd(x, y)); }
+
 static INLINE vdouble vload_vd_p(const double *ptr) { return _mm_load_pd(ptr); }
 static INLINE vdouble vloadu_vd_p(const double *ptr) { return _mm_loadu_pd(ptr); }
 
@@ -322,6 +335,9 @@ static INLINE vopmask visinf_vo_vf(vfloat d) { return veq_vo_vf_vf(vabs_vf_vf(d)
 static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(INFINITYf)); }
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
+
+static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmax_vf_vf_vf(x, y)); }
+static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmin_vf_vf_vf(x, y)); }
 
 static INLINE vfloat vload_vf_p(const float *ptr) { return _mm_load_ps(ptr); }
 static INLINE vfloat vloadu_vf_p(const float *ptr) { return _mm_loadu_ps(ptr); }

--- a/src/arch/helpersse2.h
+++ b/src/arch/helpersse2.h
@@ -33,6 +33,16 @@
 #define LOG2VECTLENSP (LOG2VECTLENDP+1)
 #define VECTLENSP (1 << LOG2VECTLENSP)
 
+#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
+
+#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+#endif
+#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
+
 #if defined(_MSC_VER)
 #include <intrin.h>
 #else
@@ -257,6 +267,9 @@ static INLINE vopmask visnan_vo_vd(vdouble d) {
   return vreinterpret_vm_vd(_mm_cmpneq_pd(d, d));
 }
 
+static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmax_vd_vd_vd(x, y)); }
+static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmin_vd_vd_vd(x, y)); }
+
 //
 
 static INLINE vdouble vload_vd_p(const double *ptr) { return _mm_load_pd(ptr); }
@@ -364,6 +377,9 @@ static INLINE vopmask visinf_vo_vf(vfloat d) { return veq_vo_vf_vf(vabs_vf_vf(d)
 static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(INFINITYf)); }
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
+
+static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmax_vf_vf_vf(x, y)); }
+static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmin_vf_vf_vf(x, y)); }
 
 static INLINE vfloat vload_vf_p(const float *ptr) { return _mm_load_ps(ptr); }
 static INLINE vfloat vloadu_vf_p(const float *ptr) { return _mm_loadu_ps(ptr); }

--- a/src/libm/dd.h
+++ b/src/libm/dd.h
@@ -396,10 +396,10 @@ static INLINE CONST vdouble2 ddsqrt_vd2_vd(vdouble d) {
 
 #ifndef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
 static INLINE CONST vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) {
-  return vmax_vd_vd_vd(vsel_vd_vo_vd_vd(visnan_vo_vd(x), y, x), vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, y));
+  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(x, y), x, y));
 }
 
 static INLINE CONST vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) {
-  return vmin_vd_vd_vd(vsel_vd_vo_vd_vd(visnan_vo_vd(x), y, x), vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, y));
+  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(y, x), x, y));
 }
 #endif

--- a/src/libm/dd.h
+++ b/src/libm/dd.h
@@ -393,3 +393,13 @@ static INLINE CONST vdouble2 ddsqrt_vd2_vd(vdouble d) {
   vdouble t = vsqrt_vd_vd(d);
   return ddscale_vd2_vd2_vd(ddmul_vd2_vd2_vd2(ddadd2_vd2_vd_vd2(d, ddmul_vd2_vd_vd(t, t)), ddrec_vd2_vd(t)), vcast_vd_d(0.5));
 }
+
+#ifndef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
+static INLINE CONST vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) {
+  return vmax_vd_vd_vd(vsel_vd_vo_vd_vd(visnan_vo_vd(x), y, x), vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, y));
+}
+
+static INLINE CONST vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) {
+  return vmin_vd_vd_vd(vsel_vd_vo_vd_vd(visnan_vo_vd(x), y, x), vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, y));
+}
+#endif

--- a/src/libm/df.h
+++ b/src/libm/df.h
@@ -464,3 +464,13 @@ static INLINE CONST vfloat2 dfsqrt_vf2_vf(vfloat d) {
   vfloat t = vsqrt_vf_vf(d);
   return dfscale_vf2_vf2_vf(dfmul_vf2_vf2_vf2(dfadd2_vf2_vf_vf2(d, dfmul_vf2_vf_vf(t, t)), dfrec_vf2_vf(t)), vcast_vf_f(0.5f));
 }
+
+#ifndef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
+static INLINE CONST vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) {
+  return vmax_vf_vf_vf(vsel_vf_vo_vf_vf(visnan_vo_vf(x), y, x), vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, y));
+}
+
+static INLINE CONST vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) {
+  return vmin_vf_vf_vf(vsel_vf_vo_vf_vf(visnan_vo_vf(x), y, x), vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, y));
+}
+#endif

--- a/src/libm/df.h
+++ b/src/libm/df.h
@@ -467,10 +467,10 @@ static INLINE CONST vfloat2 dfsqrt_vf2_vf(vfloat d) {
 
 #ifndef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
 static INLINE CONST vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) {
-  return vmax_vf_vf_vf(vsel_vf_vo_vf_vf(visnan_vo_vf(x), y, x), vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, y));
+  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(x, y), x, y));
 }
 
 static INLINE CONST vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) {
-  return vmin_vf_vf_vf(vsel_vf_vo_vf_vf(visnan_vo_vf(x), y, x), vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, y));
+  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(y, x), x, y));
 }
 #endif

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -2202,13 +2202,9 @@ EXPORT CONST vdouble xfabs(vdouble x) { return vabs_vd_vd(x); }
 
 EXPORT CONST vdouble xcopysign(vdouble x, vdouble y) { return vcopysign_vd_vd_vd(x, y); }
 
-EXPORT CONST vdouble xfmax(vdouble x, vdouble y) {
-  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(x, y), x, y));
-}
+EXPORT CONST vdouble xfmax(vdouble x, vdouble y) { return vmaxnum_vd_vd_vd(x, y); }
 
-EXPORT CONST vdouble xfmin(vdouble x, vdouble y) {
-  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(y, x), x, y));
-}
+EXPORT CONST vdouble xfmin(vdouble x, vdouble y) { return vminnum_vd_vd_vd(x, y); }
 
 EXPORT CONST vdouble xfdim(vdouble x, vdouble y) {
   vdouble ret = vsub_vd_vd_vd(x, y);

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -1677,13 +1677,9 @@ EXPORT CONST vfloat xfabsf(vfloat x) { return vabs_vf_vf(x); }
 
 EXPORT CONST vfloat xcopysignf(vfloat x, vfloat y) { return vcopysign_vf_vf_vf(x, y); }
 
-EXPORT CONST vfloat xfmaxf(vfloat x, vfloat y) {
-  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(x, y), x, y));
-}
+EXPORT CONST vfloat xfmaxf(vfloat x, vfloat y) { return vmaxnum_vf_vf_vf(x, y); }
 
-EXPORT CONST vfloat xfminf(vfloat x, vfloat y) {
-  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(y, x), x, y));
-}
+EXPORT CONST vfloat xfminf(vfloat x, vfloat y) { return vminnum_vf_vf_vf(x, y); }
 
 EXPORT CONST vfloat xfdimf(vfloat x, vfloat y) {
   vfloat ret = vsub_vf_vf_vf(x, y);


### PR DESCRIPTION
…EE-754-2008 maxNum()/minNum() semantics

* make xfmaxf(), xfminf(), xfmax() and xfmin() use vmaxnum() and vminnum()
* add vminnum()/vmaxnum() capabilities to arch SSE2, SSE3, SSE4.1, AVX, AVX2 and AArch64