### PR TITLE
[aarch64] Fix fmin and fmax on aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -q ${SDE_URL}                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo rm /etc/apt/sources.list.d/mongodb-3.2.list; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update                       ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 
 # Default linux jobs
 os: linux
-sudo: false
+sudo: required
 dist: trusty
 
 # Include osx jobs
@@ -38,6 +38,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -q ${SDE_URL}                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xvf sde-external-8.12.0-2017-10-23-lin.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update                       ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cmake libmpfr-dev     ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get remove ".*:i386"                 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo rm /var/cache/apt/archives/partial/*     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update                       ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cmake libmpfr-dev     ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,9 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get remove ".*:i386"                 ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -fix-missing -qq update          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update                       ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cmake libmpfr-dev     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then brew update                                   ; fi
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 
 # Default linux jobs
 os: linux
-sudo: required
+sudo: false
 dist: trusty
 
 # Include osx jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -q ${SDE_URL}                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo rm -f /etc/apt/sources.list.d/mongodb-*.list; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update                       ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cmake libmpfr-dev     ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo rm /var/cache/apt/archives/partial/*     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update                       ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cmake libmpfr-dev     ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -f -m -qq update                 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -fix-missing -qq update          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cmake libmpfr-dev     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then brew update                                   ; fi
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update                       ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -m -qq update                    ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cmake libmpfr-dev     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then brew update                                   ; fi
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,11 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -q ${SDE_URL}                            ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xvf sde-external-8.12.0-2017-10-23-lin.tar.bz2; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -m -qq update                    ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -f -m -qq update                 ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cmake libmpfr-dev     ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx"   ]]; then brew update                                   ; fi
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -q ${SDE_URL}                            ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=${PATH}:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo rm /etc/apt/sources.list.d/mongodb-3.2.list; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo rm -f /etc/apt/sources.list.d/mongodb-*.list; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then for i in `sudo apt-key list | grep expired | sed -e 's/.*\///g' -e 's/ .*$//g'`; do sudo apt-key adv --recv-keys --keyserver keys.gnupg.net $i;done;fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:adrozdoff/cmake; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update                       ; fi

--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -28,16 +28,6 @@
 
 #define ISANAME "AArch64 AdvSIMD"
 
-#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
-
-#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
-
 // Mask definition
 typedef uint32x4_t vmask;
 typedef uint32x4_t vopmask;
@@ -607,20 +597,6 @@ static INLINE vdouble vreinterpret_vd_vi2(vint2 vi) {
   return vreinterpretq_f64_s32(vi);
 }
 static INLINE vdouble vtruncate_vd_vd(vdouble vd) { return vrndq_f64(vd); }
-
-// max number, min number
-static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) {
-  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(x, y), x, y));
-}
-static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) {
-  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(y, x), x, y));
-}
-static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) {
-  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(x, y), x, y));
-}
-static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) {
-  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(y, x), x, y));
-}
 
 //
 

--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -161,14 +161,6 @@ static INLINE vfloat vmin_vf_vf_vf(vfloat x, vfloat y) {
   return vminq_f32(x, y);
 }
 
-// max number, min number
-static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) {
-  return vmaxnmq_f32(x, y);
-}
-static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) {
-  return vminnmq_f32(x, y);
-}
-
 // Comparisons
 static INLINE vmask veq_vm_vf_vf(vfloat x, vfloat y) { return vceqq_f32(x, y); }
 static INLINE vmask vneq_vm_vf_vf(vfloat x, vfloat y) {
@@ -306,14 +298,6 @@ static INLINE vdouble vmax_vd_vd_vd(vdouble x, vdouble y) {
 }
 static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) {
   return vminq_f64(x, y);
-}
-
-// max number, min number
-static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) {
-  return vmaxnmq_f64(x, y);
-}
-static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) {
-  return vminnmq_f64(x, y);
 }
 
 // Multiply accumulate: z = z + x * y
@@ -623,6 +607,20 @@ static INLINE vdouble vreinterpret_vd_vi2(vint2 vi) {
   return vreinterpretq_f64_s32(vi);
 }
 static INLINE vdouble vtruncate_vd_vd(vdouble vd) { return vrndq_f64(vd); }
+
+// max number, min number
+static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) {
+  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(x, y), x, y));
+}
+static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) {
+  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(y, x), x, y));
+}
+static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) {
+  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(x, y), x, y));
+}
+static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) {
+  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(y, x), x, y));
+}
 
 //
 

--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -29,16 +29,6 @@
 
 #define FULL_FP_ROUNDING
 
-#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
-
-#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
-
 #if defined(_MSC_VER)
 #include <intrin.h>
 #else
@@ -293,9 +283,6 @@ static INLINE vopmask visnan_vo_vd(vdouble d) {
   return vreinterpret_vm_vd(_mm256_cmp_pd(d, d, _CMP_NEQ_UQ));
 }
 
-static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmax_vd_vd_vd(x, y)); }
-static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmin_vd_vd_vd(x, y)); }
-
 static INLINE vdouble vload_vd_p(const double *ptr) { return _mm256_load_pd(ptr); }
 static INLINE vdouble vloadu_vd_p(const double *ptr) { return _mm256_loadu_pd(ptr); }
 
@@ -480,9 +467,6 @@ static INLINE vopmask visinf_vo_vf(vfloat d) { return veq_vo_vf_vf(vabs_vf_vf(d)
 static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(INFINITYf)); }
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
-
-static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmax_vf_vf_vf(x, y)); }
-static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmin_vf_vf_vf(x, y)); }
 
 //
 

--- a/src/arch/helperavx2.h
+++ b/src/arch/helperavx2.h
@@ -26,16 +26,6 @@
 #define FULL_FP_ROUNDING
 #define SPLIT_KERNEL
 
-#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
-
-#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
-
 #if defined(_MSC_VER)
 #include <intrin.h>
 #else
@@ -249,9 +239,6 @@ static INLINE vopmask visnan_vo_vd(vdouble d) {
   return vreinterpret_vm_vd(_mm256_cmp_pd(d, d, _CMP_NEQ_UQ));
 }
 
-static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmax_vd_vd_vd(x, y)); }
-static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmin_vd_vd_vd(x, y)); }
-
 #if defined(_MSC_VER)
 // This function is needed when debugging on MSVC.
 static INLINE double vcast_d_vd(vdouble v) {
@@ -355,9 +342,6 @@ static INLINE vopmask visinf_vo_vf(vfloat d) { return veq_vo_vf_vf(vabs_vf_vf(d)
 static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(INFINITYf)); }
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
-
-static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmax_vf_vf_vf(x, y)); }
-static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmin_vf_vf_vf(x, y)); }
 
 #ifdef _MSC_VER
 // This function is needed when debugging on MSVC.

--- a/src/arch/helperavx2_128.h
+++ b/src/arch/helperavx2_128.h
@@ -26,16 +26,6 @@
 #define FULL_FP_ROUNDING
 #define SPLIT_KERNEL
 
-#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
-
-#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
-
 #if defined(_MSC_VER)
 #include <intrin.h>
 #else
@@ -231,9 +221,6 @@ static INLINE vopmask visnan_vo_vd(vdouble d) {
   return vreinterpret_vm_vd(_mm_cmp_pd(d, d, _CMP_NEQ_UQ));
 }
 
-static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmax_vd_vd_vd(x, y)); }
-static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmin_vd_vd_vd(x, y)); }
-
 static INLINE vdouble vload_vd_p(const double *ptr) { return _mm_load_pd(ptr); }
 static INLINE vdouble vloadu_vd_p(const double *ptr) { return _mm_loadu_pd(ptr); }
 
@@ -335,9 +322,6 @@ static INLINE vopmask visinf_vo_vf(vfloat d) { return veq_vo_vf_vf(vabs_vf_vf(d)
 static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(INFINITYf)); }
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
-
-static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmax_vf_vf_vf(x, y)); }
-static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmin_vf_vf_vf(x, y)); }
 
 static INLINE vfloat vload_vf_p(const float *ptr) { return _mm_load_ps(ptr); }
 static INLINE vfloat vloadu_vf_p(const float *ptr) { return _mm_loadu_ps(ptr); }

--- a/src/arch/helpersse2.h
+++ b/src/arch/helpersse2.h
@@ -33,16 +33,6 @@
 #define LOG2VECTLENSP (LOG2VECTLENDP+1)
 #define VECTLENSP (1 << LOG2VECTLENSP)
 
-#ifdef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_SINGLE_MINMAXNUM_AVAILABLE 1
-
-#ifdef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#error prior definition of SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-#endif
-#define SLEEF_DOUBLE_MINMAXNUM_AVAILABLE 1
-
 #if defined(_MSC_VER)
 #include <intrin.h>
 #else
@@ -267,9 +257,6 @@ static INLINE vopmask visnan_vo_vd(vdouble d) {
   return vreinterpret_vm_vd(_mm_cmpneq_pd(d, d));
 }
 
-static INLINE vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmax_vd_vd_vd(x, y)); }
-static INLINE vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) { return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmin_vd_vd_vd(x, y)); }
-
 //
 
 static INLINE vdouble vload_vd_p(const double *ptr) { return _mm_load_pd(ptr); }
@@ -377,9 +364,6 @@ static INLINE vopmask visinf_vo_vf(vfloat d) { return veq_vo_vf_vf(vabs_vf_vf(d)
 static INLINE vopmask vispinf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(INFINITYf)); }
 static INLINE vopmask visminf_vo_vf(vfloat d) { return veq_vo_vf_vf(d, vcast_vf_f(-INFINITYf)); }
 static INLINE vopmask visnan_vo_vf(vfloat d) { return vneq_vo_vf_vf(d, d); }
-
-static INLINE vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmax_vf_vf_vf(x, y)); }
-static INLINE vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) { return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmin_vf_vf_vf(x, y)); }
 
 static INLINE vfloat vload_vf_p(const float *ptr) { return _mm_load_ps(ptr); }
 static INLINE vfloat vloadu_vf_p(const float *ptr) { return _mm_loadu_ps(ptr); }

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -32,6 +32,9 @@
 #define M_2_PIl 0.636619772367581343075535053490057448L
 #endif
 
+#define SLEEF_SNAN (((union { long long int i; double d; }) { .i = 0x7ff0000000000001LL }).d)
+#define SLEEF_SNANf (((union { long int i; float f; }) { .i = 0xff800001 }).f)
+
 //
 
 /*

--- a/src/libm-tester/tester.c
+++ b/src/libm-tester/tester.c
@@ -2572,8 +2572,8 @@ void do_test() {
     {
       fprintf(stderr, "fmax denormal/nonnumber test : ");
 
-      double xa[] = { +0.0, -0.0, +1, -1, +1e+100, -1e+100, DBL_MAX, -DBL_MAX, DBL_MIN, -DBL_MIN, POSITIVE_INFINITY, NEGATIVE_INFINITY, NAN };
-      double ya[] = { +0.0, -0.0, +1, -1, +1e+100, -1e+100, DBL_MAX, -DBL_MAX, DBL_MIN, -DBL_MIN, POSITIVE_INFINITY, NEGATIVE_INFINITY, NAN };
+      double xa[] = { +0.0, -0.0, +1, -1, +1e+100, -1e+100, DBL_MAX, -DBL_MAX, DBL_MIN, -DBL_MIN, POSITIVE_INFINITY, NEGATIVE_INFINITY, NAN, SLEEF_SNAN };
+      double ya[] = { +0.0, -0.0, +1, -1, +1e+100, -1e+100, DBL_MAX, -DBL_MAX, DBL_MIN, -DBL_MIN, POSITIVE_INFINITY, NEGATIVE_INFINITY, NAN, SLEEF_SNAN };
 
       for(i=0;i<sizeof(xa)/sizeof(double) && success;i++) {
 	for(j=0;j<sizeof(ya)/sizeof(double) && success;j++) {
@@ -2587,8 +2587,8 @@ void do_test() {
     {
       fprintf(stderr, "fmin denormal/nonnumber test : ");
 
-      double xa[] = { +0.0, -0.0, +1, -1, +1e+100, -1e+100, DBL_MAX, -DBL_MAX, DBL_MIN, -DBL_MIN, POSITIVE_INFINITY, NEGATIVE_INFINITY, NAN };
-      double ya[] = { +0.0, -0.0, +1, -1, +1e+100, -1e+100, DBL_MAX, -DBL_MAX, DBL_MIN, -DBL_MIN, POSITIVE_INFINITY, NEGATIVE_INFINITY, NAN };
+      double xa[] = { +0.0, -0.0, +1, -1, +1e+100, -1e+100, DBL_MAX, -DBL_MAX, DBL_MIN, -DBL_MIN, POSITIVE_INFINITY, NEGATIVE_INFINITY, NAN, SLEEF_SNAN };
+      double ya[] = { +0.0, -0.0, +1, -1, +1e+100, -1e+100, DBL_MAX, -DBL_MAX, DBL_MIN, -DBL_MIN, POSITIVE_INFINITY, NEGATIVE_INFINITY, NAN, SLEEF_SNAN };
 
       for(i=0;i<sizeof(xa)/sizeof(double) && success;i++) {
 	for(j=0;j<sizeof(ya)/sizeof(double) && success;j++) {
@@ -3068,8 +3068,8 @@ void do_test() {
     {
       fprintf(stderr, "fmaxf denormal/nonnumber test : ");
 
-      float xa[] = { +0.0, -0.0, +1, -1, +1e+30, -1e+30, FLT_MAX, -FLT_MAX, FLT_MIN, -FLT_MIN, POSITIVE_INFINITYf, NEGATIVE_INFINITYf, NAN };
-      float ya[] = { +0.0, -0.0, +1, -1, +1e+30, -1e+30, FLT_MAX, -FLT_MAX, FLT_MIN, -FLT_MIN, POSITIVE_INFINITYf, NEGATIVE_INFINITYf, NAN };
+      float xa[] = { +0.0, -0.0, +1, -1, +1e+30, -1e+30, FLT_MAX, -FLT_MAX, FLT_MIN, -FLT_MIN, POSITIVE_INFINITYf, NEGATIVE_INFINITYf, NAN, SLEEF_SNANf };
+      float ya[] = { +0.0, -0.0, +1, -1, +1e+30, -1e+30, FLT_MAX, -FLT_MAX, FLT_MIN, -FLT_MIN, POSITIVE_INFINITYf, NEGATIVE_INFINITYf, NAN, SLEEF_SNANf };
 
       for(i=0;i<sizeof(xa)/sizeof(float) && success;i++) {
 	for(j=0;j<sizeof(ya)/sizeof(float) && success;j++) {
@@ -3083,8 +3083,8 @@ void do_test() {
     {
       fprintf(stderr, "fminf denormal/nonnumber test : ");
 
-      float xa[] = { +0.0, -0.0, +1, -1, +1e+30, -1e+30, FLT_MAX, -FLT_MAX, FLT_MIN, -FLT_MIN, POSITIVE_INFINITYf, NEGATIVE_INFINITYf, NAN };
-      float ya[] = { +0.0, -0.0, +1, -1, +1e+30, -1e+30, FLT_MAX, -FLT_MAX, FLT_MIN, -FLT_MIN, POSITIVE_INFINITYf, NEGATIVE_INFINITYf, NAN };
+      float xa[] = { +0.0, -0.0, +1, -1, +1e+30, -1e+30, FLT_MAX, -FLT_MAX, FLT_MIN, -FLT_MIN, POSITIVE_INFINITYf, NEGATIVE_INFINITYf, NAN, SLEEF_SNANf };
+      float ya[] = { +0.0, -0.0, +1, -1, +1e+30, -1e+30, FLT_MAX, -FLT_MAX, FLT_MIN, -FLT_MIN, POSITIVE_INFINITYf, NEGATIVE_INFINITYf, NAN, SLEEF_SNANf };
 
       for(i=0;i<sizeof(xa)/sizeof(float) && success;i++) {
 	for(j=0;j<sizeof(ya)/sizeof(float) && success;j++) {

--- a/src/libm/dd.h
+++ b/src/libm/dd.h
@@ -393,13 +393,3 @@ static INLINE CONST vdouble2 ddsqrt_vd2_vd(vdouble d) {
   vdouble t = vsqrt_vd_vd(d);
   return ddscale_vd2_vd2_vd(ddmul_vd2_vd2_vd2(ddadd2_vd2_vd_vd2(d, ddmul_vd2_vd_vd(t, t)), ddrec_vd2_vd(t)), vcast_vd_d(0.5));
 }
-
-#ifndef SLEEF_DOUBLE_MINMAXNUM_AVAILABLE
-static INLINE CONST vdouble vmaxnum_vd_vd_vd(vdouble x, vdouble y) {
-  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(x, y), x, y));
-}
-
-static INLINE CONST vdouble vminnum_vd_vd_vd(vdouble x, vdouble y) {
-  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(y, x), x, y));
-}
-#endif

--- a/src/libm/df.h
+++ b/src/libm/df.h
@@ -464,13 +464,3 @@ static INLINE CONST vfloat2 dfsqrt_vf2_vf(vfloat d) {
   vfloat t = vsqrt_vf_vf(d);
   return dfscale_vf2_vf2_vf(dfmul_vf2_vf2_vf2(dfadd2_vf2_vf_vf2(d, dfmul_vf2_vf_vf(t, t)), dfrec_vf2_vf(t)), vcast_vf_f(0.5f));
 }
-
-#ifndef SLEEF_SINGLE_MINMAXNUM_AVAILABLE
-static INLINE CONST vfloat vmaxnum_vf_vf_vf(vfloat x, vfloat y) {
-  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(x, y), x, y));
-}
-
-static INLINE CONST vfloat vminnum_vf_vf_vf(vfloat x, vfloat y) {
-  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(y, x), x, y));
-}
-#endif

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -2252,9 +2252,21 @@ EXPORT CONST vdouble xfabs(vdouble x) { return vabs_vd_vd(x); }
 
 EXPORT CONST vdouble xcopysign(vdouble x, vdouble y) { return vcopysign_vd_vd_vd(x, y); }
 
-EXPORT CONST vdouble xfmax(vdouble x, vdouble y) { return vmaxnum_vd_vd_vd(x, y); }
+EXPORT CONST vdouble xfmax(vdouble x, vdouble y) {
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(ENABLE_VECEXT) && !defined(ENABLE_PUREC)
+  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmax_vd_vd_vd(x, y));
+#else
+  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(x, y), x, y));
+#endif
+}
 
-EXPORT CONST vdouble xfmin(vdouble x, vdouble y) { return vminnum_vd_vd_vd(x, y); }
+EXPORT CONST vdouble xfmin(vdouble x, vdouble y) {
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(ENABLE_VECEXT) && !defined(ENABLE_PUREC)
+  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vmin_vd_vd_vd(x, y));
+#else
+  return vsel_vd_vo_vd_vd(visnan_vo_vd(y), x, vsel_vd_vo_vd_vd(vgt_vo_vd_vd(y, x), x, y));
+#endif
+}
 
 EXPORT CONST vdouble xfdim(vdouble x, vdouble y) {
   vdouble ret = vsub_vd_vd_vd(x, y);

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -1723,9 +1723,21 @@ EXPORT CONST vfloat xfabsf(vfloat x) { return vabs_vf_vf(x); }
 
 EXPORT CONST vfloat xcopysignf(vfloat x, vfloat y) { return vcopysign_vf_vf_vf(x, y); }
 
-EXPORT CONST vfloat xfmaxf(vfloat x, vfloat y) { return vmaxnum_vf_vf_vf(x, y); }
+EXPORT CONST vfloat xfmaxf(vfloat x, vfloat y) {
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(ENABLE_VECEXT) && !defined(ENABLE_PUREC)
+  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmax_vf_vf_vf(x, y));
+#else
+  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(x, y), x, y));
+#endif
+}
 
-EXPORT CONST vfloat xfminf(vfloat x, vfloat y) { return vminnum_vf_vf_vf(x, y); }
+EXPORT CONST vfloat xfminf(vfloat x, vfloat y) {
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(ENABLE_VECEXT) && !defined(ENABLE_PUREC)
+  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vmin_vf_vf_vf(x, y));
+#else
+  return vsel_vf_vo_vf_vf(visnan_vo_vf(y), x, vsel_vf_vo_vf_vf(vgt_vo_vf_vf(y, x), x, y));
+#endif
+}
 
 EXPORT CONST vfloat xfdimf(vfloat x, vfloat y) {
   vfloat ret = vsub_vf_vf_vf(x, y);


### PR DESCRIPTION
vmaxnum_v*_v*_v* and vminnum_v*_v*_v* are helper functions for utilizing instructions for choosing larger and smaller elements from two given vectors, and they are introduced in the following PR.

https://github.com/shibatch/sleef/pull/109

It is said that vmaxnmq and vminnmq on aarch64 are IEEE754-conformant, but I recently found that handling of signalling NaN by these instructions is not conforming to the specification of fmin and fmax functions in the ANSI C standard.

This patch fixes that problem.
