### PR TITLE
Add NEON32+VFPV4 helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(TARGET_IUTAVX2128 "iutavx2128")
 set(TARGET_IUTAVX512F "iutavx512f")
 set(TARGET_IUTADVSIMD "iutadvsimd")
 set(TARGET_IUTNEON32 "iutneon32")
+set(TARGET_IUTNEON32VFPV4 "iutneon32vfpv4")
 set(TARGET_IUTSVE "iutsve")
 set(TARGET_IUTVSX "iutvsx")
 # The target to generate LLVM bitcode only, available when SLEEF_ENABLE_LLVM_BITCODE is passed to cmake

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -25,7 +25,7 @@ endif()
 set(SLEEF_SUPPORTED_EXTENSIONS
   AVX512F AVX2 AVX2128 FMA4 AVX SSE4 SSE2 # x86
   ADVSIMD SVE				  # Aarch64
-  NEON32				  # Aarch32
+  NEON32 NEON32VFPV4			  # Aarch32
   VSX				          # PPC64
   CACHE STRING "List of SIMD architectures supported by libsleef."
   )
@@ -100,13 +100,16 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
   set(SLEEF_ARCH_AARCH32 ON CACHE INTERNAL "True for Aarch32 architecture.")
   set(COMPILER_SUPPORTS_NEON32 1)
+  set(COMPILER_SUPPORTS_NEON32VFPV4 1)
 
   set(SLEEF_HEADER_LIST
     NEON32_
     NEON32
+    NEON32VFPV4
   )
   command_arguments(HEADER_PARAMS_NEON32_   2 4 - float32x4_t int32x2_t int32x4_t __ARM_NEON__)
   command_arguments(HEADER_PARAMS_NEON32    2 4 - float32x4_t int32x2_t int32x4_t __ARM_NEON__ neon)
+  command_arguments(HEADER_PARAMS_NEON32VFPV4 2 4 - float32x4_t int32x2_t int32x4_t __ARM_NEON__ neonvfpv4)
 
   command_arguments(ALIAS_PARAMS_NEON32_SP -4 float32x4_t int32x4_t - neon)
   command_arguments(ALIAS_PARAMS_NEON32_DP 0)
@@ -134,6 +137,7 @@ command_arguments(RENAME_PARAMS_AVX2128        2 4 avx2128)
 command_arguments(RENAME_PARAMS_AVX512F        8 16 avx512f)
 command_arguments(RENAME_PARAMS_ADVSIMD        2 4 advsimd)
 command_arguments(RENAME_PARAMS_NEON32         2 4 neon)
+command_arguments(RENAME_PARAMS_NEON32VFPV4    2 4 neonvfpv4)
 command_arguments(RENAME_PARAMS_VSX            2 4 vsx)
 # The vector length parameters in SVE, for SP and DP, are chosen for
 # the smallest SVE vector size (128-bit). The name is generated using
@@ -180,6 +184,7 @@ set(CLANG_FLAGS_ENABLE_AVX2 "-mavx2;-mfma")
 set(CLANG_FLAGS_ENABLE_AVX2128 "-mavx2;-mfma")
 set(CLANG_FLAGS_ENABLE_AVX512F "-mavx512f")
 set(CLANG_FLAGS_ENABLE_NEON32 "--target=arm-linux-gnueabihf;-mcpu=cortex-a8")
+set(CLANG_FLAGS_ENABLE_NEON32VFPV4 "-march=armv7-a;-mfpu=neon-vfpv4")
 # Arm AArch64 vector extensions.
 set(CLANG_FLAGS_ENABLE_ADVSIMD "-march=armv8-a+simd")
 set(CLANG_FLAGS_ENABLE_SVE "-march=armv8-a+sve")

--- a/src/arch/helperneon32.h
+++ b/src/arch/helperneon32.h
@@ -15,7 +15,12 @@
 #define LOG2VECTLENSP 2
 #define VECTLENSP (1 << LOG2VECTLENSP)
 
+#if CONFIG == 4
+#define ISANAME "AARCH32 NEON-VFPV4"
+#define ENABLE_FMA_SP
+#else
 #define ISANAME "AARCH32 NEON"
+#endif
 #define DFTPRIORITY 10
 
 #define ENABLE_RECSQRT_SP
@@ -42,6 +47,9 @@ static INLINE int vtestallones_i_vo32(vopmask g) {
   uint32x2_t x1 = vpmin_u32(x0, x0);
   return vget_lane_u32(x1, 0);
 }
