### PR TITLE
[Determinism] Add purecscalar and noFMA helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,11 @@ matrix:
         - ENABLE_DOCKER="true"
 
 before_install:
-     - export PATH=$PATH:/usr/bin:${TRAVIS_BUILD_DIR}/sde-external-8.12.0-2017-10-23-lin
+     - export PATH=$PATH:/usr/bin
      - cd ${TRAVIS_BUILD_DIR}
      - chmod +x ${TRAVIS_BUILD_DIR}/travis/*.sh
      - if [[ "${ENABLE_DOCKER}" == "true" ]]; then ${TRAVIS_BUILD_DIR}/travis/setupdocker.sh; fi
      - if [[ "${ENABLE_DOCKER}" == "true" ]]; then docker exec xenial /build/travis/before_install.${LABEL}.sh; fi
-     - if [[ ( "${LABEL}" == "x86_64-gcc"   ) && ( "${SDE_URL}" != "" ) ]]; then wget -q ${SDE_URL}; fi
-     - if [[ ( "${LABEL}" == "x86_64-clang" ) && ( "${SDE_URL}" != "" ) ]]; then wget -q ${SDE_URL}; fi
      - if [[ "${ENABLE_DOCKER}" != "true" ]]; then ${TRAVIS_BUILD_DIR}/travis/before_install.${LABEL}.sh; fi
 
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,18 +72,6 @@ set(TARGET_HEADERS "headers")
 # Defined in src/libm-tester/CMakeLists.txt via command add_executable
 set(TARGET_TESTER "tester")
 set(TARGET_IUT "iut")
-set(TARGET_IUTSSE2 "iutsse2")
-set(TARGET_IUTSSE4 "iutsse4")
-set(TARGET_IUTAVX "iutavx")
-set(TARGET_IUTFMA4 "iutfma4")
-set(TARGET_IUTAVX2 "iutavx2")
-set(TARGET_IUTAVX2128 "iutavx2128")
-set(TARGET_IUTAVX512F "iutavx512f")
-set(TARGET_IUTADVSIMD "iutadvsimd")
-set(TARGET_IUTNEON32 "iutneon32")
-set(TARGET_IUTNEON32VFPV4 "iutneon32vfpv4")
-set(TARGET_IUTSVE "iutsve")
-set(TARGET_IUTVSX "iutvsx")
 # The target to generate LLVM bitcode only, available when SLEEF_ENABLE_LLVM_BITCODE is passed to cmake
 set(TARGET_LLVM_BITCODE "llvm-bitcode")
 # Generates the helper executable file mkrename needed to write the sleef header

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,6 +153,24 @@ pipeline {
 			 '''
             	     }
 		 }
+
+                stage('AArch32') {
+            	     agent { label 'aarch32' }
+            	     steps {
+	    	     	 sh '''
+                	 echo "aarch32 on" `hostname`
+			 rm -rf build
+ 			 mkdir build
+			 cd build
+			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 ..
+			 make -j 4 all
+			 export OMP_WAIT_POLICY=passive
+		         export CTEST_OUTPUT_ON_FAILURE=TRUE
+		         ctest -j 4
+		         make install
+			 '''
+            	     }
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ pipeline {
                 	 echo "FMA4 on" `hostname`
 			 export PATH=$PATH:/opt/local/bin:/opt/bin:/opt/sde-external-8.16.0-2018-01-30-lin
 			 export LD_LIBRARY_PATH=/opt/local/lib:/opt/lib
+		         export CC=gcc-8.2.0
 			 rm -rf build
  			 mkdir build
 			 cd build

--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -540,6 +540,7 @@ static INLINE void vsscatter2_v_p_i_i_vd(double *ptr, int offset, int step, vdou
 
 static INLINE vfloat vrev21_vf_vf(vfloat d0) { return _mm256_shuffle_ps(d0, d0, (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0)); }
 static INLINE vfloat vreva2_vf_vf(vfloat d0) { d0 = _mm256_permute2f128_ps(d0, d0, 1); return _mm256_shuffle_ps(d0, d0, (1 << 6) | (0 << 4) | (3 << 2) | (2 << 0)); }
+static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
 
 static INLINE void vstream_v_p_vf(float *ptr, vfloat v) { _mm256_stream_ps(ptr, v); }
 

--- a/src/arch/helperavx2.h
+++ b/src/arch/helperavx2.h
@@ -399,6 +399,7 @@ static INLINE void vsscatter2_v_p_i_i_vd(double *ptr, int offset, int step, vdou
 
 static INLINE vfloat vrev21_vf_vf(vfloat d0) { return _mm256_shuffle_ps(d0, d0, (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0)); }
 static INLINE vfloat vreva2_vf_vf(vfloat d0) { d0 = _mm256_permute2f128_ps(d0, d0, 1); return _mm256_shuffle_ps(d0, d0, (1 << 6) | (0 << 4) | (3 << 2) | (2 << 0)); }
+static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
 
 static INLINE void vstream_v_p_vf(float *ptr, vfloat v) { _mm256_stream_ps(ptr, v); }
 

--- a/src/arch/helperavx2_128.h
+++ b/src/arch/helperavx2_128.h
@@ -372,6 +372,7 @@ static INLINE void vsscatter2_v_p_i_i_vd(double *ptr, int offset, int step, vdou
 
 static INLINE vfloat vrev21_vf_vf(vfloat d0) { return _mm_shuffle_ps(d0, d0, (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0)); }
 static INLINE vfloat vreva2_vf_vf(vfloat d0) { return _mm_shuffle_ps(d0, d0, (1 << 6) | (0 << 4) | (3 << 2) | (2 << 0)); }
+static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
 
 static INLINE void vstream_v_p_vf(float *ptr, vfloat v) { _mm_stream_ps(ptr, v); }
 

--- a/src/arch/helperavx512f.h
+++ b/src/arch/helperavx512f.h
@@ -1,9 +1,9 @@
-//          Copyright Naoki Shibata 2010 - 2017.
+//          Copyright Naoki Shibata 2010 - 2018.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#if CONFIG == 1
+#if CONFIG == 1 || CONFIG == 2
 
 #ifndef __AVX512F__
 #error Please specify -mavx512f.
@@ -16,15 +16,18 @@
 #define ENABLE_DP
 #define LOG2VECTLENDP 3
 #define VECTLENDP (1 << LOG2VECTLENDP)
-#define ENABLE_FMA_DP
 
 #define ENABLE_SP
 #define LOG2VECTLENSP (LOG2VECTLENDP+1)
 #define VECTLENSP (1 << LOG2VECTLENSP)
+
+#if CONFIG == 1
+#define ENABLE_FMA_DP
 #define ENABLE_FMA_SP
+#define SPLIT_KERNEL
+#endif
 
 #define FULL_FP_ROUNDING
-#define SPLIT_KERNEL
 #define ACCURATE_SQRT
 
 #if defined(_MSC_VER)
@@ -64,6 +67,15 @@ static INLINE int vavailability_i(int name) {
 }
 #define ISANAME "AVX512F"
 #define DFTPRIORITY 30
+#endif
+
+#if CONFIG == 2 && defined(__AVX512F__)
+static INLINE int vavailability_i(int name) {
+  int d = cpuSupportsAVX512F();
+  return d ? 3 : 0;
+}
+#define ISANAME "AVX512FNOFMA"
+#define DFTPRIORITY 0
 #endif
 
 static INLINE void vprefetch_v_p(const void *ptr) { _mm_prefetch(ptr, _MM_HINT_T0); }
@@ -162,11 +174,17 @@ static INLINE vdouble vrec_vd_vd(vdouble x) { return _mm512_div_pd(_mm512_set1_p
 static INLINE vdouble vsqrt_vd_vd(vdouble x) { return _mm512_sqrt_pd(x); }
 static INLINE vdouble vabs_vd_vd(vdouble d) { return vreinterpret_vd_vm(_mm512_andnot_si512(vreinterpret_vm_vd(_mm512_set1_pd(-0.0)), vreinterpret_vm_vd(d))); }
 static INLINE vdouble vneg_vd_vd(vdouble d) { return vreinterpret_vd_vm(_mm512_xor_si512(vreinterpret_vm_vd(_mm512_set1_pd(-0.0)), vreinterpret_vm_vd(d))); }
+static INLINE vdouble vmax_vd_vd_vd(vdouble x, vdouble y) { return _mm512_max_pd(x, y); }
+static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) { return _mm512_min_pd(x, y); }
+
+#if CONFIG == 1
 static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm512_fmadd_pd(x, y, z); }
 static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm512_fmsub_pd(x, y, z); }
 static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm512_fnmadd_pd(x, y, z); }
-static INLINE vdouble vmax_vd_vd_vd(vdouble x, vdouble y) { return _mm512_max_pd(x, y); }
-static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) { return _mm512_min_pd(x, y); }
+#else
+static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vadd_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
+static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vsub_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
+#endif
 
 static INLINE vdouble vfma_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm512_fmadd_pd(x, y, z); }
 static INLINE vdouble vfmapp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm512_fmadd_pd(x, y, z); }
@@ -341,11 +359,17 @@ static INLINE vfloat vrec_vf_vf(vfloat x) { return vdiv_vf_vf_vf(vcast_vf_f(1.0f
 static INLINE vfloat vsqrt_vf_vf(vfloat x) { return _mm512_sqrt_ps(x); }
 static INLINE vfloat vabs_vf_vf(vfloat f) { return vreinterpret_vf_vm(vandnot_vm_vm_vm(vreinterpret_vm_vf(vcast_vf_f(-0.0f)), vreinterpret_vm_vf(f))); }
 static INLINE vfloat vneg_vf_vf(vfloat d) { return vreinterpret_vf_vm(vxor_vm_vm_vm(vreinterpret_vm_vf(vcast_vf_f(-0.0f)), vreinterpret_vm_vf(d))); }
+static INLINE vfloat vmax_vf_vf_vf(vfloat x, vfloat y) { return _mm512_max_ps(x, y); }
+static INLINE vfloat vmin_vf_vf_vf(vfloat x, vfloat y) { return _mm512_min_ps(x, y); }
+
+#if CONFIG == 1
 static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return _mm512_fmadd_ps(x, y, z); }
 static INLINE vfloat vmlapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return _mm512_fmsub_ps(x, y, z); }
 static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return _mm512_fnmadd_ps(x, y, z); }
-static INLINE vfloat vmax_vf_vf_vf(vfloat x, vfloat y) { return _mm512_max_ps(x, y); }
-static INLINE vfloat vmin_vf_vf_vf(vfloat x, vfloat y) { return _mm512_min_ps(x, y); }
+#else
+static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vadd_vf_vf_vf(vmul_vf_vf_vf(x, y), z); }
+static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vsub_vf_vf_vf(z, vmul_vf_vf_vf(x, y)); }
+#endif
 
 static INLINE vfloat vfma_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return _mm512_fmadd_ps(x, y, z); }
 static INLINE vfloat vfmapp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return _mm512_fmadd_ps(x, y, z); }
@@ -484,6 +508,7 @@ static INLINE void vsscatter2_v_p_i_i_vd(double *ptr, int offset, int step, vdou
 //
 
 static INLINE vfloat vrev21_vf_vf(vfloat vf) { return _mm512_permute_ps(vf, 0xb1); }
+static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
 
 static INLINE vfloat vreva2_vf_vf(vfloat vf) {
   return vreinterpret_vf_vm(_mm512_permutexvar_epi32(_mm512_set_epi32(1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14), vreinterpret_vm_vf(vf)));

--- a/src/arch/helperpower_128.h
+++ b/src/arch/helperpower_128.h
@@ -3,7 +3,7 @@
 //    (See accompanying file LICENSE.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#if CONFIG == 1
+#if CONFIG == 1 || CONFIG == 2
 
 #ifndef __VSX__
 #error Please specify -mvsx.
@@ -16,16 +16,19 @@
 #define ENABLE_DP
 #define LOG2VECTLENDP 1
 #define VECTLENDP (1 << LOG2VECTLENDP)
-#define ENABLE_FMA_DP
 
 #define ENABLE_SP
 #define LOG2VECTLENSP (LOG2VECTLENDP+1)
 #define VECTLENSP (1 << LOG2VECTLENSP)
+
+#if CONFIG == 1
+#define ENABLE_FMA_DP
 #define ENABLE_FMA_SP
+//#define SPLIT_KERNEL // Benchmark comparison is needed to determine whether this option should be enabled.
+#endif
 
 #define ACCURATE_SQRT
 #define FULL_FP_ROUNDING
-//#define SPLIT_KERNEL // Benchmark comparison is needed to determine whether this option should be enabled.
 
 #include <altivec.h>
 
@@ -174,6 +177,7 @@ static INLINE vdouble vrev21_vd_vd(vdouble vd) { return vec_perm(vd, vd, (vector
 static INLINE vdouble vreva2_vd_vd(vdouble vd) { return vd; }
 static INLINE vfloat vrev21_vf_vf(vfloat vf) { return vec_perm(vf, vf, (vector unsigned char)(4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11)); }
 static INLINE vfloat vreva2_vf_vf(vfloat vf) { return vec_perm(vf, vf, (vector unsigned char)(8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7)); }
+static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
 
 static INLINE vopmask veq64_vo_vm_vm(vmask x, vmask y) {
   vopmask o = vec_cmpeq(x, y);
@@ -199,14 +203,20 @@ static INLINE vfloat vnegpos_vf_vf(vfloat d) { return vreinterpret_vf_vm(vxor_vm
 //
 
 static INLINE vdouble vabs_vd_vd(vdouble d) { return vec_abs(d); }
-static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_madd(x, y, z); }
-static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_msub(x, y, z); }
 static INLINE vdouble vmax_vd_vd_vd(vdouble x, vdouble y) { return vec_max(x, y); }
 static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) { return vec_min(x, y); }
 static INLINE vdouble vsubadd_vd_vd_vd(vdouble x, vdouble y) { return vadd_vd_vd_vd(x, vnegpos_vd_vd(y)); }
-static INLINE vdouble vmlsubadd_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vmla_vd_vd_vd_vd(x, y, vnegpos_vd_vd(z)); }
 static INLINE vdouble vsqrt_vd_vd(vdouble d) { return vec_sqrt(d); }
 
+#if CONFIG == 1
+static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_madd(x, y, z); }
+static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_msub(x, y, z); }
+#else
+static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vadd_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
+static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vsub_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
+#endif
+
+static INLINE vdouble vmlsubadd_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vmla_vd_vd_vd_vd(x, y, vnegpos_vd_vd(z)); }
 static INLINE vdouble vfma_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_madd(x, y, z); }
 static INLINE vdouble vfmapp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_madd(x, y, z); }
 static INLINE vdouble vfmapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_msub(x, y, z); }
@@ -214,14 +224,20 @@ static INLINE vdouble vfmanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { retu
 static INLINE vdouble vfmann_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_nmadd(x, y, z); }
 
 static INLINE vfloat vabs_vf_vf(vfloat f) { return vec_abs(f); }
-static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_madd(x, y, z); }
-static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_nmsub(x, y, z); }
 static INLINE vfloat vmax_vf_vf_vf(vfloat x, vfloat y) { return vec_max(x, y); }
 static INLINE vfloat vmin_vf_vf_vf(vfloat x, vfloat y) { return vec_min(x, y); }
 static INLINE vfloat vsubadd_vf_vf_vf(vfloat x, vfloat y) { return vadd_vf_vf_vf(x, vnegpos_vf_vf(y)); }
-static INLINE vfloat vmlsubadd_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vmla_vf_vf_vf_vf(x, y, vnegpos_vf_vf(z)); }
 static INLINE vfloat vsqrt_vf_vf(vfloat d) { return vec_sqrt(d); }
 
+#if CONFIG == 1
+static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_madd(x, y, z); }
+static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_nmsub(x, y, z); }
+#else
+static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vadd_vf_vf_vf(vmul_vf_vf_vf(x, y), z); }
+static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vsub_vf_vf_vf(z, vmul_vf_vf_vf(x, y)); }
+#endif
+
+static INLINE vfloat vmlsubadd_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vmla_vf_vf_vf_vf(x, y, vnegpos_vf_vf(z)); }
 static INLINE vfloat vfma_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_madd(x, y, z); }
 static INLINE vfloat vfmapp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_madd(x, y, z); }
 static INLINE vfloat vfmapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_msub(x, y, z); }

--- a/src/arch/helperpurec.h
+++ b/src/arch/helperpurec.h
@@ -229,7 +229,7 @@ static INLINE vdouble vrint_vd_vd(vdouble vd) { return vcast_vd_vi(vrint_vi_vd(v
 static INLINE vint vcast_vi_i(int j) { vint ret; for(int i=0;i<VECTLENDP;i++) ret.i[i] = j; return ret; }
 
 static INLINE vopmask veq64_vo_vm_vm(vmask x, vmask y) { vopmask ret; for(int i=0;i<VECTLENDP;i++) ret.x[i] = x.x[i] == y.x[i] ? -1 : 0; return ret; }
-static INLINE vmask vadd64_vo_vm_vm(vmask x, vmask y) { vmask ret; for(int i=0;i<VECTLENDP;i++) ret.x[i] = x.x[i] + y.x[i]; return ret; }
+static INLINE vmask vadd64_vm_vm_vm(vmask x, vmask y) { vmask ret; for(int i=0;i<VECTLENDP;i++) ret.x[i] = x.x[i] + y.x[i]; return ret; }
 
 //
 
@@ -340,6 +340,8 @@ static INLINE vmask vreinterpret_vm_vf(vfloat vf) { union { vfloat vf; vmask vm;
 static INLINE vfloat vreinterpret_vf_vm(vmask vm) { union { vfloat vf; vmask vm; } cnv; cnv.vm = vm; return cnv.vf; }
 static INLINE vfloat vreinterpret_vf_vi2(vint2 vi) { union { vfloat vf; vint2 vi2; } cnv; cnv.vi2 = vi; return cnv.vf; }
 static INLINE vint2 vreinterpret_vi2_vf(vfloat vf) { union { vfloat vf; vint2 vi2; } cnv; cnv.vf = vf; return cnv.vi2; }
+
+static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
 
 static INLINE vfloat vadd_vf_vf_vf(vfloat x, vfloat y) { vfloat ret; for(int i=0;i<VECTLENSP;i++) ret.f[i] = x.f[i] + y.f[i]; return ret; }
 static INLINE vfloat vsub_vf_vf_vf(vfloat x, vfloat y) { vfloat ret; for(int i=0;i<VECTLENSP;i++) ret.f[i] = x.f[i] - y.f[i]; return ret; }

--- a/src/arch/helperpurec_scalar.h
+++ b/src/arch/helperpurec_scalar.h
@@ -1,0 +1,369 @@
+//          Copyright Naoki Shibata 2010 - 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <stdint.h>
+
+#ifndef ENABLE_BUILTIN_MATH
+#include <math.h>
+
+#define SQRT sqrt
+#define SQRTF sqrtf
+#define FMA fma
+#define FMAF fmaf
+#define RINT rint
+#define RINTF rintf
+#define TRUNC trunc
+#define TRUNCF truncf
+
+#else
+
+#define SQRT __builtin_sqrt
+#define SQRTF __builtin_sqrtf
+#define FMA __builtin_fma
+#define FMAF __builtin_fmaf
+#define RINT __builtin_rint
+#define RINTF __builtin_rintf
+#define TRUNC __builtin_trunc
+#define TRUNCF __builtin_truncf
+
+#endif
+
+#include "misc.h"
+
+#ifndef CONFIG
+#error CONFIG macro not defined
+#endif
+
+#define ENABLE_DP
+#define ENABLE_SP
+
+#if CONFIG == 2
+#define ENABLE_FMA_DP
+#define ENABLE_FMA_SP
+
+#if defined(__AVX2__) || defined(__aarch64__) || defined(__arm__) || defined(__powerpc64__)
+#ifndef FP_FAST_FMA
+#define FP_FAST_FMA
+#endif
+#ifndef FP_FAST_FMAF
+#define FP_FAST_FMAF
+#endif
+#endif
+
+#if !defined(FP_FAST_FMA) || !defined(FP_FAST_FMAF)
+#error FP_FAST_FMA or FP_FAST_FMAF not defined
+#endif
+#define ISANAME "Pure C scalar with FMA"
+
+#else // #if CONFIG == 2
+#define ISANAME "Pure C scalar"
+#endif // #if CONFIG == 2
+
+#define LOG2VECTLENDP 0
+#define VECTLENDP (1 << LOG2VECTLENDP)
+#define LOG2VECTLENSP 0
+#define VECTLENSP (1 << LOG2VECTLENSP)
+
+#define ACCURATE_SQRT
+
+#if defined(__SSE4_1__) || defined(__aarch64__)
+#define FULL_FP_ROUNDING
+#endif
+
+#define DFTPRIORITY LOG2VECTLENDP
+
+typedef union {
+  uint32_t u[2];
+  int32_t i[2];
+  uint64_t x;
+  double d;
+  float f;
+  int64_t i2;
+} versatileVector;
+
+typedef uint64_t vmask;
+typedef uint32_t vopmask;
+typedef double vdouble;
+typedef int32_t vint;
+typedef float vfloat;
+typedef int64_t vint2;
+
+//
+
+static INLINE int vavailability_i(int name) { return -1; }
+static INLINE void vprefetch_v_p(const void *ptr) {}
+
+static INLINE int vtestallones_i_vo64(vopmask g) { return g; }
+static INLINE int vtestallones_i_vo32(vopmask g) { return g; }
+
+//
+
+static vint2 vloadu_vi2_p(int32_t *p) { return *p; }
+static void vstoreu_v_p_vi2(int32_t *p, vint2 v) { *p = v; }
+static vint vloadu_vi_p(int32_t *p) { return *p; }
+static void vstoreu_v_p_vi(int32_t *p, vint v) { *p = v; }
+
+//
+
+static INLINE vopmask vcast_vo32_vo64(vopmask m) { return m; }
+static INLINE vopmask vcast_vo64_vo32(vopmask m) { return m; }
+static INLINE vmask vcast_vm_i_i(int h, int l) { return (((uint64_t)h) << 32) | (uint32_t)l; }
+
+static INLINE vint2 vcastu_vi2_vi(vint vi) { return ((int64_t)vi) << 32; }
+static INLINE vint vcastu_vi_vi2(vint2 vi2) { return vi2 >> 32; }
+
+static INLINE vint2 vrev21_vi2_vi2(vint2 vi2) { return (((uint64_t)vi2) << 32) | (((uint64_t)vi2) >> 32); }
+
+static INLINE vdouble vcast_vd_d(double d) { return d; }
+
+//
+
+static INLINE vopmask vand_vo_vo_vo   (vopmask x, vopmask y) { return x & y; }
+static INLINE vopmask vandnot_vo_vo_vo(vopmask x, vopmask y) { return y & ~x; }
+static INLINE vopmask vor_vo_vo_vo    (vopmask x, vopmask y) { return x | y; }
+static INLINE vopmask vxor_vo_vo_vo   (vopmask x, vopmask y) { return x ^ y; }
+
+static INLINE vmask vand_vm_vm_vm     (vmask x, vmask y)     { return x & y; }
+static INLINE vmask vandnot_vm_vm_vm  (vmask x, vmask y)     { return y & ~x; }
+static INLINE vmask vor_vm_vm_vm      (vmask x, vmask y)     { return x | y; }
+static INLINE vmask vxor_vm_vm_vm     (vmask x, vmask y)     { return x ^ y; }
+
+static INLINE vmask vcast_vm_vo(vopmask o) { return (vmask)o | (((vmask)o) << 32); }
+
+static INLINE vmask vand_vm_vo64_vm(vopmask x, vmask y)      { return vcast_vm_vo(x) & y; }
+static INLINE vmask vandnot_vm_vo64_vm(vopmask x, vmask y)   { return y & ~vcast_vm_vo(x); }
+static INLINE vmask vor_vm_vo64_vm(vopmask x, vmask y)       { return vcast_vm_vo(x) | y; }
+static INLINE vmask vxor_vm_vo64_vm(vopmask x, vmask y)      { return vcast_vm_vo(x) ^ y; }
+
+static INLINE vmask vand_vm_vo32_vm(vopmask x, vmask y)      { return vcast_vm_vo(x) & y; }
+static INLINE vmask vandnot_vm_vo32_vm(vopmask x, vmask y)   { return y & ~vcast_vm_vo(x); }
+static INLINE vmask vor_vm_vo32_vm(vopmask x, vmask y)       { return vcast_vm_vo(x) | y; }
+static INLINE vmask vxor_vm_vo32_vm(vopmask x, vmask y)      { return vcast_vm_vo(x) ^ y; }
+
+//
+
+static INLINE vdouble vsel_vd_vo_vd_vd   (vopmask o, vdouble x, vdouble y) { return o ? x : y; }
+static INLINE vint2   vsel_vi2_vo_vi2_vi2(vopmask o, vint2 x, vint2 y)     { return o ? x : y; }
+
+static INLINE CONST vdouble vsel_vd_vo_d_d(vopmask o, double v1, double v0) { return o ? v1 : v0; }
+
+static INLINE vdouble vsel_vd_vo_vo_d_d_d(vopmask o0, vopmask o1, double d0, double d1, double d2) {
+  return vsel_vd_vo_vd_vd(o0, vcast_vd_d(d0), vsel_vd_vo_d_d(o1, d1, d2));
+}
+
+static INLINE vdouble vsel_vd_vo_vo_vo_d_d_d_d(vopmask o0, vopmask o1, vopmask o2, double d0, double d1, double d2, double d3) {
+  return vsel_vd_vo_vd_vd(o0, vcast_vd_d(d0), vsel_vd_vo_vd_vd(o1, vcast_vd_d(d1), vsel_vd_vo_d_d(o2, d2, d3)));
+}
+
+static INLINE vdouble vcast_vd_vi(vint vi) { return vi; }
+static INLINE vint vcast_vi_i(int j) { return j; }
+
+#ifdef FULL_FP_ROUNDING
+static INLINE vint vrint_vi_vd(vdouble d) { return (int32_t)RINT(d); }
+static INLINE vdouble vrint_vd_vd(vdouble vd) { return RINT(vd); }
+static INLINE vdouble vtruncate_vd_vd(vdouble vd) { return TRUNC(vd); }
+static INLINE vint vtruncate_vi_vd(vdouble vd) { return (int32_t)TRUNC(vd); }
+#else
+static INLINE vint vrint_vi_vd(vdouble a) {
+  a += a > 0 ? 0.5 : -0.5;
+  versatileVector v = { .d = a }; v.x -= 1 & (int)a;
+  return (int32_t)v.d;
+}
+static INLINE vdouble vrint_vd_vd(vdouble vd) { return vcast_vd_vi(vrint_vi_vd(vd)); }
+static INLINE vint vtruncate_vi_vd(vdouble vd) { return vd; }
+static INLINE vdouble vtruncate_vd_vd(vdouble vd) { return vcast_vd_vi(vtruncate_vi_vd(vd)); }
+#endif
+
+static INLINE vopmask veq64_vo_vm_vm(vmask x, vmask y) { return x == y ? ~(uint32_t)0 : 0; }
+static INLINE vmask vadd64_vm_vm_vm(vmask x, vmask y) { return x + y; }
+
+//
+
+static INLINE vmask vreinterpret_vm_vd(vdouble vd) { union { vdouble vd; vmask vm; } cnv; cnv.vd = vd; return cnv.vm; }
+static INLINE vint2 vreinterpret_vi2_vd(vdouble vd) { union { vdouble vd; vint2 vi2; } cnv; cnv.vd = vd; return cnv.vi2; }
+static INLINE vdouble vreinterpret_vd_vi2(vint2 vi) { union { vint2 vi2; vdouble vd; } cnv; cnv.vi2 = vi; return cnv.vd; }
+static INLINE vdouble vreinterpret_vd_vm(vmask vm) { union { vmask vm; vdouble vd; } cnv; cnv.vm = vm; return cnv.vd; }
+
+static INLINE vdouble vadd_vd_vd_vd(vdouble x, vdouble y) { return x + y; }
+static INLINE vdouble vsub_vd_vd_vd(vdouble x, vdouble y) { return x - y; }
+static INLINE vdouble vmul_vd_vd_vd(vdouble x, vdouble y) { return x * y; }
+static INLINE vdouble vdiv_vd_vd_vd(vdouble x, vdouble y) { return x / y; }
+static INLINE vdouble vrec_vd_vd(vdouble x)               { return 1 / x; }
+
+static INLINE vdouble vabs_vd_vd(vdouble d) { versatileVector v = { .d = d }; v.x &= 0x7fffffffffffffffULL; return v.d; }
+static INLINE vdouble vneg_vd_vd(vdouble d) { return -d; }
+
+static INLINE vdouble vmax_vd_vd_vd(vdouble x, vdouble y) { return x > y ? x : y; }
+static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) { return x < y ? x : y; }
+
+#ifndef ENABLE_FMA_DP
+static INLINE vdouble vmla_vd_vd_vd_vd  (vdouble x, vdouble y, vdouble z) { return x * y + z; }
+static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return x * y - z; }
+#else
+static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(x, y, z); }
+static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(x, y, -z); }
+static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(-x, y, z); }
+static INLINE vdouble vfma_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(x, y, z); }
+static INLINE vdouble vfmapp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(x, y, z); }
+static INLINE vdouble vfmapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(x, y, -z); }
+static INLINE vdouble vfmanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(-x, y, z); }
+static INLINE vdouble vfmann_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(-x, y, -z); }
+#endif
+
+static INLINE vopmask veq_vo_vd_vd(vdouble x, vdouble y)  { return x == y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vneq_vo_vd_vd(vdouble x, vdouble y) { return x != y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vlt_vo_vd_vd(vdouble x, vdouble y)  { return x <  y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vle_vo_vd_vd(vdouble x, vdouble y)  { return x <= y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vgt_vo_vd_vd(vdouble x, vdouble y)  { return x >  y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vge_vo_vd_vd(vdouble x, vdouble y)  { return x >= y ? ~(uint32_t)0 : 0; }
+
+static INLINE vint vadd_vi_vi_vi(vint x, vint y) { return x + y; }
+static INLINE vint vsub_vi_vi_vi(vint x, vint y) { return x - y; }
+static INLINE vint vneg_vi_vi   (vint x)         { return   - x; }
+
+static INLINE vint vand_vi_vi_vi(vint x, vint y)    { return x & y; }
+static INLINE vint vandnot_vi_vi_vi(vint x, vint y) { return y & ~x; }
+static INLINE vint vor_vi_vi_vi(vint x, vint y)     { return x | y; }
+static INLINE vint vxor_vi_vi_vi(vint x, vint y)    { return x ^ y; }
+
+static INLINE vint vand_vi_vo_vi(vopmask x, vint y)    { return x & y; }
+static INLINE vint vandnot_vi_vo_vi(vopmask x, vint y) { return y & ~x; }
+
+static INLINE vint vsll_vi_vi_i(vint x, int c) { return (uint32_t)x << c; }
+static INLINE vint vsrl_vi_vi_i(vint x, int c) { return (uint32_t)x >> c; }
+static INLINE vint vsra_vi_vi_i(vint x, int c) { return x >> c; }
+
+static INLINE vopmask veq_vo_vi_vi(vint x, vint y) { return x == y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vgt_vo_vi_vi(vint x, vint y) { return x >  y ? ~(uint32_t)0 : 0; }
+
+static INLINE vint vsel_vi_vo_vi_vi(vopmask m, vint x, vint y) { return m ? x : y; }
+
+static INLINE vopmask visinf_vo_vd(vdouble d)  { return (d == SLEEF_INFINITY || d == -SLEEF_INFINITY) ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vispinf_vo_vd(vdouble d) { return d == SLEEF_INFINITY ? ~(uint32_t)0 : 0; }
+static INLINE vopmask visminf_vo_vd(vdouble d) { return d == -SLEEF_INFINITY ? ~(uint32_t)0 : 0; }
+static INLINE vopmask visnan_vo_vd(vdouble d)  { return d != d ? ~(uint32_t)0 : 0; }
+
+static INLINE vdouble vsqrt_vd_vd(vdouble d) { return SQRT(d); }
+static INLINE vfloat vsqrt_vf_vf(vfloat x) { return SQRTF(x); }
+
+static INLINE double vcast_d_vd(vdouble v) { return v; }
+
+static INLINE vdouble vload_vd_p(const double *ptr) { return *ptr; }
+static INLINE vdouble vloadu_vd_p(const double *ptr) { return *ptr; }
+static INLINE vdouble vgather_vd_p_vi(const double *ptr, vint vi) { return ptr[vi]; }
+
+static INLINE void vstore_v_p_vd(double *ptr, vdouble v) { *ptr = v; }
+static INLINE void vstoreu_v_p_vd(double *ptr, vdouble v) { *ptr = v; }
+static INLINE void vstream_v_p_vd(double *ptr, vdouble v) { *ptr = v; }
+
+//
+
+static INLINE vint2 vcast_vi2_vm(vmask vm) { union { vint2 vi2; vmask vm; } cnv; cnv.vm = vm; return cnv.vi2; }
+static INLINE vmask vcast_vm_vi2(vint2 vi) { union { vint2 vi2; vmask vm; } cnv; cnv.vi2 = vi; return cnv.vm; }
+
+static INLINE vfloat vcast_vf_vi2(vint2 vi) { return (int32_t)vi; }
+static INLINE vint2 vcast_vi2_i(int j) { return j; }
+
+#ifdef FULL_FP_ROUNDING
+static INLINE vint2 vrint_vi2_vf(vfloat d) { return (int)RINTF(d); }
+static INLINE vfloat vrint_vf_vf(vfloat vd) { return RINTF(vd); }
+static INLINE vfloat vtruncate_vf_vf(vfloat vd) { return TRUNCF(vd); }
+static INLINE vint2 vtruncate_vi2_vf(vfloat vf) { return (int32_t)TRUNCF(vf); }
+#else
+static INLINE vint2 vrint_vi2_vf(vfloat a) {
+  a += a > 0 ? 0.5f : -0.5f;
+  versatileVector v = { .f = a }; v.u[0] -= 1 & (int)a;
+  return (int32_t)v.f;
+}
+static INLINE vfloat vrint_vf_vf(vfloat vd) { return vcast_vf_vi2(vrint_vi2_vf(vd)); }
+static INLINE vint2 vtruncate_vi2_vf(vfloat vf) { return vf; }
+static INLINE vfloat vtruncate_vf_vf(vfloat vd) { return vcast_vf_vi2(vtruncate_vi2_vf(vd)); }
+#endif
+
+static INLINE vfloat vcast_vf_f(float f) { return f; }
+static INLINE vmask vreinterpret_vm_vf(vfloat vf) { union { vfloat vf; vmask vm; } cnv; cnv.vf = vf; return cnv.vm; }
+static INLINE vfloat vreinterpret_vf_vm(vmask vm) { union { vfloat vf; vmask vm; } cnv; cnv.vm = vm; return cnv.vf; }
+static INLINE vfloat vreinterpret_vf_vi2(vint2 vi) { union { vfloat vf; vint2 vi2; } cnv; cnv.vi2 = vi; return cnv.vf; }
+static INLINE vint2 vreinterpret_vi2_vf(vfloat vf) { union { vfloat vf; vint2 vi2; } cnv; cnv.vi2 = 0; cnv.vf = vf; return cnv.vi2; }
+
+static INLINE vfloat vadd_vf_vf_vf(vfloat x, vfloat y) { return x + y; }
+static INLINE vfloat vsub_vf_vf_vf(vfloat x, vfloat y) { return x - y; }
+static INLINE vfloat vmul_vf_vf_vf(vfloat x, vfloat y) { return x * y; }
+static INLINE vfloat vdiv_vf_vf_vf(vfloat x, vfloat y) { return x / y; }
+static INLINE vfloat vrec_vf_vf   (vfloat x)           { return 1 / x; }
+
+static INLINE vfloat vabs_vf_vf(vfloat x) { versatileVector v = { .f = x }; v.x &= 0x7fffffff; return v.f; }
+static INLINE vfloat vneg_vf_vf(vfloat x) { return -x; }
+
+static INLINE vfloat vmax_vf_vf_vf(vfloat x, vfloat y) { return x > y ? x : y; }
+static INLINE vfloat vmin_vf_vf_vf(vfloat x, vfloat y) { return x < y ? x : y; }
+
+#ifndef ENABLE_FMA_SP
+static INLINE vfloat vmla_vf_vf_vf_vf  (vfloat x, vfloat y, vfloat z) { return x * y + z; }
+static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return - x * y + z; }
+#else
+static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return FMAF(x, y, z); }
+static INLINE vfloat vmlapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return FMAF(x, y, -z); }
+static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return FMAF(-x, y, z); }
+static INLINE vfloat vfma_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return FMAF(x, y, z); }
+static INLINE vfloat vfmapp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return FMAF(x, y, z); }
+static INLINE vfloat vfmapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return FMAF(x, y, -z); }
+static INLINE vfloat vfmanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return FMAF(-x, y, z); }
+static INLINE vfloat vfmann_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return FMAF(-x, y, -z); }
+#endif
+
+static INLINE vopmask veq_vo_vf_vf(vfloat x, vfloat y)  { return x == y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vneq_vo_vf_vf(vfloat x, vfloat y) { return x != y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vlt_vo_vf_vf(vfloat x, vfloat y)  { return x <  y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vle_vo_vf_vf(vfloat x, vfloat y)  { return x <= y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vgt_vo_vf_vf(vfloat x, vfloat y)  { return x >  y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vge_vo_vf_vf(vfloat x, vfloat y)  { return x >= y ? ~(uint32_t)0 : 0; }
+
+static INLINE vint2 vadd_vi2_vi2_vi2(vint2 x, vint2 y) { versatileVector v = { .i2 = x }, w = { .i2 = y }; v.i[0] += w.i[0]; v.i[1] += w.i[1]; return v.i2; }
+static INLINE vint2 vsub_vi2_vi2_vi2(vint2 x, vint2 y) { versatileVector v = { .i2 = x }, w = { .i2 = y }; v.i[0] -= w.i[0]; v.i[1] -= w.i[1]; return v.i2; }
+static INLINE vint2 vneg_vi2_vi2(vint2 x)              { versatileVector v = { .i2 = x }; v.i[0] = -v.i[0]; return v.i2; }
+
+static INLINE vint2 vand_vi2_vi2_vi2(vint2 x, vint2 y)    { return x & y; }
+static INLINE vint2 vandnot_vi2_vi2_vi2(vint2 x, vint2 y) { return y & ~x; }
+static INLINE vint2 vor_vi2_vi2_vi2(vint2 x, vint2 y)     { return x | y; }
+static INLINE vint2 vxor_vi2_vi2_vi2(vint2 x, vint2 y)    { return x ^ y; }
+
+static INLINE vfloat vsel_vf_vo_vf_vf(vopmask o, vfloat x, vfloat y) { return o ? x : y; }
+static INLINE vfloat vsel_vf_vo_f_f(vopmask o, float v1, float v0) { return o ? v1 : v0; }
+
+static INLINE vfloat vsel_vf_vo_vo_f_f_f(vopmask o0, vopmask o1, float d0, float d1, float d2) {
+  return vsel_vf_vo_vf_vf(o0, vcast_vf_f(d0), vsel_vf_vo_f_f(o1, d1, d2));
+}
+
+static INLINE vfloat vsel_vf_vo_vo_vo_f_f_f_f(vopmask o0, vopmask o1, vopmask o2, float d0, float d1, float d2, float d3) {
+  return vsel_vf_vo_vf_vf(o0, vcast_vf_f(d0), vsel_vf_vo_vf_vf(o1, vcast_vf_f(d1), vsel_vf_vo_f_f(o2, d2, d3)));
+}
+
+static INLINE vint2 vand_vi2_vo_vi2(vopmask x, vint2 y) { return vcast_vm_vo(x) & y; }
+static INLINE vint2 vandnot_vi2_vo_vi2(vopmask x, vint2 y) { return y & ~vcast_vm_vo(x); }
+
+static INLINE vint2 vsll_vi2_vi2_i(vint2 x, int c) { versatileVector v = { .i2 = x }; v.u[0] <<= c; v.u[1] <<= c; return v.i2; }
+static INLINE vint2 vsrl_vi2_vi2_i(vint2 x, int c) { versatileVector v = { .i2 = x }; v.u[0] >>= c; v.u[1] >>= c; return v.i2; }
+static INLINE vint2 vsra_vi2_vi2_i(vint2 x, int c) { versatileVector v = { .i2 = x }; v.i[0] >>= c; v.i[1] >>= c; return v.i2; }
+
+static INLINE vopmask visinf_vo_vf (vfloat d) { return (d == SLEEF_INFINITYf || d == -SLEEF_INFINITYf) ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vispinf_vo_vf(vfloat d) { return d == SLEEF_INFINITYf ? ~(uint32_t)0 : 0; }
+static INLINE vopmask visminf_vo_vf(vfloat d) { return d == -SLEEF_INFINITYf ? ~(uint32_t)0 : 0; }
+static INLINE vopmask visnan_vo_vf (vfloat d) { return d != d ? ~(uint32_t)0 : 0; }
+
+static INLINE vopmask veq_vo_vi2_vi2 (vint2 x, vint2 y) { return (int32_t)x == (int32_t)y ? ~(uint32_t)0 : 0; }
+static INLINE vopmask vgt_vo_vi2_vi2 (vint2 x, vint2 y) { return (int32_t)x >  (int32_t)y ? ~(uint32_t)0 : 0; }
+static INLINE vint2   veq_vi2_vi2_vi2(vint2 x, vint2 y) { return (int32_t)x == (int32_t)y ? ~(uint32_t)0 : 0; }
+static INLINE vint2   vgt_vi2_vi2_vi2(vint2 x, vint2 y) { return (int32_t)x >  (int32_t)y ? ~(uint32_t)0 : 0; }
+
+static INLINE float vcast_f_vf(vfloat v) { return v; }
+
+static INLINE vfloat vload_vf_p(const float *ptr) { return *ptr; }
+static INLINE vfloat vloadu_vf_p(const float *ptr) { return *ptr; }
+static INLINE vfloat vgather_vf_p_vi2(const float *ptr, vint2 vi) { return ptr[vi]; }
+
+static INLINE void vstore_v_p_vf(float *ptr, vfloat v) { *ptr = v; }
+static INLINE void vstoreu_v_p_vf(float *ptr, vfloat v) { *ptr = v; }
+static INLINE void vstream_v_p_vf(float *ptr, vfloat v) { *ptr = v; }

--- a/src/arch/helpersse2.h
+++ b/src/arch/helpersse2.h
@@ -273,14 +273,12 @@ static INLINE vdouble vgather_vd_p_vi(const double *ptr, vint vi) {
   return _mm_set_pd(ptr[a[1]], ptr[a[0]]);
 }
 
-#if defined(_MSC_VER)
-// This function is needed when debugging on MSVC.
+// This function is for debugging
 static INLINE double vcast_d_vd(vdouble v) {
   double a[VECTLENDP];
   vstoreu_v_p_vd(a, v);
   return a[0];
 }
-#endif
 
 //
 
@@ -385,14 +383,13 @@ static INLINE vfloat vgather_vf_p_vi2(const float *ptr, vint2 vi) {
   return _mm_set_ps(ptr[a[3]], ptr[a[2]], ptr[a[1]], ptr[a[0]]);
 }
 
-#ifdef _MSC_VER
-// This function is useful when debugging on MSVC.
+// This function is for debugging
 static INLINE float vcast_f_vf(vfloat v) {
   float a[VECTLENSP];
   vstoreu_v_p_vf(a, v);
   return a[0];
 }
-#endif
+
 //
 
 #define PNMASK ((vdouble) { +0.0, -0.0 })
@@ -426,6 +423,7 @@ static INLINE void vsscatter2_v_p_i_i_vd(double *ptr, int offset, int step, vdou
 
 static INLINE vfloat vrev21_vf_vf(vfloat d0) { return _mm_shuffle_ps(d0, d0, (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0)); }
 static INLINE vfloat vreva2_vf_vf(vfloat d0) { return _mm_shuffle_ps(d0, d0, (1 << 6) | (0 << 4) | (3 << 2) | (2 << 0)); }
+static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
 
 static INLINE void vstream_v_p_vf(float *ptr, vfloat v) { _mm_stream_ps(ptr, v); }
 

--- a/src/arch/helpervecext.h
+++ b/src/arch/helpervecext.h
@@ -695,6 +695,7 @@ static INLINE vmask vreinterpret_vm_vf(vfloat vf) { return (vmask)vf; }
 static INLINE vfloat vreinterpret_vf_vm(vmask vm) { return (vfloat)vm; }
 static INLINE vfloat vreinterpret_vf_vi2(vint2 vi) { return (vfloat)vi; }
 static INLINE vint2 vreinterpret_vi2_vf(vfloat vf) { return (vint2)vf; }
+static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
 
 static INLINE vfloat vadd_vf_vf_vf(vfloat x, vfloat y) { return x + y; }
 static INLINE vfloat vsub_vf_vf_vf(vfloat x, vfloat y) { return x - y; }

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -68,6 +68,9 @@ set(IUT_SRC iutsimd.c iutsimdmain.c testerutil)
 # Add vector extension `iut`s
 macro(test_extension SIMD)
   if(COMPILER_SUPPORTS_${SIMD})
+    string(TOLOWER ${SIMD} LCSIMD)
+    string(CONCAT TARGET_IUT${SIMD} "iut" ${LCSIMD})
+
     add_executable(${TARGET_IUT${SIMD}} ${IUT_SRC})
     target_compile_options(${TARGET_IUT${SIMD}}
       PRIVATE ${FLAGS_ENABLE_${SIMD}})

--- a/src/libm-tester/iutsimd.c
+++ b/src/libm-tester/iutsimd.c
@@ -91,6 +91,14 @@ typedef Sleef___m512d_2 vdouble2;
 typedef Sleef___m512_2 vfloat2;
 #endif
 
+#ifdef ENABLE_AVX512FNOFMA
+#define CONFIG 2
+#include "helperavx512f.h"
+#include "renameavx512fnofma.h"
+typedef Sleef___m512d_2 vdouble2;
+typedef Sleef___m512_2 vfloat2;
+#endif
+
 #ifdef ENABLE_VECEXT
 #define CONFIG 1
 #include "helpervecext.h"
@@ -125,6 +133,14 @@ typedef Sleef_float64x2_t_2 vdouble2;
 typedef Sleef_float32x4_t_2 vfloat2;
 #endif
 
+#ifdef ENABLE_ADVSIMDNOFMA
+#define CONFIG 2
+#include "helperadvsimd.h"
+#include "renameadvsimdnofma.h"
+typedef Sleef_float64x2_t_2 vdouble2;
+typedef Sleef_float32x4_t_2 vfloat2;
+#endif
+
 #ifdef ENABLE_DSP128
 #define CONFIG 2
 #include "helpersse2.h"
@@ -143,6 +159,14 @@ typedef Sleef_svfloat32_t_2 vfloat2;
 #endif
 #endif
 
+#ifdef ENABLE_SVENOFMA
+#define CONFIG 2
+#include "helpersve.h"
+#include "renamesvenofma.h"
+typedef Sleef_svfloat64_t_2 vdouble2;
+typedef Sleef_svfloat32_t_2 vfloat2;
+#endif
+
 #ifdef ENABLE_DSP256
 #define CONFIG 1
 #include "helperavx.h"
@@ -157,6 +181,30 @@ typedef Sleef___m256_2 vfloat2;
 #include "renamevsx.h"
 typedef Sleef_vector_double_2 vdouble2;
 typedef Sleef_vector_float_2 vfloat2;
+#endif
+
+#ifdef ENABLE_VSXNOFMA
+#define CONFIG 2
+#include "helperpower_128.h"
+#include "renamevsxnofma.h"
+typedef Sleef_vector_double_2 vdouble2;
+typedef Sleef_vector_float_2 vfloat2;
+#endif
+
+#ifdef ENABLE_PUREC_SCALAR
+#define CONFIG 1
+#include "helperpurec_scalar.h"
+#include "renamepurec_scalar.h"
+typedef Sleef_double_2 vdouble2;
+typedef Sleef_float_2 vfloat2;
+#endif
+
+#ifdef ENABLE_PURECFMA_SCALAR
+#define CONFIG 2
+#include "helperpurec_scalar.h"
+#include "renamepurecfma_scalar.h"
+typedef Sleef_double_2 vdouble2;
+typedef Sleef_float_2 vfloat2;
 #endif
 
 //

--- a/src/libm-tester/tester2simddp.c
+++ b/src/libm-tester/tester2simddp.c
@@ -86,6 +86,14 @@ typedef Sleef___m512d_2 vdouble2;
 typedef Sleef___m512_2 vfloat2;
 #endif
 
+#ifdef ENABLE_AVX512FNOFMA
+#define CONFIG 2
+#include "helperavx512f.h"
+#include "renameavx512fnofma.h"
+typedef Sleef___m512d_2 vdouble2;
+typedef Sleef___m512_2 vfloat2;
+#endif
+
 #ifdef ENABLE_VECEXT
 #define CONFIG 1
 #include "helpervecext.h"
@@ -106,6 +114,14 @@ typedef Sleef_float64x2_t_2 vdouble2;
 typedef Sleef_float32x4_t_2 vfloat2;
 #endif
 
+#ifdef ENABLE_ADVSIMDNOFMA
+#define CONFIG 2
+#include "helperadvsimd.h"
+#include "renameadvsimdnofma.h"
+typedef Sleef_float64x2_t_2 vdouble2;
+typedef Sleef_float32x4_t_2 vfloat2;
+#endif
+
 #ifdef ENABLE_SVE
 #define CONFIG 1
 #include "helpersve.h"
@@ -114,12 +130,44 @@ typedef Sleef_svfloat64_t_2 vdouble2;
 typedef Sleef_svfloat32_t_2 vfloat2;
 #endif /* ENABLE_SVE */
 
