### PR TITLE
[cmake] Move functions in common.c to libsleef

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TARGET_MKDISP "mkdisp")
 # Generates static library common
 # Defined in src/common/CMakeLists.txt via command add_library
 set(TARGET_LIBCOMMON_STATIC "common")
+set(TARGET_LIBARRAYMAP_STATIC "arraymap")
 
 # Generates object file (shared library) `libsleefdft`
 # Defined in src/dft/CMakeLists.txt via command add_library

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -10,12 +10,7 @@ set(COMMON_TARGET_PROPERTIES
 add_library(${TARGET_LIBCOMMON_STATIC} STATIC common.c)
 set_target_properties(${TARGET_LIBCOMMON_STATIC} PROPERTIES ${COMMON_TARGET_PROPERTIES})
 
-# Target common.o
+# Target TARGET_LIBARRAYMAP_STATIC
 
-add_library(common_obj OBJECT common.c)
-set_target_properties(common_obj PROPERTIES ${COMMON_TARGET_PROPERTIES})
-
-# Target arraymap.o
-
-add_library(arraymap_obj OBJECT arraymap.c)
-set_target_properties(arraymap_obj PROPERTIES ${COMMON_TARGET_PROPERTIES})
+add_library(${TARGET_LIBARRAYMAP_STATIC} STATIC arraymap.c)
+set_target_properties(${TARGET_LIBARRAYMAP_STATIC} PROPERTIES ${COMMON_TARGET_PROPERTIES})

--- a/src/dft/CMakeLists.txt
+++ b/src/dft/CMakeLists.txt
@@ -254,8 +254,8 @@ endforeach()
 
 # Target libdft
 
-add_library(${TARGET_LIBDFT} SHARED $<TARGET_OBJECTS:dftcommon_obj> $<TARGET_OBJECTS:common_obj> $<TARGET_OBJECTS:arraymap_obj>)
-target_link_libraries(${TARGET_LIBDFT} ${TARGET_LIBSLEEF})
+add_library(${TARGET_LIBDFT} SHARED $<TARGET_OBJECTS:dftcommon_obj>)
+target_link_libraries(${TARGET_LIBDFT} ${TARGET_LIBSLEEF} ${TARGET_LIBARRAYMAP_STATIC})
 
 foreach(T ${LIST_SUPPORTED_FPTYPE})
   list(GET LISTSHORTTYPENAME ${T} ST)                       # ST is "dp", for example

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -72,6 +72,25 @@ foreach(SIMD ${SLEEF_SUPPORTED_EXTENSIONS})
   test_extension(${SIMD})
 endforeach()
 
+# iutdsp128
+
+add_executable(iutdsp128 ${IUT_SRC})
+target_compile_definitions(iutdsp128 PRIVATE ENABLE_DSP128=1)
+target_link_libraries(iutdsp128 ${TARGET_LIBSLEEF})
+add_dependencies(iutdsp128 ${TARGET_HEADERS} ${TARGET_LIBSLEEF})
+add_test(NAME iutdsp128 COMMAND ${TARGET_TESTER} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/iutdsp128)
+list(APPEND IUT_LIST iutdsp128)
+
+# iutdsp256
+
+add_executable(iutdsp256 ${IUT_SRC})
+target_compile_definitions(iutdsp256 PRIVATE ENABLE_DSP256=1)
+target_compile_options(iutdsp256 PRIVATE ${FLAGS_ENABLE_AVX})
+target_link_libraries(iutdsp256 ${TARGET_LIBSLEEF})
+add_dependencies(iutdsp256 ${TARGET_HEADERS} ${TARGET_LIBSLEEF})
+add_test(NAME iutdsp256 COMMAND ${TARGET_TESTER} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/iutdsp256)
+list(APPEND IUT_LIST iutdsp256)
+
 # Build tester2 scalar
 foreach(P dp sp)
   set(T "tester2${P}")

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -72,24 +72,24 @@ foreach(SIMD ${SLEEF_SUPPORTED_EXTENSIONS})
   test_extension(${SIMD})
 endforeach()
 
-# iutdsp128
+if (SLEEF_ARCH_X86)
+  # iutdsp128
+  add_executable(iutdsp128 ${IUT_SRC})
+  target_compile_definitions(iutdsp128 PRIVATE ENABLE_DSP128=1)
+  target_link_libraries(iutdsp128 ${TARGET_LIBSLEEF})
+  add_dependencies(iutdsp128 ${TARGET_HEADERS} ${TARGET_LIBSLEEF})
+  add_test(NAME iutdsp128 COMMAND ${TARGET_TESTER} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/iutdsp128)
+  list(APPEND IUT_LIST iutdsp128)
 
-add_executable(iutdsp128 ${IUT_SRC})
-target_compile_definitions(iutdsp128 PRIVATE ENABLE_DSP128=1)
-target_link_libraries(iutdsp128 ${TARGET_LIBSLEEF})
-add_dependencies(iutdsp128 ${TARGET_HEADERS} ${TARGET_LIBSLEEF})
-add_test(NAME iutdsp128 COMMAND ${TARGET_TESTER} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/iutdsp128)
-list(APPEND IUT_LIST iutdsp128)
-
-# iutdsp256
-
-add_executable(iutdsp256 ${IUT_SRC})
-target_compile_definitions(iutdsp256 PRIVATE ENABLE_DSP256=1)
-target_compile_options(iutdsp256 PRIVATE ${FLAGS_ENABLE_AVX})
-target_link_libraries(iutdsp256 ${TARGET_LIBSLEEF})
-add_dependencies(iutdsp256 ${TARGET_HEADERS} ${TARGET_LIBSLEEF})
-add_test(NAME iutdsp256 COMMAND ${TARGET_TESTER} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/iutdsp256)
-list(APPEND IUT_LIST iutdsp256)
+  # iutdsp256
+  add_executable(iutdsp256 ${IUT_SRC})
+  target_compile_definitions(iutdsp256 PRIVATE ENABLE_DSP256=1)
+  target_compile_options(iutdsp256 PRIVATE ${FLAGS_ENABLE_AVX})
+  target_link_libraries(iutdsp256 ${TARGET_LIBSLEEF})
+  add_dependencies(iutdsp256 ${TARGET_HEADERS} ${TARGET_LIBSLEEF})
+  add_test(NAME iutdsp256 COMMAND ${TARGET_TESTER} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/iutdsp256)
+  list(APPEND IUT_LIST iutdsp256)
+endif(SLEEF_ARCH_X86)
 
 # Build tester2 scalar
 foreach(P dp sp)

--- a/src/libm-tester/tester2simddp.c
+++ b/src/libm-tester/tester2simddp.c
@@ -94,7 +94,9 @@ typedef Sleef___m512_2 vfloat2;
 #ifdef ENABLE_ADVSIMD
 #define CONFIG 1
 #include "helperadvsimd.h"
-#include "norename.h"
+#include "renameadvsimd.h"
+typedef Sleef_float64x2_t_2 vdouble2;
+typedef Sleef_float32x4_t_2 vfloat2;
 #endif
 
 #define DENORMAL_DBL_MIN (4.9406564584124654418e-324)

--- a/src/libm-tester/tester2simdsp.c
+++ b/src/libm-tester/tester2simdsp.c
@@ -95,7 +95,9 @@ typedef Sleef___m512_2 vfloat2;
 #ifdef ENABLE_ADVSIMD
 #define CONFIG 1
 #include "helperadvsimd.h"
-#include "norename.h"
+#include "renameadvsimd.h"
+typedef Sleef_float64x2_t_2 vdouble2;
+typedef Sleef_float32x4_t_2 vfloat2;
 #endif
 
 #define DENORMAL_FLT_MIN (1.4012984643248170709e-45f)

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -181,6 +181,63 @@ endif(LIBM)
 
 target_link_libraries(${TARGET_LIBSLEEF} ${TARGET_LIBCOMMON_STATIC})
 
+# --------------------------------------------------------------------
+
+# Target dispsse.c
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c
+  COMMENT "Generating dispsse.c"
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/dispsse.c.org ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c
+  COMMAND ${TARGET_MKDISP} 2 4 __m128d __m128 __m128i sse2 sse4 avx2128 >> ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c
+  DEPENDS ${TARGET_MKDISP}
+  )
+add_custom_target(dispsse.c_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c)
+
+# Target renamedsp128.h
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp128.h
+  COMMENT "Generating renamedsp128.h"
+  COMMAND ${TARGET_MKRENAME} 2 4 > ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp128.h
+  DEPENDS ${TARGET_MKRENAME}
+  )
+add_custom_target(renamedsp128.h_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp128.h)
+
+# Target dispavx.c
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c
+  COMMENT "Generating dispavx.c"
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/dispavx.c.org ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c
+  COMMAND ${TARGET_MKDISP} 4 8 __m256d __m256 __m128i avx fma4 avx2 >> ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c
+  DEPENDS ${TARGET_MKDISP}
+  )
+add_custom_target(dispavx.c_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c)
+
+# Target renamedsp256.h
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp256.h
+  COMMENT "Generating renamedsp256.h"
+  COMMAND ${TARGET_MKRENAME} 4 8 > ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp256.h
+  DEPENDS ${TARGET_MKRENAME}
+  )
+add_custom_target(renamedsp256.h_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp256.h)
+
+# Target dispsse_obj
+
+add_library(dispsse_obj OBJECT dispsse.c ${SLEEF_INCLUDE_HEADER})
+set_target_properties(dispsse_obj PROPERTIES ${COMMON_TARGET_PROPERTIES})
+target_include_directories(dispsse_obj PRIVATE ${CMAKE_BINARY_DIR}/include)
+add_dependencies(dispsse_obj dispsse.c_generated renamedsp128.h_generated ${TARGET_HEADERS})
+target_sources(${TARGET_LIBSLEEF} PRIVATE $<TARGET_OBJECTS:dispsse_obj>)
+
+# Target dispavx_obj
+
+add_library(dispavx_obj OBJECT dispavx.c ${SLEEF_INCLUDE_HEADER})
+target_compile_options(dispavx_obj PRIVATE ${FLAGS_ENABLE_AVX})
+set_target_properties(dispavx_obj PROPERTIES ${COMMON_TARGET_PROPERTIES})
+target_include_directories(dispavx_obj PRIVATE ${CMAKE_BINARY_DIR}/include)
+add_dependencies(dispavx_obj dispavx.c_generated renamedsp256.h_generated ${TARGET_HEADERS})
+target_sources(${TARGET_LIBSLEEF} PRIVATE $<TARGET_OBJECTS:dispavx_obj>)
+
 
 # --------------------------------------------------------------------
 # TARGET_LIBSLEEFGNUABI

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -179,6 +179,8 @@ if(LIBM)
   target_link_libraries(${TARGET_LIBSLEEF} ${LIBM})
 endif(LIBM)
 