+
+static vfloat vloaduf(float *p) { return vld1q_f32(p); }
+static void vstoreuf(float *p, vfloat v) { vst1q_f32(p, v); }
 
 static vint2 vloadu_vi2_p(int32_t *p) { return vld1q_s32(p); }
 static void vstoreu_v_p_vi2(int32_t *p, vint2 v) { vst1q_s32(p, v); }
@@ -103,17 +111,53 @@ static INLINE vfloat vadd_vf_vf_vf(vfloat x, vfloat y) { return vaddq_f32(x, y);
 static INLINE vfloat vsub_vf_vf_vf(vfloat x, vfloat y) { return vsubq_f32(x, y); }
 static INLINE vfloat vmul_vf_vf_vf(vfloat x, vfloat y) { return vmulq_f32(x, y); }
 
+static INLINE vfloat vabs_vf_vf(vfloat f) { return vabsq_f32(f); }
+static INLINE vfloat vneg_vf_vf(vfloat f) { return vnegq_f32(f); }
+#if CONFIG == 4
+static INLINE vfloat vmla_vf_vf_vf_vf  (vfloat x, vfloat y, vfloat z) { return vfmaq_f32(z, x, y); }
+static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vfmsq_f32(z, x, y); }
+static INLINE vfloat vfma_vf_vf_vf_vf  (vfloat x, vfloat y, vfloat z) { return vfmaq_f32(z, x, y); }
+static INLINE vfloat vfmanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vfmsq_f32(z, x, y); }
+static INLINE vfloat vfmapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vneg_vf_vf(vfmanp_vf_vf_vf_vf(x, y, z)); }
+
+static INLINE vfloat vdiv_vf_vf_vf(vfloat x, vfloat y) {
+  float32x4_t t = vrecpeq_f32(y), u;
+  t = vmulq_f32(t, vrecpsq_f32(y, t));
+  t = vfmaq_f32(t, vfmsq_f32(vdupq_n_f32(1.0f), y, t), t);
+  u = vmulq_f32(x, t);
+  return vfmaq_f32(u, vfmsq_f32(x, y, u), t);
+}
+
+static INLINE vfloat vsqrt_vf_vf(vfloat d) {
+  float32x4_t x = vrsqrteq_f32(d);
+  x = vmulq_f32(x, vrsqrtsq_f32(d, vmulq_f32(x, x)));
+  x = vmulq_f32(x, vrsqrtsq_f32(d, vmulq_f32(x, x)));
+  float32x4_t u = vmulq_f32(x, d);
+  u = vfmaq_f32(u, vfmsq_f32(d, u, u), vmulq_f32(x, vdupq_n_f32(0.5)));
+  return (float32x4_t)vbicq_u32((uint32x4_t)u, vceqq_f32(d, vdupq_n_f32(0.0f)));
+}
+
+static INLINE vfloat vrec_vf_vf(vfloat y) {
+  float32x4_t t = vrecpeq_f32(y), u;
+  t = vmulq_f32(t, vrecpsq_f32(y, t));
+  t = vfmaq_f32(t, vfmsq_f32(vdupq_n_f32(1.0f), y, t), t);
+  return vfmaq_f32(t, vfmsq_f32(vdupq_n_f32(1.0f), y, t), t);
+}
+
+static INLINE vfloat vrecsqrt_vf_vf(vfloat d) {
+  float32x4_t x = vrsqrteq_f32(d);
+  x = vmulq_f32(x, vrsqrtsq_f32(d, vmulq_f32(x, x)));
+  return vfmaq_f32(x, vfmsq_f32(vdupq_n_f32(1), x, vmulq_f32(x, d)), vmulq_f32(x, vdupq_n_f32(0.5)));
+}
+#else
+static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vmlaq_f32(z, x, y); }
+static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vmlsq_f32(z, x, y); }
+
 static INLINE vfloat vdiv_vf_vf_vf(vfloat n, vfloat d) {
   float32x4_t x = vrecpeq_f32(d);
   x = vmulq_f32(x, vrecpsq_f32(d, x));
   float32x4_t t = vmulq_f32(n, x);
   return vmlsq_f32(vaddq_f32(t, t), vmulq_f32(t, x), d);
-}
-
-static INLINE vfloat vrec_vf_vf(vfloat d) {
-  float32x4_t x = vrecpeq_f32(d);
-  x = vmulq_f32(x, vrecpsq_f32(d, x));
-  return vmlsq_f32(vaddq_f32(x, x), vmulq_f32(x, x), d);
 }
 
 static INLINE vfloat vsqrt_vf_vf(vfloat d) {
@@ -124,16 +168,18 @@ static INLINE vfloat vsqrt_vf_vf(vfloat d) {
   return (float32x4_t)vbicq_u32((uint32x4_t)u, vceqq_f32(d, vdupq_n_f32(0.0f)));
 }
 
+static INLINE vfloat vrec_vf_vf(vfloat d) {
+  float32x4_t x = vrecpeq_f32(d);
+  x = vmulq_f32(x, vrecpsq_f32(d, x));
+  return vmlsq_f32(vaddq_f32(x, x), vmulq_f32(x, x), d);
+}
+
 static INLINE vfloat vrecsqrt_vf_vf(vfloat d) {
   float32x4_t x = vrsqrteq_f32(d);
   x = vmulq_f32(x, vrsqrtsq_f32(d, vmulq_f32(x, x)));
   return vmlaq_f32(x, vmlsq_f32(vdupq_n_f32(1), x, vmulq_f32(x, d)), vmulq_f32(x, vdupq_n_f32(0.5)));
 }
-
-static INLINE vfloat vabs_vf_vf(vfloat f) { return vabsq_f32(f); }
-static INLINE vfloat vneg_vf_vf(vfloat f) { return vnegq_f32(f); }
-static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vmlaq_f32(z, x, y); }
-static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vmlsq_f32(z, x, y); }
+#endif
 static INLINE vfloat vmax_vf_vf_vf(vfloat x, vfloat y) { return vmaxq_f32(x, y); }
 static INLINE vfloat vmin_vf_vf_vf(vfloat x, vfloat y) { return vminq_f32(x, y); }
 