+#ifdef ENABLE_SVENOFMA
+#define CONFIG 2
+#include "helpersve.h"
+#include "renamesvenofma.h"
+typedef Sleef_svfloat64_t_2 vdouble2;
+typedef Sleef_svfloat32_t_2 vfloat2;
+#endif
+
 #ifdef ENABLE_VSX
 #define CONFIG 1
 #include "helperpower_128.h"
 #include "renamevsx.h"
 typedef Sleef_vector_double_2 vdouble2;
 typedef Sleef_vector_float_2 vfloat2;
+#endif
+
+#ifdef ENABLE_VSXNOFMA
+#define CONFIG 2
+#include "helperpower_128.h"
+#include "renamevsxnofma.h"
+typedef Sleef_vector_double_2 vdouble2;
+typedef Sleef_vector_float_2 vfloat2;
+#endif
+
+#ifdef ENABLE_PUREC_SCALAR
+#define CONFIG 1
+#include "helperpurec_scalar.h"
+#include "renamepurec_scalar.h"
+typedef Sleef_double_2 vdouble2;
+typedef Sleef_float_2 vfloat2;
+#endif
+
+#ifdef ENABLE_PURECFMA_SCALAR
+#define CONFIG 2
+#include "helperpurec_scalar.h"
+#include "renamepurecfma_scalar.h"
+typedef Sleef_double_2 vdouble2;
+typedef Sleef_float_2 vfloat2;
 #endif
 
 //

