### PR TITLE
[build] Don't force building shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ configure_file(
   ${PROJECT_SOURCE_DIR}/sleef-config.h.in
   ${PROJECT_BINARY_DIR}/include/sleef-config.h @ONLY)
 
+option(SLEEFLIBM_STATIC "Build sleeflibm as a dynamic library." OFF)
+if (NOT ${SLEEFLIBM_STATIC})
+  set(BUILD_SHARED_LIBS ON)
+endif()
+
 # We like to have a documented index of all targets in the project. The
 # variables listed below carry the names of the targets defined throughout
 # the project.

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -128,16 +128,22 @@ if(COMPILER_SUPPORTS_LONG_DOUBLE)
   list(APPEND STANDARD_SOURCES sleefld.c)
 endif()
 
-add_library(${TARGET_LIBSLEEF} SHARED ${STANDARD_SOURCES})
+add_library(${TARGET_LIBSLEEF} ${STANDARD_SOURCES})
 set_target_properties(${TARGET_LIBSLEEF} PROPERTIES
   VERSION ${SLEEF_VERSION_MAJOR}.${SLEEF_VERSION_MINOR}
   SOVERSION ${SLEEF_SOVERSION}
   ${COMMON_TARGET_PROPERTIES}
 )
 
-target_compile_definitions(${TARGET_LIBSLEEF} 
+target_compile_definitions(${TARGET_LIBSLEEF}
   PRIVATE DORENAME=1
 )
+
+if(NOT ${BUILD_SHARED_LIBS})
+  target_compile_definitions(${TARGET_LIBSLEEF}
+    PUBLIC SLEEFLIBM_STATIC=1
+  )
+endif()
 
 if(COMPILER_SUPPORTS_FLOAT128)
   # TODO: Not supported for LLVM bitcode gen as it has a specific compilation flags
@@ -275,7 +281,7 @@ if(ENABLE_GNUABI)
   endforeach()
 
   # Create library 
-  add_library(${TARGET_LIBSLEEFGNUABI} SHARED ${TARGET_LIBSLEEFGNUABI_OBJECTS})
+  add_library(${TARGET_LIBSLEEFGNUABI} ${TARGET_LIBSLEEFGNUABI_OBJECTS})
   
   # Library properties
   set_target_properties(${TARGET_LIBSLEEFGNUABI} PROPERTIES

--- a/src/libm/sleeflibm_header.h.org
+++ b/src/libm/sleeflibm_header.h.org
@@ -16,12 +16,16 @@
 #endif
 
 #if defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__) || defined(_MSC_VER)
+#ifdef SLEEFLIBM_STATIC
+#define IMPORT
+#else
 #ifdef IMPORT_IS_EXPORT
 #define IMPORT __declspec(dllexport)
 #else
 #define IMPORT __declspec(dllimport)
 #if (defined(_MSC_VER))
 #pragma comment(lib,"sleef.lib")
+#endif
 #endif
 #endif
 #else // #if defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__) || defined(_MSC_VER)


### PR DESCRIPTION
By not explicitly using add_library(SHARED), the user can override the default
and choose to build libsleef as a static libraries by setting SLEEFLIBM_STATIC=ON.

There are still two points to be addressed later:
 - The dft library is always built as a shared library.
 - On Windows when building sleeflibm as a static library,
   the imported symbols in dft.dll are wrong,
   causing a linker error.