+target_link_libraries(${TARGET_LIBSLEEF} ${TARGET_LIBCOMMON_STATIC})
+
 
 # --------------------------------------------------------------------
 # TARGET_LIBSLEEFGNUABI

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -183,61 +183,62 @@ target_link_libraries(${TARGET_LIBSLEEF} ${TARGET_LIBCOMMON_STATIC})
 
 # --------------------------------------------------------------------
 
-# Target dispsse.c
+if (SLEEF_ARCH_X86)
+  # Target dispsse.c
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c
-  COMMENT "Generating dispsse.c"
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/dispsse.c.org ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c
-  COMMAND ${TARGET_MKDISP} 2 4 __m128d __m128 __m128i sse2 sse4 avx2128 >> ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c
-  DEPENDS ${TARGET_MKDISP}
-  )
-add_custom_target(dispsse.c_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c)
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c
+    COMMENT "Generating dispsse.c"
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/dispsse.c.org ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c
+    COMMAND ${TARGET_MKDISP} 2 4 __m128d __m128 __m128i sse2 sse4 avx2128 >> ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c
+    DEPENDS ${TARGET_MKDISP}
+    )
+  add_custom_target(dispsse.c_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/dispsse.c)
 
-# Target renamedsp128.h
+  # Target renamedsp128.h
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp128.h
-  COMMENT "Generating renamedsp128.h"
-  COMMAND ${TARGET_MKRENAME} 2 4 > ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp128.h
-  DEPENDS ${TARGET_MKRENAME}
-  )
-add_custom_target(renamedsp128.h_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp128.h)
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp128.h
+    COMMENT "Generating renamedsp128.h"
+    COMMAND ${TARGET_MKRENAME} 2 4 > ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp128.h
+    DEPENDS ${TARGET_MKRENAME}
+    )
+  add_custom_target(renamedsp128.h_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp128.h)
 