@@ -156,9 +202,15 @@ static INLINE vint2 vxor_vi2_vi2_vi2(vint2 x, vint2 y) { return veorq_s32(x, y);
 static INLINE vint2 vand_vi2_vo_vi2(vopmask x, vint2 y) { return (vint2)vandq_u32(x, (vopmask)y); }
 static INLINE vint2 vandnot_vi2_vo_vi2(vopmask x, vint2 y) { return (vint2)vbicq_u32((vopmask)y, x); }
 
+#if defined(__clang__)
 #define vsll_vi2_vi2_i(x, c) vshlq_n_s32(x, c)
 #define vsrl_vi2_vi2_i(x, c) vreinterpretq_s32_u32(vshrq_n_u32(vreinterpretq_u32_s32(x), c))
 #define vsra_vi2_vi2_i(x, c) vshrq_n_s32(x, c)
+#else
+static INLINE vint2 vsll_vi2_vi2_i(vint2 x, int c) { return (int32x4_t) vshlq_n_u32((uint32x4_t)x, c); }
+static INLINE vint2 vsrl_vi2_vi2_i(vint2 x, int c) { return (int32x4_t) vshrq_n_u32((uint32x4_t)x, c); }
+static INLINE vint2 vsra_vi2_vi2_i(vint2 x, int c) { return vshrq_n_s32(x, c); }
+#endif
 
 static INLINE vopmask veq_vo_vi2_vi2(vint2 x, vint2 y) { return vceqq_s32(x, y); }
 static INLINE vopmask vgt_vo_vi2_vi2(vint2 x, vint2 y) { return vcgeq_s32(x, y); }
@@ -227,6 +279,7 @@ static INLINE vfloat vmlsubadd_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { retur
 
 static INLINE vfloat vrev21_vf_vf(vfloat d0) { return vrev64q_f32(d0); }
 static INLINE vfloat vreva2_vf_vf(vfloat d0) { return vcombine_f32(vget_high_f32(d0), vget_low_f32(d0)); }
+static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
 
 static INLINE void vstream_v_p_vf(float *ptr, vfloat v) { vstore_v_p_vf(ptr, v); }
 

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -82,7 +82,7 @@ macro(test_extension SIMD)
     add_test_iut(${TARGET_IUT${SIMD}})
     list(APPEND IUT_LIST ${TARGET_IUT${SIMD}})
 
-    if(LIB_MPFR AND NOT ${SIMD} STREQUAL NEON32 AND NOT MINGW)
+    if(LIB_MPFR AND NOT ${SIMD} STREQUAL NEON32 AND NOT ${SIMD} STREQUAL NEON32VFPV4 AND NOT MINGW)
       # Build tester2 SIMD
       string(TOLOWER ${SIMD} SCSIMD)
       foreach(P dp sp)

--- a/src/libm-tester/iutsimd.c
+++ b/src/libm-tester/iutsimd.c
@@ -110,6 +110,13 @@ typedef Sleef___m512_2 vfloat2;
 typedef Sleef_float32x4_t_2 vfloat2;
 #endif
 
+#ifdef ENABLE_NEON32VFPV4
+#define CONFIG 4
+#include "helperneon32.h"
+#include "renameneon32vfpv4.h"
+typedef Sleef_float32x4_t_2 vfloat2;
+#endif
+
 #ifdef ENABLE_ADVSIMD
 #define CONFIG 1
 #include "helperadvsimd.h"
@@ -397,7 +404,7 @@ int do_test(int argc, char **argv) {
 #ifdef ENABLE_SP
     k += 2;
 #endif
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
     k += 4; // flush to zero
 #elif defined(ENABLE_VECEXT)
     if (vcast_f_vf(xpowf(vcast_vf_f(0.5f), vcast_vf_f(140))) == 0) k += 4;

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -116,6 +116,14 @@ extern const float rempitabsp[];
 #endif
 #endif
 
+#ifdef ENABLE_NEON32VFPV4
+#define CONFIG 4
+#include "helperneon32.h"
+#ifdef DORENAME
+#include "renameneon32vfpv4.h"
+#endif
+#endif
+
 #ifdef ENABLE_VSX
 #define CONFIG 1
 #include "helperpower_128.h"
@@ -950,7 +958,7 @@ EXPORT CONST vfloat xatanf(vfloat d) {
 
   t = vreinterpret_vf_vm(vxor_vm_vm_vm(vand_vm_vo32_vm(veq_vo_vi2_vi2(vand_vi2_vi2_vi2(q, vcast_vi2_i(2)), vcast_vi2_i(2)), vreinterpret_vm_vf(vcast_vf_f(-0.0f))), vreinterpret_vm_vf(t)));
 
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
   t = vsel_vf_vo_vf_vf(visinf_vo_vf(d), vmulsign_vf_vf_vf(vcast_vf_f(1.5874010519681994747517056f), d), t);
 #endif
 
@@ -1237,7 +1245,7 @@ static INLINE CONST vfloat expm1fk(vfloat d) {
   return u;
 }
 
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
 EXPORT CONST vfloat xsqrtf_u35(vfloat d) {
   vfloat e = vreinterpret_vf_vi2(vadd_vi2_vi2_vi2(vcast_vi2_i(0x20000000), vand_vi2_vi2_vi2(vcast_vi2_i(0x7f000000), vsrl_vi2_vi2_i(vreinterpret_vi2_vf(d), 1))));
   vfloat m = vreinterpret_vf_vi2(vadd_vi2_vi2_vi2(vcast_vi2_i(0x3f000000), vand_vi2_vi2_vi2(vcast_vi2_i(0x01ffffff), vreinterpret_vi2_vf(d))));
@@ -1468,7 +1476,7 @@ EXPORT CONST vfloat xpowf(vfloat x, vfloat y) {
   vopmask yisodd = vand_vo_vo_vo(vand_vo_vo_vo(veq_vo_vi2_vi2(vand_vi2_vi2_vi2(vtruncate_vi2_vf(y), vcast_vi2_i(1)), vcast_vi2_i(1)), yisint),
 				 vlt_vo_vf_vf(vabs_vf_vf(y), vcast_vf_f(1 << 24)));
 
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
   yisodd = vandnot_vm_vo32_vm(visinf_vo_vf(y), yisodd);
 #endif
 
@@ -2132,7 +2140,7 @@ EXPORT CONST vfloat xfmodf(vfloat x, vfloat y) {
   de = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(de, vcast_vf_f(1ULL << 25)), de);
   s  = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(s , vcast_vf_f(1.0f / (1ULL << 25))), s);
   vfloat rde = vtoward0f(vrec_vf_vf(de));
-#ifdef ENABLE_NEON32
+#if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
   rde = vtoward0f(rde);
 #endif
   vfloat2 r = vcast_vf2_vf_vf(nu, vcast_vf_f(0));
@@ -2473,6 +2481,7 @@ EXPORT CONST vfloat __tgammaf_u1_finite(vfloat)         __attribute__((weak, ali
 // gcc -DENABLE_MAIN -Wno-attributes -I../common -I../arch -DENABLE_AVX2 -mavx2 -mfma sleefsimdsp.c ../common/common.c -lm
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 int main(int argc, char **argv) {
   vfloat vf1 = vcast_vf_f(atof(argv[1]));
   //vfloat vf2 = vcast_vf_f(atof(argv[2]));


### PR DESCRIPTION
This patch adds NEON32+VFPV4 helper which has FMA support.

VFPV4 is supported on most of new 32-bit ARM CPUs, and the computation of some functions is much faster.
This patch does not include a dispatcher.