### PR TITLE
[travis] Remove Makefile compilation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then eval "${MATRIX_EVAL}"                         ; fi
 
 before_script:
-  - if [[ "$CC" == "gcc" ]] &&  [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make libsleef; fi
-  - if [[ "$CC" == "gcc" ]] &&  [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test-dft; fi
-  - git clean -f
   - mkdir sleef.build
   - cd sleef.build
   - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 ..


### PR DESCRIPTION
After the merge of https://github.com/shibatch/sleef/pull/112,
`libdft` gets compiled and tested via cmake, so there is no need to
have this Makefile compilation of `libdft`.