--- a/src/libm-tester/tester2simdsp.c
+++ b/src/libm-tester/tester2simdsp.c
@@ -87,6 +87,14 @@ typedef Sleef___m512d_2 vdouble2;
 typedef Sleef___m512_2 vfloat2;
 #endif
 
+#ifdef ENABLE_AVX512FNOFMA
+#define CONFIG 2
+#include "helperavx512f.h"
+#include "renameavx512fnofma.h"
+typedef Sleef___m512d_2 vdouble2;
+typedef Sleef___m512_2 vfloat2;
+#endif
+
 #ifdef ENABLE_VECEXT
 #define CONFIG 1
 #include "helpervecext.h"
@@ -107,6 +115,14 @@ typedef Sleef_float64x2_t_2 vdouble2;
 typedef Sleef_float32x4_t_2 vfloat2;
 #endif
 
+#ifdef ENABLE_ADVSIMDNOFMA
+#define CONFIG 2
+#include "helperadvsimd.h"
+#include "renameadvsimdnofma.h"
+typedef Sleef_float64x2_t_2 vdouble2;
+typedef Sleef_float32x4_t_2 vfloat2;
+#endif
+
 #ifdef ENABLE_SVE
 #define CONFIG 1
 #include "helpersve.h"
@@ -114,6 +130,14 @@ typedef Sleef_float32x4_t_2 vfloat2;
 typedef Sleef_svfloat64_t_2 vdouble2;
 typedef Sleef_svfloat32_t_2 vfloat2;
 #endif /* ENABLE_SVE */
