### PR TITLE
delete output that is never generated

### DIFF
--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -213,7 +213,7 @@ foreach(SIMD ${SLEEF_SUPPORTED_EXTENSIONS})
 	)
     else()
       add_custom_command(
-	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/alias${SIMD}.h ${CMAKE_CURRENT_BINARY_DIR}/include/alias_${SIMDLC}.h
+	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/alias_${SIMDLC}.h
        	COMMENT "Generating alias_${SIMDLC}.h"
        	COMMAND $<TARGET_FILE:${TARGET_MKALIAS}> ${ALIAS_PARAMS_${SIMD}_SP} >  ${CMAKE_CURRENT_BINARY_DIR}/include/alias_${SIMDLC}.h
        	COMMAND $<TARGET_FILE:${TARGET_MKALIAS}> ${ALIAS_PARAMS_${SIMD}_DP} >> ${CMAKE_CURRENT_BINARY_DIR}/include/alias_${SIMDLC}.h


### PR DESCRIPTION
As far as I can tell, mkalias never generates the first file in this output list, causing this rule to appear always out-of-date, which causes a bunch of dependencies downstream to always rebuild.