### PR TITLE
DO NOT MERGE! Improve GNUABI compatibility testing. DO NOT MERGE!

### DIFF
--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -60,19 +60,6 @@ macro(test_extension SIMD)
 
     list(APPEND IUT_LIST ${TARGET_IUT${SIMD}})
 
-    if(ENABLE_GNUABI)
-      if (COMPILER_SUPPORTS_WEAK_ALIASES)
-	add_executable(link_finite${SIMD} finite_names_testing.c)
-	target_compile_options(link_finite${SIMD}
-	  PRIVATE ${FLAGS_ENABLE_${SIMD}})
-	target_compile_definitions(link_finite${SIMD}
-	  PRIVATE ENABLE_${SIMD}=1 ${COMMON_TARGET_DEFINITIONS})
-	target_link_libraries(link_finite${SIMD} ${TARGET_LIBSLEEFGNUABI} ${LIBM})
-	add_test(NAME link_finite${SIMD}
-	  COMMAND link_finite${SIMD})
-      endif (COMPILER_SUPPORTS_WEAK_ALIASES)
-    endif(ENABLE_GNUABI)
-
     if(LIB_MPFR AND NOT ${SIMD} STREQUAL NEON32)
       # Build tester2 SIMD
       string(TOLOWER ${SIMD} SCSIMD)
@@ -96,6 +83,22 @@ endmacro(test_extension)
 foreach(SIMD ${SLEEF_SUPPORTED_EXTENSIONS})
   test_extension(${SIMD})
 endforeach()
+
+if(ENABLE_GNUABI)
+  foreach(SIMD ${SLEEF_SUPPORTED_GNUABI_EXTENSIONS})
+    if(COMPILER_SUPPORTS_${SIMD})
+      add_executable(link_finite${SIMD} finite_names_testing.c)
+      target_compile_options(link_finite${SIMD}
+	PRIVATE ${FLAGS_ENABLE_${SIMD}})
+      target_compile_definitions(link_finite${SIMD}
+	PRIVATE ENABLE_${SIMD}=1 ${COMMON_TARGET_DEFINITIONS})
+      target_link_libraries(link_finite${SIMD} ${TARGET_LIBSLEEFGNUABI} ${LIBM})
+      add_test(NAME link_finite${SIMD}
+	COMMAND link_finite${SIMD})
+    endif (COMPILER_SUPPORTS_${SIMD})
+  endforeach(SIMD ${SLEEF_SUPPORTED_GNUABI_EXTENSIONS})
+endif(ENABLE_GNUABI)
+
 
 if (SLEEF_ARCH_X86)
   # iutdsp128

--- a/src/libm-tester/finite_names_testing.c
+++ b/src/libm-tester/finite_names_testing.c
@@ -1,119 +1,78 @@
 #include <setjmp.h>
 #include <signal.h>
-#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 
-#if defined(ENABLE_SSE2) || defined(ENABLE_SSE4)
-
-#ifdef ENABLE_SSE2
-#define NAME "SSE2"
-#define CONFIG 2
-#endif
-
-#ifdef ENABLE_SSE4
-#define NAME "SSE4"
-#define CONFIG 4
-#endif
-
-#include "helpersse2.h"
-#define vacos_finite _ZGVbN2v___acos_finite
-#define vasin_finite _ZGVbN2v___asin_finite
-
-#define vacosf_finite _ZGVbN4v___acosf_finite
-#define vasinf_finite _ZGVbN4v___asinf_finite
-
-#endif /* defined(ENABLE_SSE2) || defined(ENABLE_SSE4) */
+#if defined(ENABLE_SSE4) || defined(ENABLE_SSE2)
+#define ISA_TOKEN b
+#define VLEN_SP 4
+#define VLEN_DP 2
+#endif /* defined(ENABLE_SSE4) || defined(ENABLE_SSE2) */
 
 #ifdef ENABLE_AVX
-#define NAME "AVX"
-#define CONFIG 1
-#include "helperavx.h"
-#define vacos_finite _ZGVcN4v___acos_finite
-#define vasin_finite _ZGVcN4v___asin_finite
-
-#define vacosf_finite _ZGVcN8v___acosf_finite
-#define vasinf_finite _ZGVcN8v___asinf_finite
+#define ISA_TOKEN c
+#define VLEN_SP 8
+#define VLEN_DP 4
 #endif /* ENABLE_AVX */
 
 #ifdef ENABLE_AVX2
-#define NAME "AVX2"
-#define CONFIG 1
-#include "helperavx2.h"
-#define vacos_finite _ZGVdN4v___acos_finite
-#define vasin_finite _ZGVdN4v___asin_finite
-
-#define vacosf_finite _ZGVdN8v___acosf_finite
-#define vasinf_finite _ZGVdN8v___asinf_finite
+#define ISA_TOKEN d
+#define VLEN_SP 8
+#define VLEN_DP 4
 #endif /* ENABLE_AVX2 */
 
 #ifdef ENABLE_AVX512F
-#define NAME "AVX512F"
-#define CONFIG 1
-#include "helperavx512f.h"
-#define vacos_finite _ZGVeN8v___acos_finite
-#define vasin_finite _ZGVeN8v___asin_finite
-
-#define vacosf_finite _ZGVeN16v___acosf_finite
-#define vasinf_finite _ZGVeN16v___asinf_finite
+#define ISA_TOKEN e
+#define VLEN_SP 16
+#define VLEN_DP 8
 #endif /* ENABLE_AVX512F */
 
