### PR TITLE
[AArch32] This patch adds neon32+vfpv4 target support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(TARGET_IUTAVX2128 "iutavx2128")
 set(TARGET_IUTAVX512F "iutavx512f")
 set(TARGET_IUTADVSIMD "iutadvsimd")
 set(TARGET_IUTNEON32 "iutneon32")
+set(TARGET_IUTNEON32VFPV4 "iutneon32vfpv4")
 set(TARGET_IUTSVE "iutsve")
 set(TARGET_IUTVSX "iutvsx")
 # The target to generate LLVM bitcode only, available when SLEEF_ENABLE_LLVM_BITCODE is passed to cmake

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -25,7 +25,7 @@ endif()
 set(SLEEF_SUPPORTED_EXTENSIONS
   AVX512F AVX2 AVX2128 FMA4 AVX SSE4 SSE2 # x86
   ADVSIMD SVE				  # Aarch64
-  NEON32				  # Aarch32
+  NEON32 NEON32VFPV4			  # Aarch32
   VSX				          # PPC64
   CACHE STRING "List of SIMD architectures supported by libsleef."
   )
@@ -100,13 +100,16 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
   set(SLEEF_ARCH_AARCH32 ON CACHE INTERNAL "True for Aarch32 architecture.")
   set(COMPILER_SUPPORTS_NEON32 1)
+  set(COMPILER_SUPPORTS_NEON32VFPV4 1)
 
   set(SLEEF_HEADER_LIST
     NEON32_
     NEON32
+    NEON32VFPV4
   )
   command_arguments(HEADER_PARAMS_NEON32_   2 4 - float32x4_t int32x2_t int32x4_t __ARM_NEON__)
   command_arguments(HEADER_PARAMS_NEON32    2 4 - float32x4_t int32x2_t int32x4_t __ARM_NEON__ neon)
+  command_arguments(HEADER_PARAMS_NEON32VFPV4 2 4 - float32x4_t int32x2_t int32x4_t __ARM_NEON__ neonvfpv4)
 
   command_arguments(ALIAS_PARAMS_NEON32_SP -4 float32x4_t int32x4_t - neon)
   command_arguments(ALIAS_PARAMS_NEON32_DP 0)
@@ -134,6 +137,7 @@ command_arguments(RENAME_PARAMS_AVX2128        2 4 avx2128)
 command_arguments(RENAME_PARAMS_AVX512F        8 16 avx512f)
 command_arguments(RENAME_PARAMS_ADVSIMD        2 4 advsimd)
 command_arguments(RENAME_PARAMS_NEON32         2 4 neon)
+command_arguments(RENAME_PARAMS_NEON32VFPV4    2 4 neonvfpv4)
 command_arguments(RENAME_PARAMS_VSX            2 4 vsx)
 # The vector length parameters in SVE, for SP and DP, are chosen for
 # the smallest SVE vector size (128-bit). The name is generated using
@@ -180,6 +184,7 @@ set(CLANG_FLAGS_ENABLE_AVX2 "-mavx2;-mfma")
 set(CLANG_FLAGS_ENABLE_AVX2128 "-mavx2;-mfma")
 set(CLANG_FLAGS_ENABLE_AVX512F "-mavx512f")
 set(CLANG_FLAGS_ENABLE_NEON32 "--target=arm-linux-gnueabihf;-mcpu=cortex-a8")
+set(CLANG_FLAGS_ENABLE_NEON32VFPV4 "-march=armv7-a;-mfpu=neon-vfpv4")
 # Arm AArch64 vector extensions.
 set(CLANG_FLAGS_ENABLE_ADVSIMD "-march=armv8-a+simd")
 set(CLANG_FLAGS_ENABLE_SVE "-march=armv8-a+sve")

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -82,7 +82,7 @@ macro(test_extension SIMD)
     add_test_iut(${TARGET_IUT${SIMD}})
     list(APPEND IUT_LIST ${TARGET_IUT${SIMD}})
 
-    if(LIB_MPFR AND NOT ${SIMD} STREQUAL NEON32 AND NOT MINGW)
+    if(LIB_MPFR AND NOT ${SIMD} STREQUAL NEON32 AND NOT ${SIMD} STREQUAL NEON32VFPV4 AND NOT MINGW)
       # Build tester2 SIMD
       string(TOLOWER ${SIMD} SCSIMD)
       foreach(P dp sp)

