### PR TITLE
Set CMP0066 to the behavior of CMake 3.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,9 @@ option(SLEEF_SHOW_ERROR_LOG "Show cmake error log." OFF)
 # See doc/build-with-cmake.md for instructions on how to build Sleef.
 cmake_minimum_required(VERSION 3.4.3)
 # Set to NEW when updating cmake_minimum_required to VERSION >= 3.7.2
-cmake_policy(SET CMP0066 OLD)
+if(${CMAKE_VERSION} VERSION_GREATER "3.7.1")
+  cmake_policy(SET CMP0066 OLD)
+endif()
 
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ option(SLEEF_SHOW_ERROR_LOG "Show cmake error log." OFF)
 
 # See doc/build-with-cmake.md for instructions on how to build Sleef.
 cmake_minimum_required(VERSION 3.4.3)
+# Set to NEW when updating cmake_minimum_required to VERSION >= 3.7.2
+cmake_policy(SET CMP0066 OLD)
 
 enable_testing()
 


### PR DESCRIPTION
The CMake Policy CMP0066 is not specified in the CMake file which produces some developer warnings (see below). It controls whether CMAKE_C_FLAGS and friends are honored in the `try_compile` tests (that is, whether they are passed to the compiler while building these tests). 

The new recommended behavior is to pass these flags, but for backwards compatibility this behavior is disabled by default. The first version that supports the new behavior is CMake 3.7.2 (AFAICT) which is larger than the minimum supported CMake version. 

This PR sets the behavior to the old one for consistency across all supported CMake versions. Once the minimum updated cmake version is updated to 3.7.2 or newer, this behavior should be changed to the new one by setting this policy to `NEW`. 

---

Example warning:

```
CMake Warning (dev) at /share/cmake/Modules/CheckCSourceCompiles.cmake:98 (try_compile):
  Policy CMP0066 is not set: Honor per-config flags in try_compile()
  source-file signature.  Run "cmake --help-policy CMP0066" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  For compatibility with older versions of CMake, try_compile is not honoring
  caller config-specific compiler flags (e.g.  CMAKE_C_FLAGS_DEBUG) in the
  test project.
Call Stack (most recent call first):
  Configure.cmake:364 (CHECK_C_SOURCE_COMPILES)
  CMakeLists.txt:52 (include)
```