-#ifdef NAME
+#ifdef ENABLE_ADVSIMD
+#define ISA_TOKEN n
+#define VLEN_SP 4
+#define VLEN_DP 2
+#endif /* ENABLE_ADVSIMDF */
 
-extern vdouble vacos_finite(vdouble);
-extern vdouble vasin_finite(vdouble);
+#define __MAKE_FN_NAME(name, t, vl, p) _ZGV##t##N##vl##p##_##name
 
-extern vfloat vacosf_finite(vfloat);
-extern vfloat vasinf_finite(vfloat);
+#define __DECLARE(name, t, vl, p) void __MAKE_FN_NAME(name, t, vl, p)(int *)
+#define __CALL(name, t, vl, p) __MAKE_FN_NAME(name, t, vl, p)(a)
 
-void check_featureDP() {
-#ifdef ENABLE_DP
-  double s[VECTLENDP];
-  int i;
-  for (i = 0; i < VECTLENDP; i++) {
-    s[i] = 1.0;
-  }
-  vdouble a = vloadu_vd_p(s);
-  a = vacos_finite(a);
-  vstoreu_v_p_vd(s, a);
+#ifndef ISA_TOKEN
+#error "Missing ISA token"
 #endif
-}
 
-void check_featureSP() {
-#ifdef ENABLE_SP
-  float s[VECTLENSP];
-  int i;
-  for (i = 0; i < VECTLENSP; i++) {
-    s[i] = 1.0;
-  }
-  vfloat a = vloadu_vf_p(s);
-  a = vacosf_finite(a);
-  vstoreu_v_p_vf(s, a);
+#ifndef VLEN_DP
+#error "Missing VLEN_DP"
 #endif
-}
+
+#ifndef VLEN_DP
+#error "Missing VLEN_SP"
+#endif
+
+#define DECLARE_DP(name, p) __DECLARE(name, ISA_TOKEN, VLEN_DP, p)
+#define CALL_DP(name, p) __CALL(name, ISA_TOKEN, VLEN_DP, p)
+
+DECLARE_DP(__acos_finite, v);
+DECLARE_DP(__asin_finite, v);
+
+#define DECLARE_SP(name, p) __DECLARE(name, ISA_TOKEN, VLEN_SP, p)
+#define CALL_SP(name, p) __CALL(name, ISA_TOKEN, VLEN_SP, p)
+
+DECLARE_SP(__acosf_finite, v);
+DECLARE_SP(__asinf_finite, v);
+
+int b;
+int *a = &b;
 
 static jmp_buf sigjmp;
 
 static void sighandler(int signum) { longjmp(sigjmp, 1); }
 
-int detectFeatureDP() {
+int detectFeature() {
   signal(SIGILL, sighandler);
 
   if (setjmp(sigjmp) == 0) {
-    check_featureDP();
-    signal(SIGILL, SIG_DFL);
-    return 1;
-  } else {
-    signal(SIGILL, SIG_DFL);
-    return 0;
-  }
-}
-
-int detectFeatureSP() {
-  signal(SIGILL, sighandler);
-
-  if (setjmp(sigjmp) == 0) {
-    check_featureSP();
+    CALL_DP(__acos_finite, v);
     signal(SIGILL, SIG_DFL);
     return 1;
   } else {
@@ -123,61 +82,17 @@ int detectFeatureSP() {
 }
 
 int main(void) {
-  if (!detectFeatureDP() || !detectFeatureSP()) {
-    printf("%s is not available on this machine.\n", NAME);
+
+  if (!detectFeature()) {
     return 0;
   }
 
-#ifdef ENABLE_DP
-  {
-    double in[VECTLENDP], out[VECTLENDP];
-    vdouble vin, vout;
-    int i;
+  CALL_DP(__acos_finite, v);
+  CALL_DP(__asin_finite, v);
 
-    for (i = 0; i < VECTLENDP; ++i)
-      in[i] = i;
+  CALL_SP(__acosf_finite, v);
+  CALL_SP(__asinf_finite, v);
 
-    vin = vload_vd_p(in);
-    vout = vacos_finite(vin);
-    vout = vasin_finite(vout);
-    vstore_v_p_vd(out, vout);
-
-    printf("DP: %s... ", NAME);
-    for (i = 0; i < VECTLENDP; ++i)
-      printf("%g ", out[i]);
-    printf(" ...passed. \n");
-  }
-#endif
-
-#ifdef ENABLE_SP
-  {
-    float in[VECTLENSP], out[VECTLENSP];
-    vfloat vin, vout;
-    int i;
-
-    for (i = 0; i < VECTLENSP; ++i)
-      in[i] = i;
-
-    vin = vload_vf_p(in);
-    vout = vacosf_finite(vin);
-    vout = vasinf_finite(vout);
-    vstore_v_p_vf(out, vout);
-
-    printf("SP: %s... ", NAME);
-    for (i = 0; i < VECTLENSP; ++i)
-      printf("%g ", out[i]);
-    printf(" ...passed. \n");
-  }
-#endif
-
+  printf("%d\n", b);
   return 0;
 }
-
-#else /* #ifdef NAME */
-
-int main(void) {
-  printf("Nothing here.\n");
-  return 0;
-}
-
-#endif /* #ifdef NAME */


### PR DESCRIPTION
This patch converts the "finite" tests into a more generic GNUABI-compatibility tests.

The names for the functions are generated using custom macros instead of the `mkrename*` scripts, so that we can cross check such name generation.

This patch shows the mechanism I want to implement in this tests.

The tests are created and executed only for those vectro extensions for which we create a GNUABI version.

TODOS:

1. test all names (including the non finite ones)
2. rename the tests to something related to GNUABI, not to "finite".