### PR TITLE
[MSVC][CMake] Enable building static libs on MSVC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ environment:
     DO_TEST: FALSE
 install:
   - if "%DO_TEST%" == "TRUE" ( set ORGPATH="%PATH%" )
-  - if "%DO_TEST%" == "TRUE" ( "C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake" )
+  - if "%DO_TEST%" == "TRUE" ( C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake )
   - if "%DO_TEST%" == "TRUE" ( PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;"%PATH%" )
-  - if "%DO_TEST%" == "TRUE" ( "C:\\Cygwin64\\bin\\bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2'" )
+  - if "%DO_TEST%" == "TRUE" ( C:\\Cygwin64\\bin\\bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2' )
   - if "%DO_TEST%" == "TRUE" ( del /Q /F c:\projects\sleef\build-cygwin\bin\iut* )
   - if "%DO_TEST%" == "TRUE" ( PATH "%ORGPATH%";c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin )
   - if "%DO_TEST%" == "TRUE" ( cd "c:\\projects\\sleef" )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,13 +9,13 @@ environment:
   - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=FALSE
     DO_TEST: FALSE
 install:
-  - if "%DO_TEST%" == "TRUE" ( set ORGPATH="%PATH%" )
-  - if "%DO_TEST%" == "TRUE" ( C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake )
-  - if "%DO_TEST%" == "TRUE" ( PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;"%PATH%" )
-  - if "%DO_TEST%" == "TRUE" ( C:\\Cygwin64\\bin\\bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2' )
-  - if "%DO_TEST%" == "TRUE" ( del /Q /F c:\projects\sleef\build-cygwin\bin\iut* )
-  - if "%DO_TEST%" == "TRUE" ( PATH "%ORGPATH%;c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin" )
-  - if "%DO_TEST%" == "TRUE" ( cd "c:\\projects\\sleef" )
+  - if "%DO_TEST%" == "TRUE" set ORGPATH="%PATH%"
+  - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\setup-x86_64.exe" -q -g -P libmpfr-devel,libgmp-devel,cmake
+  - if "%DO_TEST%" == "TRUE" PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;"%PATH%"
+  - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\bin\\bash" -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2'
+  - if "%DO_TEST%" == "TRUE" del /Q /F c:\projects\sleef\build-cygwin\bin\iut*
+  - if "%DO_TEST%" == "TRUE" PATH "%ORGPATH%";c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin
+  - if "%DO_TEST%" == "TRUE" cd "c:\\projects\\sleef"
   - mkdir build
   - cd build
   - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 %ENV_BUILD_STATIC%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,15 +9,13 @@ environment:
   - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=FALSE
     DO_TEST: FALSE
 install:
-  - if "%DO_TEST%" == "TRUE" (
-    set ORGPATH=%PATH%
-    "C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake"
-    PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;%PATH%
-    "C:\\Cygwin64\\bin\\bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2'"
-    del /Q /F c:\projects\sleef\build-cygwin\bin\iut*
-    PATH %ORGPATH%;c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin
-    cd "c:\\projects\\sleef"
-    )
+  - if "%DO_TEST%" == "TRUE" ( set ORGPATH=%PATH% )
+  - if "%DO_TEST%" == "TRUE" ( "C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake" )
+  - if "%DO_TEST%" == "TRUE" ( PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;%PATH% )
+  - if "%DO_TEST%" == "TRUE" ( "C:\\Cygwin64\\bin\\bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2'" )
+  - if "%DO_TEST%" == "TRUE" ( del /Q /F c:\projects\sleef\build-cygwin\bin\iut* )
+  - if "%DO_TEST%" == "TRUE" ( PATH %ORGPATH%;c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin )
+  - if "%DO_TEST%" == "TRUE" ( cd "c:\\projects\\sleef" )
   - mkdir build
   - cd build
   - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 %ENV_BUILD_STATIC%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - if "%DO_TEST%" == "TRUE" ( PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;"%PATH%" )
   - if "%DO_TEST%" == "TRUE" ( C:\\Cygwin64\\bin\\bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2' )
   - if "%DO_TEST%" == "TRUE" ( del /Q /F c:\projects\sleef\build-cygwin\bin\iut* )
-  - if "%DO_TEST%" == "TRUE" ( PATH "%ORGPATH%";c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin )
+  - if "%DO_TEST%" == "TRUE" ( PATH "%ORGPATH%;c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin" )
   - if "%DO_TEST%" == "TRUE" ( cd "c:\\projects\\sleef" )
   - mkdir build
   - cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,13 +9,15 @@ environment:
   - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=FALSE
     DO_TEST: FALSE
 install:
-  - set ORGPATH=%PATH%
-  - "C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake"
-  - PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;%PATH%
-  - "C:\\Cygwin64\\bin\\bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2'"
-  - del /Q /F c:\projects\sleef\build-cygwin\bin\iut*
-  - PATH %ORGPATH%;c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin
-  - cd "c:\\projects\\sleef"
+  - if "%DO_TEST%" == "TRUE" (
+    set ORGPATH=%PATH%
+    "C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake"
+    PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;%PATH%
+    "C:\\Cygwin64\\bin\\bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2'"
+    del /Q /F c:\projects\sleef\build-cygwin\bin\iut*
+    PATH %ORGPATH%;c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin
+    cd "c:\\projects\\sleef"
+    )
   - mkdir build
   - cd build
   - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 %ENV_BUILD_STATIC%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   - cd "c:\\projects\\sleef"
   - mkdir build
   - cd build
-  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 $env:ENV_BUILD_STATIC
+  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 %ENV_BUILD_STATIC%
 build_script:
   - cmake --build . --target install --config Release
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,11 @@ version: 1.0.{build}
 max_jobs: 1
 image: Visual Studio 2017
 configuration: Release
+environment:
+  matrix:
+  - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=TRUE
+
+  - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=FALSE
 install:
   - set ORGPATH=%PATH%
   - "C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake"
@@ -12,7 +17,7 @@ install:
   - cd "c:\\projects\\sleef"
   - mkdir build
   - cd build
-  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1
+  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 $env:ENV_BUILD_STATIC
 build_script:
   - cmake --build . --target install --config Release
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,12 @@ environment:
   - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=FALSE
     DO_TEST: FALSE
 install:
-  - if "%DO_TEST%" == "TRUE" ( set ORGPATH=%PATH% )
+  - if "%DO_TEST%" == "TRUE" ( set ORGPATH="%PATH%" )
   - if "%DO_TEST%" == "TRUE" ( "C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake" )
-  - if "%DO_TEST%" == "TRUE" ( PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;%PATH% )
+  - if "%DO_TEST%" == "TRUE" ( PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;"%PATH%" )
   - if "%DO_TEST%" == "TRUE" ( "C:\\Cygwin64\\bin\\bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2'" )
   - if "%DO_TEST%" == "TRUE" ( del /Q /F c:\projects\sleef\build-cygwin\bin\iut* )
-  - if "%DO_TEST%" == "TRUE" ( PATH %ORGPATH%;c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin )
+  - if "%DO_TEST%" == "TRUE" ( PATH "%ORGPATH%";c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin )
   - if "%DO_TEST%" == "TRUE" ( cd "c:\\projects\\sleef" )
   - mkdir build
   - cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,9 @@ configuration: Release
 environment:
   matrix:
   - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=TRUE
-
+    DO_TEST: TRUE
   - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=FALSE
+    DO_TEST: FALSE
 install:
   - set ORGPATH=%PATH%
   - "C:\\Cygwin64\\setup-x86_64.exe -q -g -P libmpfr-devel,libgmp-devel,cmake"
@@ -21,7 +22,7 @@ install:
 build_script:
   - cmake --build . --target install --config Release
 test_script:
-  - ctest --output-on-failure -j 2 -C Release
+  - if "%DO_TEST%" == "TRUE" (ctest --output-on-failure -j 2 -C Release)
 artifacts:
 - path: build\install\**\*
   name: SLEEFWindowsx64

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -58,7 +58,7 @@ macro(test_extension SIMD)
     target_compile_options(${TARGET_IUT${SIMD}}
       PRIVATE ${FLAGS_ENABLE_${SIMD}})
     target_compile_definitions(${TARGET_IUT${SIMD}}
-      PRIVATE ENABLE_${SIMD}=1)
+      PRIVATE ENABLE_${SIMD}=1 ${COMMON_TARGET_DEFINITIONS})
     target_link_libraries(${TARGET_IUT${SIMD}} ${TARGET_LIBSLEEF}
       ${TARGET_LIBCOMMON_STATIC} ${LIBM} ${LIBRT})
 


### PR DESCRIPTION
This patch fixes a bug in CMakelists.txt which was preventing build static libs with MSVC.
This patch also adds directive for building static libs on appveryor.