+
+#ifdef ENABLE_SVENOFMA
+#define CONFIG 2
+#include "helpersve.h"
+#include "renamesvenofma.h"
+typedef Sleef_svfloat64_t_2 vdouble2;
+typedef Sleef_svfloat32_t_2 vfloat2;
+#endif
 
 #ifdef ENABLE_VSX
 #define CONFIG 1
@@ -123,6 +147,29 @@ typedef Sleef_vector_double_2 vdouble2;
 typedef Sleef_vector_float_2 vfloat2;
 #endif
 
+#ifdef ENABLE_VSXNOFMA
+#define CONFIG 2
+#include "helperpower_128.h"
+#include "renamevsxnofma.h"
+typedef Sleef_vector_double_2 vdouble2;
+typedef Sleef_vector_float_2 vfloat2;
+#endif
+
+#ifdef ENABLE_PUREC_SCALAR
+#define CONFIG 1
+#include "helperpurec_scalar.h"
+#include "renamepurec_scalar.h"
+typedef Sleef_double_2 vdouble2;
+typedef Sleef_float_2 vfloat2;
+#endif
+
+#ifdef ENABLE_PURECFMA_SCALAR
+#define CONFIG 2
+#include "helperpurec_scalar.h"
+#include "renamepurecfma_scalar.h"
+typedef Sleef_double_2 vdouble2;
+typedef Sleef_float_2 vfloat2;
+#endif
 
 //
 

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -206,6 +206,10 @@ foreach(SIMD ${SLEEF_SUPPORTED_EXTENSIONS})
     # Create a library
     add_library(${OBJECT_${SIMD}} OBJECT ${SIMD_SOURCES} ${HEADER_${SIMD}})    
 