-# Target dispavx.c
+  # Target dispavx.c
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c
-  COMMENT "Generating dispavx.c"
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/dispavx.c.org ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c
-  COMMAND ${TARGET_MKDISP} 4 8 __m256d __m256 __m128i avx fma4 avx2 >> ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c
-  DEPENDS ${TARGET_MKDISP}
-  )
-add_custom_target(dispavx.c_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c)
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c
+    COMMENT "Generating dispavx.c"
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/dispavx.c.org ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c
+    COMMAND ${TARGET_MKDISP} 4 8 __m256d __m256 __m128i avx fma4 avx2 >> ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c
+    DEPENDS ${TARGET_MKDISP}
+    )
+  add_custom_target(dispavx.c_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/dispavx.c)
 
-# Target renamedsp256.h
+  # Target renamedsp256.h
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp256.h
-  COMMENT "Generating renamedsp256.h"
-  COMMAND ${TARGET_MKRENAME} 4 8 > ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp256.h
-  DEPENDS ${TARGET_MKRENAME}
-  )
-add_custom_target(renamedsp256.h_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp256.h)
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp256.h
+    COMMENT "Generating renamedsp256.h"
+    COMMAND ${TARGET_MKRENAME} 4 8 > ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp256.h
+    DEPENDS ${TARGET_MKRENAME}
+    )
+  add_custom_target(renamedsp256.h_generated SOURCES ${CMAKE_CURRENT_BINARY_DIR}/include/renamedsp256.h)
 