--- a/src/libm-tester/iutsimd.c
+++ b/src/libm-tester/iutsimd.c
@@ -110,6 +110,13 @@ typedef Sleef___m512_2 vfloat2;
 typedef Sleef_float32x4_t_2 vfloat2;
 #endif
 
+#ifdef ENABLE_NEON32VFPV4
+#define CONFIG 4
+#include "helperneon32.h"
+#include "renameneon32vfpv4.h"
+typedef Sleef_float32x4_t_2 vfloat2;
+#endif
+
 #ifdef ENABLE_ADVSIMD
 #define CONFIG 1
 #include "helperadvsimd.h"
@@ -397,7 +404,7 @@ int do_test(int argc, char **argv) {
 #ifdef ENABLE_SP
     k += 2;
 #endif
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
     k += 4; // flush to zero
 #elif defined(ENABLE_VECEXT)
     if (vcast_f_vf(xpowf(vcast_vf_f(0.5f), vcast_vf_f(140))) == 0) k += 4;

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -116,6 +116,14 @@ extern const float rempitabsp[];
 #endif
 #endif
 
+#ifdef ENABLE_NEON32VFPV4
+#define CONFIG 4
+#include "helperneon32.h"
+#ifdef DORENAME
+#include "renameneon32vfpv4.h"
+#endif
+#endif
+
 #ifdef ENABLE_VSX
 #define CONFIG 1
 #include "helperpower_128.h"
@@ -949,7 +957,7 @@ EXPORT CONST vfloat xatanf(vfloat d) {
 
   t = vreinterpret_vf_vm(vxor_vm_vm_vm(vand_vm_vo32_vm(veq_vo_vi2_vi2(vand_vi2_vi2_vi2(q, vcast_vi2_i(2)), vcast_vi2_i(2)), vreinterpret_vm_vf(vcast_vf_f(-0.0f))), vreinterpret_vm_vf(t)));
 
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
   t = vsel_vf_vo_vf_vf(visinf_vo_vf(d), vmulsign_vf_vf_vf(vcast_vf_f(1.5874010519681994747517056f), d), t);
 #endif
 
@@ -1236,7 +1244,7 @@ static INLINE CONST vfloat expm1fk(vfloat d) {
   return u;
 }
 
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
 EXPORT CONST vfloat xsqrtf_u35(vfloat d) {
   vfloat e = vreinterpret_vf_vi2(vadd_vi2_vi2_vi2(vcast_vi2_i(0x20000000), vand_vi2_vi2_vi2(vcast_vi2_i(0x7f000000), vsrl_vi2_vi2_i(vreinterpret_vi2_vf(d), 1))));
   vfloat m = vreinterpret_vf_vi2(vadd_vi2_vi2_vi2(vcast_vi2_i(0x3f000000), vand_vi2_vi2_vi2(vcast_vi2_i(0x01ffffff), vreinterpret_vi2_vf(d))));
@@ -1467,7 +1475,7 @@ EXPORT CONST vfloat xpowf(vfloat x, vfloat y) {
   vopmask yisodd = vand_vo_vo_vo(vand_vo_vo_vo(veq_vo_vi2_vi2(vand_vi2_vi2_vi2(vtruncate_vi2_vf(y), vcast_vi2_i(1)), vcast_vi2_i(1)), yisint),
 				 vlt_vo_vf_vf(vabs_vf_vf(y), vcast_vf_f(1 << 24)));
 
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
   yisodd = vandnot_vm_vo32_vm(visinf_vo_vf(y), yisodd);
 #endif
 
@@ -2131,7 +2139,7 @@ EXPORT CONST vfloat xfmodf(vfloat x, vfloat y) {
   de = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(de, vcast_vf_f(1ULL << 25)), de);
   s  = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(s , vcast_vf_f(1.0f / (1ULL << 25))), s);
   vfloat rde = vtoward0f(vrec_vf_vf(de));
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
   rde = vtoward0f(rde);
 #endif
   vfloat2 r = vcast_vf2_vf_vf(nu, vcast_vf_f(0));


### PR DESCRIPTION
Usage of FMA is enabled on hardware with vfpv4 support.
This patch won't change the existing functions.