+    if(COMPILER_SUPPORTS_BUILTIN_MATH)
+      target_compile_definitions(${OBJECT_${SIMD}} PRIVATE ENABLE_BUILTIN_MATH=1)
+    endif()
+
     if (INDEX_ALIAS EQUAL -1)
       target_compile_definitions(${OBJECT_${SIMD}} PRIVATE
 	ENABLE_${SIMD}=1

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -191,10 +191,6 @@ endif()
 
 # Compile SIMD versions
 # Single precision and double precision
-set(SIMD_SOURCES sleefsimdsp.c sleefsimddp.c)
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
-  set(SIMD_SOURCES sleefsimdsp.c)
-endif()
 
 # Include symbols for each SIMD architecture (if supported by the platform)
 # Note: adds object file as sources via cmake conditional generator expression
@@ -202,6 +198,12 @@ foreach(SIMD ${SLEEF_SUPPORTED_EXTENSIONS})
   if(COMPILER_SUPPORTS_${SIMD})
     list(FIND EXT_ENABLE_ALIAS ${SIMD} INDEX_ALIAS)
     string(TOLOWER ${SIMD} SIMDLC)
+
+    if (${SIMD} STREQUAL "NEON32" OR ${SIMD} STREQUAL "NEON32VFPV4")
+      set(SIMD_SOURCES sleefsimdsp.c)
+    else()
+      set(SIMD_SOURCES sleefsimdsp.c sleefsimddp.c)
+    endif()
 
     # Create a library
     add_library(${OBJECT_${SIMD}} OBJECT ${SIMD_SOURCES} ${HEADER_${SIMD}})    

--- a/src/libm/dd.h
+++ b/src/libm/dd.h
@@ -3,7 +3,7 @@
 //    (See accompanying file LICENSE.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#ifdef ENABLE_SVE
+#if defined(ENABLE_SVE) || defined(ENABLE_SVENOFMA)
 typedef __sizeless_struct vdouble2 {
   svfloat64_t x;
   svfloat64_t y;

--- a/src/libm/df.h
+++ b/src/libm/df.h
@@ -3,7 +3,7 @@
 //    (See accompanying file LICENSE.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#ifdef ENABLE_SVE
+#if defined(ENABLE_SVE) || defined(ENABLE_SVENOFMA)
 typedef __sizeless_struct vfloat2 {
   svfloat32_t x;
   svfloat32_t y;

--- a/src/libm/sleeflibm_header.h.org
+++ b/src/libm/sleeflibm_header.h.org
@@ -15,6 +15,16 @@
 #define CONST
 #endif
 
+#if defined(__AVX2__) || defined(__aarch64__) || defined(__arm__) || defined(__powerpc64__)
+#ifndef FP_FAST_FMA
+#define FP_FAST_FMA
+#endif
+#endif
+
+#if defined(_MSC_VER) && !defined(__STDC__)
+#define __STDC__ 1
+#endif
+
 #if (defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__) || defined(_MSC_VER)) && !defined(SLEEF_STATIC_LIBS)
 #ifdef IMPORT_IS_EXPORT
 #define IMPORT __declspec(dllexport)

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -1625,6 +1625,9 @@ EXPORT CONST vdouble xatan_u1(vdouble d) {
 EXPORT CONST vdouble xatan(vdouble s) {
   vdouble t, u;
   vint q;
+#if defined(__INTEL_COMPILER) && defined(ENABLE_PURECFMA_SCALAR)
+  vdouble w = s;
+#endif
 
   q = vsel_vi_vd_vi(s, vcast_vi_i(2));
   s = vabs_vd_vd(s);
@@ -1685,6 +1688,10 @@ EXPORT CONST vdouble xatan(vdouble s) {
 
   t = vsel_vd_vo_vd_vd(vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(q, vcast_vi_i(1)), vcast_vi_i(1))), vsub_vd_vd_vd(vcast_vd_d(M_PI/2), t), t);
   t = vreinterpret_vd_vm(vxor_vm_vm_vm(vand_vm_vo64_vm(vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(q, vcast_vi_i(2)), vcast_vi_i(2))), vreinterpret_vm_vd(vcast_vd_d(-0.0))), vreinterpret_vm_vd(t)));
+
+#if defined(__INTEL_COMPILER) && defined(ENABLE_PURECFMA_SCALAR)
+  t = vsel_vd_vo_vd_vd(veq_vo_vd_vd(w, vcast_vd_d(0)), w, t);
+#endif
 
   return t;
 }

--- a/travis/before_install.x86_64-clang.sh
+++ b/travis/before_install.x86_64-clang.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -ev
-#tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2 # Turned off SDE to reduce time for testing
 sudo add-apt-repository -y ppa:adrozdoff/cmake
 sudo apt-get -qq update
 sudo apt-get install -y cmake libmpfr-dev libfftw3-dev

--- a/travis/before_install.x86_64-gcc.sh
+++ b/travis/before_install.x86_64-gcc.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -ev
-#tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2
 sudo add-apt-repository -y ppa:adrozdoff/cmake
 sudo apt-get -qq update
 sudo apt-get install -y cmake libmpfr-dev

--- a/travis/before_install.x86_64-gcc.sh
+++ b/travis/before_install.x86_64-gcc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
-tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2
+#tar xf sde-external-8.12.0-2017-10-23-lin.tar.bz2
 sudo add-apt-repository -y ppa:adrozdoff/cmake
 sudo apt-get -qq update
 sudo apt-get install -y cmake libmpfr-dev


### PR DESCRIPTION
This patch adds pure C scalar helpers with which scalar functions are implemented using the SIMD source code.
It also adds helper files which do not use FMA on platforms with FMA support.