-# Target dispsse_obj
+  # Target dispsse_obj
 
-add_library(dispsse_obj OBJECT dispsse.c ${SLEEF_INCLUDE_HEADER})
-set_target_properties(dispsse_obj PROPERTIES ${COMMON_TARGET_PROPERTIES})
-target_include_directories(dispsse_obj PRIVATE ${CMAKE_BINARY_DIR}/include)
-add_dependencies(dispsse_obj dispsse.c_generated renamedsp128.h_generated ${TARGET_HEADERS})
-target_sources(${TARGET_LIBSLEEF} PRIVATE $<TARGET_OBJECTS:dispsse_obj>)
+  add_library(dispsse_obj OBJECT dispsse.c ${SLEEF_INCLUDE_HEADER})
+  set_target_properties(dispsse_obj PROPERTIES ${COMMON_TARGET_PROPERTIES})
+  target_include_directories(dispsse_obj PRIVATE ${CMAKE_BINARY_DIR}/include)
+  add_dependencies(dispsse_obj dispsse.c_generated renamedsp128.h_generated ${TARGET_HEADERS})
+  target_sources(${TARGET_LIBSLEEF} PRIVATE $<TARGET_OBJECTS:dispsse_obj>)
 
-# Target dispavx_obj
+  # Target dispavx_obj
 
-add_library(dispavx_obj OBJECT dispavx.c ${SLEEF_INCLUDE_HEADER})
-target_compile_options(dispavx_obj PRIVATE ${FLAGS_ENABLE_AVX})
-set_target_properties(dispavx_obj PROPERTIES ${COMMON_TARGET_PROPERTIES})
-target_include_directories(dispavx_obj PRIVATE ${CMAKE_BINARY_DIR}/include)
-add_dependencies(dispavx_obj dispavx.c_generated renamedsp256.h_generated ${TARGET_HEADERS})
-target_sources(${TARGET_LIBSLEEF} PRIVATE $<TARGET_OBJECTS:dispavx_obj>)
-
+  add_library(dispavx_obj OBJECT dispavx.c ${SLEEF_INCLUDE_HEADER})
+  target_compile_options(dispavx_obj PRIVATE ${FLAGS_ENABLE_AVX})
+  set_target_properties(dispavx_obj PROPERTIES ${COMMON_TARGET_PROPERTIES})
+  target_include_directories(dispavx_obj PRIVATE ${CMAKE_BINARY_DIR}/include)
+  add_dependencies(dispavx_obj dispavx.c_generated renamedsp256.h_generated ${TARGET_HEADERS})
+  target_sources(${TARGET_LIBSLEEF} PRIVATE $<TARGET_OBJECTS:dispavx_obj>)
+endif(SLEEF_ARCH_X86)
 
 # --------------------------------------------------------------------
 # TARGET_LIBSLEEFGNUABI


### PR DESCRIPTION
This patch moves functions defined in src/common/common.c from libdft to libsleef.
https://github.com/shibatch/sleef/issues/120

It also adds dispatchers to libsleef. 
https://github.com/shibatch/sleef/issues/121

It also removes linking with object files and substitute it with linking with static libraries libcommon and libarraymap.
