### PR TITLE
Add quadprecision math library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ dist: trusty
 matrix:
   include:
     - os: osx
-      osx_image: xcode8
-      compiler: gcc
-      env:
-        - LABEL="osx-gcc"
-    - os: osx
       compiler: clang # use default apple clang
       env:
         - LABEL="osx-clang"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Options
 
 option(BUILD_SHARED_LIBS "Build shared libs" ON)
+option(BUILD_LIBM "libsleef will be built." ON)
 option(BUILD_DFT "libsleefdft will be built." ON)
 option(BUILD_QUAD "libsleefquad will be built." OFF)
 option(BUILD_GNUABI_LIBS "libsleefgnuabi will be built." ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 option(BUILD_SHARED_LIBS "Build shared libs" ON)
 option(BUILD_DFT "libsleefdft will be built." ON)
+option(BUILD_QUAD "libsleefquad will be built." OFF)
 option(BUILD_GNUABI_LIBS "libsleefgnuabi will be built." ON)
 option(BUILD_TESTS "Tests will be built." ON)
 

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -61,7 +61,8 @@ set(SLEEF_SUPPORTED_GNUABI_EXTENSIONS
   SSE2 AVX AVX2 AVX512F ADVSIMD SVE
   CACHE STRING "List of SIMD architectures supported by libsleef for GNU ABI."
 )
-
+set(SLEEFQUAD_SUPPORTED_EXT
+  PUREC_SCALAR PURECFMA_SCALAR SSE2 AVX FMA4 AVX2 AVX512F ADVSIMD)
 # Force set default build type if none was specified
 # Note: some sleef code requires the optimisation flags turned on
 if(NOT CMAKE_BUILD_TYPE)
@@ -278,8 +279,8 @@ set(CLANG_FLAGS_ENABLE_AVX512FNOFMA "-mavx512f")
 set(CLANG_FLAGS_ENABLE_NEON32 "--target=arm-linux-gnueabihf;-mcpu=cortex-a8")
 set(CLANG_FLAGS_ENABLE_NEON32VFPV4 "-march=armv7-a;-mfpu=neon-vfpv4")
 # Arm AArch64 vector extensions.
-set(CLANG_FLAGS_ENABLE_ADVSIMD "-march=armv8-a+simd")
-set(CLANG_FLAGS_ENABLE_ADVSIMDNOFMA "-march=armv8-a+simd")
+set(CLANG_FLAGS_ENABLE_ADVSIMD "")
+set(CLANG_FLAGS_ENABLE_ADVSIMDNOFMA "")
 set(CLANG_FLAGS_ENABLE_SVE "-march=armv8-a+sve")
 set(CLANG_FLAGS_ENABLE_SVENOFMA "-march=armv8-a+sve")
 # PPC64
@@ -331,8 +332,8 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "Intel")
   set(FLAGS_ENABLE_AVX512F "-xCOMMON-AVX512")
   set(FLAGS_ENABLE_AVX512FNOFMA "-xCOMMON-AVX512")
   set(FLAGS_ENABLE_PURECFMA_SCALAR "-march=core-avx2")
-  set(FLAGS_STRICTMATH "-fp-model strict -Qoption,cpp,--extended_float_type -qoverride-limits")
-  set(FLAGS_FASTMATH "-fp-model fast=2 -Qoption,cpp,--extended_float_type -qoverride-limits")
+  set(FLAGS_STRICTMATH "-fp-model strict -Qoption,cpp,--extended_float_type")
+  set(FLAGS_FASTMATH "-fp-model fast=2 -Qoption,cpp,--extended_float_type")
   set(FLAGS_WALL "-fmax-errors=3 -Wall -Wno-unused -Wno-attributes")
   set(FLAGS_NO_ERRNO "")
 endif()

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -62,7 +62,7 @@ set(SLEEF_SUPPORTED_GNUABI_EXTENSIONS
   CACHE STRING "List of SIMD architectures supported by libsleef for GNU ABI."
 )
 set(SLEEFQUAD_SUPPORTED_EXT
-  PUREC_SCALAR PURECFMA_SCALAR SSE2 AVX FMA4 AVX2 AVX512F ADVSIMD)
+  PUREC_SCALAR PURECFMA_SCALAR SSE2 AVX FMA4 AVX2 AVX512F ADVSIMD SVE)
 # Force set default build type if none was specified
 # Note: some sleef code requires the optimisation flags turned on
 if(NOT CMAKE_BUILD_TYPE)
@@ -279,8 +279,6 @@ set(CLANG_FLAGS_ENABLE_AVX512FNOFMA "-mavx512f")
 set(CLANG_FLAGS_ENABLE_NEON32 "--target=arm-linux-gnueabihf;-mcpu=cortex-a8")
 set(CLANG_FLAGS_ENABLE_NEON32VFPV4 "-march=armv7-a;-mfpu=neon-vfpv4")
 # Arm AArch64 vector extensions.
-set(CLANG_FLAGS_ENABLE_ADVSIMD "")
-set(CLANG_FLAGS_ENABLE_ADVSIMDNOFMA "")
 set(CLANG_FLAGS_ENABLE_SVE "-march=armv8-a+sve")
 set(CLANG_FLAGS_ENABLE_SVENOFMA "-march=armv8-a+sve")
 # PPC64

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,15 +11,15 @@ pipeline {
                 	 echo "AArch64 SVE on" `hostname`
 			 export PATH=$PATH:/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/bin
 			 export LD_LIBRARY_PATH=/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/lib:/opt/arm/arm-hpc-compiler-18.1_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib
-			 export CC=/opt/arm/arm-hpc-compiler-18.4_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin/armclang
+			 export CC=/opt/bin/armclang
 			 rm -rf build
  			 mkdir build
 			 cd build
 			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
-			 make -j 4 all
+			 make -j 6 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
-		         ctest -j 4
+		         ctest -j 6
 		         make install
 			 '''
             	     }
@@ -32,15 +32,15 @@ pipeline {
                 	 echo "AArch64 SVE on" `hostname`
 			 export PATH=$PATH:/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/bin
 			 export LD_LIBRARY_PATH=/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/lib:/opt/arm/arm-hpc-compiler-18.1_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib
-			 export CC=/opt/arm/arm-hpc-compiler-18.4_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin/armclang
+			 export CC=/opt/bin/armclang
 			 rm -rf build
  			 mkdir build
 			 cd build
 			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DFORCE_AAVPCS=On -DENABLE_GNUABI=On ..
-			 make -j 4 all
+			 make -j 6 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
-		         ctest -j 4
+		         ctest -j 6
 		         make install
 			 '''
             	     }
@@ -114,6 +114,7 @@ pipeline {
 	    	     	 sh '''
                 	 echo "On" `hostname`
 			 export PATH=$PATH:/opt/local/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
+		         export CC=gcc-7
 			 rm -rf build
  			 mkdir build
 			 cd build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,7 +137,7 @@ pipeline {
 			 set "ORG_PATH=%PATH%"
 			 PATH C:/Cygwin64/bin;C:/Cygwin64/usr/bin;%PROJECT_DIR%/build-cygwin/bin;%PATH%
 			 rmdir /S /Q build-cygwin
-			 C:/Cygwin64/bin/bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g"Unix Makefiles" ..;make -j 4'
+			 C:/Cygwin64/bin/bash -c 'mkdir build-cygwin;cd build-cygwin;cmake -g"Unix Makefiles" .. -DBUILD_QUAD=TRUE;make -j 4'
 			 del /Q /F %PROJECT_DIR%/build-cygwin/bin/iut*
 			 PATH %ORG_PATH%;C:/Cygwin64/bin;C:/Cygwin64/usr/bin;%PROJECT_DIR%/build-cygwin/bin;%PROJECT_DIR%/build/bin
 			 cd %PROJECT_DIR%
@@ -177,7 +177,7 @@ pipeline {
 			 rm -rf build-native
  			 mkdir build-native
 			 cd build-native
-			 cmake -DSLEEF_SHOW_CONFIG=1 ..
+			 cmake -DSLEEF_SHOW_CONFIG=1 .. -DBUILD_QUAD=TRUE
 			 make -j 4 all
 			 cd ..
 			 export PATH=$PATH:`pwd`/travis

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     stages {
         stage('Preamble') {
             parallel {
+/*
                 stage('AArch64 SVE') {
             	     agent { label 'aarch64' }
             	     steps {
@@ -45,7 +46,7 @@ pipeline {
 			 '''
             	     }
                 }
-
+*/		
                 stage('Intel Compiler') {
                     agent { label 'icc' }
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,15 +4,13 @@ pipeline {
     stages {
         stage('Preamble') {
             parallel {
-/*
                 stage('AArch64 SVE') {
             	     agent { label 'aarch64' }
             	     steps {
 	    	     	 sh '''
                 	 echo "AArch64 SVE on" `hostname`
-			 export PATH=$PATH:/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/bin
-			 export LD_LIBRARY_PATH=/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/lib:/opt/arm/arm-hpc-compiler-18.1_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib
-			 export CC=/opt/bin/armclang
+			 export PATH=$PATH:/opt/bin
+			 export CC=armclang
 			 rm -rf build
  			 mkdir build
 			 cd build
@@ -31,9 +29,8 @@ pipeline {
             	     steps {
 	    	     	 sh '''
                 	 echo "AArch64 SVE on" `hostname`
-			 export PATH=$PATH:/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/bin
-			 export LD_LIBRARY_PATH=/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/lib:/opt/arm/arm-hpc-compiler-18.1_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib
-			 export CC=/opt/bin/armclang
+			 export PATH=$PATH:/opt/bin
+			 export CC=armclang
 			 rm -rf build
  			 mkdir build
 			 cd build
@@ -46,7 +43,7 @@ pipeline {
 			 '''
             	     }
                 }
-*/		
+
                 stage('Intel Compiler') {
                     agent { label 'icc' }
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
 			 rm -rf build
  			 mkdir build
 			 cd build
-			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..
 			 make -j 6 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
@@ -36,7 +36,7 @@ pipeline {
 			 rm -rf build
  			 mkdir build
 			 cd build
-			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DFORCE_AAVPCS=On -DENABLE_GNUABI=On ..
+			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DFORCE_AAVPCS=On -DENABLE_GNUABI=On -DBUILD_QUAD=TRUE ..
 			 make -j 6 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
@@ -57,7 +57,7 @@ pipeline {
 		        rm -rf build
  		        mkdir build
 		        cd build
-		        cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+		        cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..
 		        make -j 4 all
 			export OMP_WAIT_POLICY=passive
 		        export CTEST_OUTPUT_ON_FAILURE=TRUE
@@ -78,7 +78,7 @@ pipeline {
 			 rm -rf build
  			 mkdir build
 			 cd build
-			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..
 			 make -j 4 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
@@ -98,7 +98,7 @@ pipeline {
 			 rm -rf build
  			 mkdir build
 			 cd build
-			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..
 			 make -j 4 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
@@ -118,7 +118,7 @@ pipeline {
 			 rm -rf build
  			 mkdir build
 			 cd build
-			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DBUILD_SHARED_LIBS=FALSE -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DENFORCE_TESTER3=TRUE ..
+			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DBUILD_SHARED_LIBS=FALSE -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..
 			 make -j 2 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
@@ -143,7 +143,7 @@ pipeline {
 			 rmdir /S /Q build
                          mkdir build
                          cd build
-                         cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DBUILD_SHARED_LIBS=FALSE -DENFORCE_TESTER3=TRUE
+                         cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DBUILD_SHARED_LIBS=FALSE -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE
                          cmake --build . --target install --config Release
 			 ctest --output-on-failure -j 4 -C Release
 			 '''
@@ -158,7 +158,7 @@ pipeline {
 			 rm -rf build
  			 mkdir build
 			 cd build
-			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..
 			 make -j 4 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
@@ -185,7 +185,7 @@ pipeline {
 			 rm -rf build
  			 mkdir build
 			 cd build
-			 cmake -DCMAKE_TOOLCHAIN_FILE=../travis/toolchain-ppc64el.cmake -DNATIVE_BUILD_DIR=`pwd`/../build-native -DEMULATOR=qemu-ppc64le-static -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+			 cmake -DCMAKE_TOOLCHAIN_FILE=../travis/toolchain-ppc64el.cmake -DNATIVE_BUILD_DIR=`pwd`/../build-native -DEMULATOR=qemu-ppc64le-static -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..
 			 make -j 4 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
@@ -203,7 +203,7 @@ pipeline {
 			 rm -rf build
  			 mkdir build
 			 cd build
-			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..
 			 make -j 4 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
@@ -221,7 +221,7 @@ pipeline {
 			 rm -rf build
  			 mkdir build
 			 cd build
-			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..
 			 make -j 3 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,15 +12,15 @@ install:
   - if "%DO_TEST%" == "TRUE" set ORGPATH="%PATH%"
   - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\setup-x86_64.exe" -q -g -P libmpfr-devel,libgmp-devel,cmake
   - if "%DO_TEST%" == "TRUE" PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;"%PATH%"
-  - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\bin\\bash" -c 'mkdir build-mingw;cd build-mingw;CC=x86_64-w64-mingw32-gcc cmake -g\"Unix Makefiles\" .. -DBUILD_SHARED_LIBS=FALSE;make -j 2'
+  - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\bin\\bash" -c 'mkdir build-mingw;cd build-mingw;CC=x86_64-w64-mingw32-gcc cmake -g\"Unix Makefiles\" .. -DBUILD_SHARED_LIBS=FALSE -DBUILD_QUAD=TRUE;make -j 2'
   - if "%DO_TEST%" == "TRUE" cd "c:\\projects\\sleef"
-  - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\bin\\bash" -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" ..;make -j 2'
+  - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\bin\\bash" -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\ -DBUILD_QUAD=TRUE" ..;make -j 2'
   - if "%DO_TEST%" == "TRUE" del /Q /F c:\projects\sleef\build-cygwin\bin\iut*
   - if "%DO_TEST%" == "TRUE" PATH "%ORGPATH%";c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin
   - if "%DO_TEST%" == "TRUE" cd "c:\\projects\\sleef"
   - mkdir build
   - cd build
-  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 -DENFORCE_TESTER3=TRUE %ENV_BUILD_STATIC%
+  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE %ENV_BUILD_STATIC%
 build_script:
   - cmake --build . --target install --config Release
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - if "%DO_TEST%" == "TRUE" PATH c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;"%PATH%"
   - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\bin\\bash" -c 'mkdir build-mingw;cd build-mingw;CC=x86_64-w64-mingw32-gcc cmake -g\"Unix Makefiles\" .. -DBUILD_SHARED_LIBS=FALSE -DBUILD_QUAD=TRUE;make -j 2'
   - if "%DO_TEST%" == "TRUE" cd "c:\\projects\\sleef"
-  - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\bin\\bash" -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\ -DBUILD_QUAD=TRUE" ..;make -j 2'
+  - if "%DO_TEST%" == "TRUE" "C:\\Cygwin64\\bin\\bash" -c 'mkdir build-cygwin;cd build-cygwin;cmake -g\"Unix Makefiles\" -DBUILD_QUAD=TRUE ..;make -j 2'
   - if "%DO_TEST%" == "TRUE" del /Q /F c:\projects\sleef\build-cygwin\bin\iut*
   - if "%DO_TEST%" == "TRUE" PATH "%ORGPATH%";c:\Cygwin64\bin;c:\Cygwin64\usr\bin;c:\projects\sleef\build-cygwin\bin;c:\projects\sleef\build\bin
   - if "%DO_TEST%" == "TRUE" cd "c:\\projects\\sleef"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,9 @@
 include_directories("common")
 include_directories("arch")
 
-if (BUILD_LIBM)
-  add_subdirectory("libm")
-  if (BUILD_TESTS)
-    add_subdirectory("libm-tester")
-  endif()
+add_subdirectory("libm")
+if (BUILD_TESTS)
+  add_subdirectory("libm-tester")
 endif()
 
 add_subdirectory("common")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,25 @@
 include_directories("common")
 include_directories("arch")
 
-add_subdirectory("libm")
-if (BUILD_TESTS)
-  add_subdirectory("libm-tester")
+if (BUILD_LIBM)
+  add_subdirectory("libm")
+  if (BUILD_TESTS)
+    add_subdirectory("libm-tester")
+  endif()
 endif()
+
 add_subdirectory("common")
 
 if (BUILD_DFT AND NOT MINGW)
   add_subdirectory("dft")
   if (BUILD_TESTS)
     add_subdirectory("dft-tester")
+  endif()
+endif()
+
+if (BUILD_QUAD)
+  add_subdirectory("quad")
+  if (BUILD_TESTS)
+    add_subdirectory("quad-tester")
   endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,6 @@ add_subdirectory("libm")
 if (BUILD_TESTS)
   add_subdirectory("libm-tester")
 endif()
-
 add_subdirectory("common")
 
 if (BUILD_DFT AND NOT MINGW)

--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -703,11 +703,5 @@ static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) {
   return vreinterpretq_u32_u64(vcgtq_s64(vreinterpretq_s64_u32(x), vreinterpretq_s64_u32(y)));
 }
 
-static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) {
-  return vreinterpretq_u32_u64(vshlq_u64(vreinterpretq_u64_u32(x), vreinterpretq_s64_u32(c)));
-}
-static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) {
-  return vreinterpretq_u32_u64(vshlq_u64(vreinterpretq_u64_u32(x), vnegq_s64(vreinterpretq_s64_u32(c))));
-}
 #define vsll64_vm_vm_i(x, c) vreinterpretq_u32_u64(vshlq_n_u64(vreinterpretq_u64_u32(x), c))
 #define vsrl64_vm_vm_i(x, c) vreinterpretq_u32_u64(vshrq_n_u64(vreinterpretq_u64_u32(x), c))

--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -45,6 +45,10 @@ typedef int32x4_t vint2;
 typedef float64x2_t vdouble;
 typedef int32x2_t vint;
 
+typedef struct {
+  vmask x, y;
+} vmask2;
+
 #define DFTPRIORITY 10
 
 static INLINE int vavailability_i(int name) { return 3; }
@@ -644,3 +648,66 @@ static INLINE VECTOR_CC void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int s
   vst1_f32((float *)(ptr+(offset + step * 0)*2), vget_low_f32(v));
   vst1_f32((float *)(ptr+(offset + step * 1)*2), vget_high_f32(v));
 }
+
+//
+
+typedef Sleef_quad2 vargquad;
+
+static INLINE vmask2 vinterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) {
+    vreinterpretq_u32_u64(vtrn1q_u64(vreinterpretq_u64_u32(v.x), vreinterpretq_u64_u32(v.y))),
+    vreinterpretq_u32_u64(vtrn2q_u64(vreinterpretq_u64_u32(v.x), vreinterpretq_u64_u32(v.y))) };
+}
+
+static INLINE vmask2 vuninterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) {
+    vreinterpretq_u32_u64(vtrn1q_u64(vreinterpretq_u64_u32(v.x), vreinterpretq_u64_u32(v.y))),
+    vreinterpretq_u32_u64(vtrn2q_u64(vreinterpretq_u64_u32(v.x), vreinterpretq_u64_u32(v.y))) };
+}
+
+static INLINE vmask2 vcast_vm2_aq(vargquad aq) {
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.aq = aq;
+  return vinterleave_vm2_vm2(c.vm2);
+}
+
+static INLINE vargquad vcast_aq_vm2(vmask2 vm2) {
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.vm2 = vuninterleave_vm2_vm2(vm2);
+  return c.aq;
+}
+
+static INLINE int vtestallzeros_i_vo64(vopmask g) {
+  uint32x2_t x0 = vorr_u32(vget_low_u32(g), vget_high_u32(g));
+  uint32x2_t x1 = vpmax_u32(x0, x0);
+  return ~vget_lane_u32(x1, 0);
+}
+
+static INLINE vmask vsel_vm_vo64_vm_vm(vopmask m, vmask x, vmask y) { return vbslq_u32(m, x, y); }
+
+static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) {
+  return vreinterpretq_u32_s64(vsubq_s64(vreinterpretq_s64_u32(x), vreinterpretq_s64_u32(y)));
+}
+
+static INLINE vmask vneg64_vm_vm(vmask x) {
+  return vreinterpretq_u32_s64(vnegq_s64(vreinterpretq_s64_u32(x)));
+}
+
+static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) {
+  return vreinterpretq_u32_u64(vcgtq_s64(vreinterpretq_s64_u32(x), vreinterpretq_s64_u32(y)));
+}
+
+static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) {
+  return vreinterpretq_u32_u64(vshlq_u64(vreinterpretq_u64_u32(x), vreinterpretq_s64_u32(c)));
+}
+static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) {
+  return vreinterpretq_u32_u64(vshlq_u64(vreinterpretq_u64_u32(x), vnegq_s64(vreinterpretq_s64_u32(c))));
+}
+#define vsll64_vm_vm_i(x, c) vreinterpretq_u32_u64(vshlq_n_u64(vreinterpretq_u64_u32(x), c))
+#define vsrl64_vm_vm_i(x, c) vreinterpretq_u32_u64(vshrq_n_u64(vreinterpretq_u64_u32(x), c))

--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -48,6 +48,10 @@ typedef __m128i vint;
 typedef __m256 vfloat;
 typedef struct { __m128i x, y; } vint2;
 
+typedef struct {
+  vmask x, y;
+} vmask2;
+
 //
 
 #ifndef __SLEEF_H__
@@ -552,3 +556,92 @@ static INLINE void vscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat
 }
 
 static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat v) { vscatter2_v_p_i_i_vf(ptr, offset, step, v); }
+
+//
+
+typedef Sleef_quad4 vargquad;
+
+static INLINE vmask2 vinterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) {
+    vreinterpret_vm_vd(_mm256_unpacklo_pd(vreinterpret_vd_vm(v.x), vreinterpret_vd_vm(v.y))),
+      vreinterpret_vm_vd(_mm256_unpackhi_pd(vreinterpret_vd_vm(v.x), vreinterpret_vd_vm(v.y))) };
+}
+
+static INLINE vmask2 vuninterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) {
+    vreinterpret_vm_vd(_mm256_unpacklo_pd(vreinterpret_vd_vm(v.x), vreinterpret_vd_vm(v.y))),
+      vreinterpret_vm_vd(_mm256_unpackhi_pd(vreinterpret_vd_vm(v.x), vreinterpret_vd_vm(v.y))) };
+}
+
+static vmask2 vloadu_vm2_p(void *p) {
+  vmask2 vm2 = {
+    vcast_vm_vi2(vloadu_vi2_p((int32_t *)p)),
+    vcast_vm_vi2(vloadu_vi2_p((int32_t *)((uint8_t *)p + sizeof(vmask))))
+  };
+  return vm2;
+}
+
+static void vstoreu_v_p_vm2(void *p, vmask2 vm2) {
+  vstoreu_v_p_vi2((int32_t *)p, vcast_vi2_vm(vm2.x));
+  vstoreu_v_p_vi2((int32_t *)((uint8_t *)p + sizeof(vmask)), vcast_vi2_vm(vm2.y));
+}
+
+static INLINE vmask2 vcast_vm2_aq(vargquad aq) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.aq = aq;
+  return vinterleave_vm2_vm2(c.vm2);
+#else
+  return vinterleave_vm2_vm2(vloadu_vm2_p(&aq));
+#endif
+}
+
+static INLINE vargquad vcast_aq_vm2(vmask2 vm2) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.vm2 = vuninterleave_vm2_vm2(vm2);
+  return c.aq;
+#else
+  vargquad a;
+  vstoreu_v_p_vm2(&a, vuninterleave_vm2_vm2(vm2));
+  return a;
+#endif
+}
+
+static INLINE int vtestallzeros_i_vo64(vopmask g) {
+  return _mm_movemask_epi8(_mm_or_si128(_mm256_extractf128_si256(g, 0), _mm256_extractf128_si256(g, 1))) == 0;
+}
+
+static INLINE vmask vsel_vm_vo64_vm_vm(vopmask o, vmask x, vmask y) {
+  return vreinterpret_vm_vd(_mm256_blendv_pd(vreinterpret_vd_vm(y), vreinterpret_vd_vm(x), vreinterpret_vd_vm(o)));
+}
+
+static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) {
+  __m128i xh = _mm256_extractf128_si256(x, 1), xl = _mm256_extractf128_si256(x, 0);
+  __m128i yh = _mm256_extractf128_si256(y, 1), yl = _mm256_extractf128_si256(y, 0);
+  vmask r = _mm256_castsi128_si256(_mm_sub_epi64(xl, yl));
+  return _mm256_insertf128_si256(r, _mm_sub_epi64(xh, yh), 1);
+}
+
+static INLINE vmask vneg64_vm_vm(vmask x) { return vsub64_vm_vm_vm(vcast_vm_i_i(0, 0), x); }
+static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) {
+  __m128i xh = _mm256_extractf128_si256(x, 1), xl = _mm256_extractf128_si256(x, 0);
+  __m128i yh = _mm256_extractf128_si256(y, 1), yl = _mm256_extractf128_si256(y, 0);
+  vmask r = _mm256_castsi128_si256(_mm_cmpgt_epi64(xl, yl));
+  return _mm256_insertf128_si256(r, _mm_cmpgt_epi64(xh, yh), 1);
+}
+
+static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return _mm256_sllv_epi64(x, c); }
+static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return _mm256_srlv_epi64(x, c); }
+#define vsll64_vm_vm_i(x, c) \
+  _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_slli_epi64(_mm256_extractf128_si256(x, 0), c)), \
+			  _mm_slli_epi64(_mm256_extractf128_si256(x, 1), c), 1)
+#define vsrl64_vm_vm_i(x, c) \
+  _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_srli_epi64(_mm256_extractf128_si256(x, 0), c)), \
+			  _mm_srli_epi64(_mm256_extractf128_si256(x, 1), c), 1)

--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -637,8 +637,6 @@ static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) {
   return _mm256_insertf128_si256(r, _mm_cmpgt_epi64(xh, yh), 1);
 }
 
-static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return _mm256_sllv_epi64(x, c); }
-static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return _mm256_srlv_epi64(x, c); }
 #define vsll64_vm_vm_i(x, c) \
   _mm256_insertf128_si256(_mm256_castsi128_si256(_mm_slli_epi64(_mm256_extractf128_si256(x, 0), c)), \
 			  _mm_slli_epi64(_mm256_extractf128_si256(x, 1), c), 1)

--- a/src/arch/helperavx2.h
+++ b/src/arch/helperavx2.h
@@ -479,7 +479,5 @@ static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) { return _mm256_sub_epi64(
 static INLINE vmask vneg64_vm_vm(vmask x) { return _mm256_sub_epi64(vcast_vm_i_i(0, 0), x); }
 static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) { return _mm256_cmpgt_epi64(x, y); } // signed compare
 
-static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return _mm256_sllv_epi64(x, c); }
-static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return _mm256_srlv_epi64(x, c); }
 #define vsll64_vm_vm_i(x, c) _mm256_slli_epi64(x, c)
 #define vsrl64_vm_vm_i(x, c) _mm256_srli_epi64(x, c)

--- a/src/arch/helperavx2.h
+++ b/src/arch/helperavx2.h
@@ -45,6 +45,10 @@ typedef __m128i vint;
 typedef __m256 vfloat;
 typedef __m256i vint2;
 
+typedef struct {
+  vmask x, y;
+} vmask2;
+
 //
 
 #ifndef __SLEEF_H__
@@ -411,3 +415,71 @@ static INLINE void vscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat
 }
 
 static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat v) { vscatter2_v_p_i_i_vf(ptr, offset, step, v); }
+
+//
+
+typedef Sleef_quad4 vargquad;
+
+static INLINE vmask2 vinterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) { _mm256_unpacklo_epi64(v.x, v.y), _mm256_unpackhi_epi64(v.x, v.y) };
+}
+
+static INLINE vmask2 vuninterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) { _mm256_unpacklo_epi64(v.x, v.y), _mm256_unpackhi_epi64(v.x, v.y) };
+}
+
+static vmask2 vloadu_vm2_p(void *p) {
+  vmask2 vm2 = {
+    vloadu_vi2_p((int32_t *)p),
+    vloadu_vi2_p((int32_t *)((uint8_t *)p + sizeof(vmask)))
+  };
+  return vm2;
+}
+
+static void vstoreu_v_p_vm2(void *p, vmask2 vm2) {
+  vstoreu_v_p_vi2((int32_t *)p, vcast_vi2_vm(vm2.x));
+  vstoreu_v_p_vi2((int32_t *)((uint8_t *)p + sizeof(vmask)), vcast_vi2_vm(vm2.y));
+}
+
+static INLINE vmask2 vcast_vm2_aq(vargquad aq) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.aq = aq;
+  return vinterleave_vm2_vm2(c.vm2);
+#else
+  return vinterleave_vm2_vm2(vloadu_vm2_p(&aq));
+#endif
+}
+
+static INLINE vargquad vcast_aq_vm2(vmask2 vm2) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.vm2 = vuninterleave_vm2_vm2(vm2);
+  return c.aq;
+#else
+  vargquad a;
+  vstoreu_v_p_vm2(&a, vuninterleave_vm2_vm2(vm2));
+  return a;
+#endif
+}
+
+static INLINE int vtestallzeros_i_vo64(vopmask g) {
+  return _mm_movemask_epi8(_mm_or_si128(_mm256_extractf128_si256(g, 0), _mm256_extractf128_si256(g, 1))) == 0;
+}
+
+static INLINE vmask vsel_vm_vo64_vm_vm(vopmask o, vmask x, vmask y) { return _mm256_blendv_epi8(y, x, o); }
+
+static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) { return _mm256_sub_epi64(x, y); }
+static INLINE vmask vneg64_vm_vm(vmask x) { return _mm256_sub_epi64(vcast_vm_i_i(0, 0), x); }
+static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) { return _mm256_cmpgt_epi64(x, y); } // signed compare
+
+static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return _mm256_sllv_epi64(x, c); }
+static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return _mm256_srlv_epi64(x, c); }
+#define vsll64_vm_vm_i(x, c) _mm256_slli_epi64(x, c)
+#define vsrl64_vm_vm_i(x, c) _mm256_srli_epi64(x, c)

--- a/src/arch/helperavx2_128.h
+++ b/src/arch/helperavx2_128.h
@@ -451,7 +451,5 @@ static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) { return _mm_sub_epi64(x, 
 static INLINE vmask vneg64_vm_vm(vmask x) { return _mm_sub_epi64(vcast_vm_i_i(0, 0), x); }
 static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) { return _mm_cmpgt_epi64(x, y); } // signed compare
 
-static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return _mm_sllv_epi64(x, c); }
-static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return _mm_srlv_epi64(x, c); }
 #define vsll64_vm_vm_i(x, c) _mm_slli_epi64(x, c)
 #define vsrl64_vm_vm_i(x, c) _mm_srli_epi64(x, c)

--- a/src/arch/helperavx2_128.h
+++ b/src/arch/helperavx2_128.h
@@ -45,6 +45,10 @@ typedef __m128i vint;
 typedef __m128  vfloat;
 typedef __m128i vint2;
 
+typedef struct {
+  vmask x, y;
+} vmask2;
+
 //
 
 #ifndef __SLEEF_H__
@@ -385,3 +389,69 @@ static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloa
   _mm_storel_pd((double *)(ptr+(offset + step * 0)*2), vreinterpret_vd_vm(vreinterpret_vm_vf(v)));
   _mm_storeh_pd((double *)(ptr+(offset + step * 1)*2), vreinterpret_vd_vm(vreinterpret_vm_vf(v)));
 }
+
+//
+
+typedef Sleef_quad2 vargquad;
+
+static INLINE vmask2 vinterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) { _mm_unpacklo_epi64(v.x, v.y), _mm_unpackhi_epi64(v.x, v.y) };
+}
+
+static INLINE vmask2 vuninterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) { _mm_unpacklo_epi64(v.x, v.y), _mm_unpackhi_epi64(v.x, v.y) };
+}
+
+static vmask2 vloadu_vm2_p(void *p) {
+  vmask2 vm2 = {
+    vloadu_vi2_p((int32_t *)p),
+    vloadu_vi2_p((int32_t *)((uint8_t *)p + sizeof(vmask)))
+  };
+  return vm2;
+}
+
+static void vstoreu_v_p_vm2(void *p, vmask2 vm2) {
+  vstoreu_v_p_vi2((int32_t *)p, vcast_vi2_vm(vm2.x));
+  vstoreu_v_p_vi2((int32_t *)((uint8_t *)p + sizeof(vmask)), vcast_vi2_vm(vm2.y));
+}
+
+static INLINE vmask2 vcast_vm2_aq(vargquad aq) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.aq = aq;
+  return vinterleave_vm2_vm2(c.vm2);
+#else
+  return vinterleave_vm2_vm2(vloadu_vm2_p(&aq));
+#endif
+}
+
+static INLINE vargquad vcast_aq_vm2(vmask2 vm2) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.vm2 = vuninterleave_vm2_vm2(vm2);
+  return c.aq;
+#else
+  vargquad a;
+  vstoreu_v_p_vm2(&a, vuninterleave_vm2_vm2(vm2));
+  return a;
+#endif
+}
+
+static INLINE int vtestallzeros_i_vo64(vopmask g) { return _mm_movemask_epi8(g) == 0; }
+
+static INLINE vmask vsel_vm_vo64_vm_vm(vopmask o, vmask x, vmask y) { return _mm_blendv_epi8(y, x, o); }
+
+static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) { return _mm_sub_epi64(x, y); }
+static INLINE vmask vneg64_vm_vm(vmask x) { return _mm_sub_epi64(vcast_vm_i_i(0, 0), x); }
+static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) { return _mm_cmpgt_epi64(x, y); } // signed compare
+
+static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return _mm_sllv_epi64(x, c); }
+static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return _mm_srlv_epi64(x, c); }
+#define vsll64_vm_vm_i(x, c) _mm_slli_epi64(x, c)
+#define vsrl64_vm_vm_i(x, c) _mm_srli_epi64(x, c)

--- a/src/arch/helperavx512f.h
+++ b/src/arch/helperavx512f.h
@@ -598,7 +598,5 @@ static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) { return _mm512_sub_epi64(
 static INLINE vmask vneg64_vm_vm(vmask x) { return _mm512_sub_epi64(vcast_vm_i_i(0, 0), x); }
 static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) { return _mm512_cmp_epi64_mask(y, x, _MM_CMPINT_LT); } // signed compare
 
-static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return _mm512_sllv_epi64(x, c); }
-static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return _mm512_srlv_epi64(x, c); }
 #define vsll64_vm_vm_i(x, c) _mm512_slli_epi64(x, c)
 #define vsrl64_vm_vm_i(x, c) _mm512_srli_epi64(x, c)

--- a/src/arch/helperavx512f.h
+++ b/src/arch/helperavx512f.h
@@ -48,6 +48,10 @@ typedef __m256i vint;
 typedef __m512 vfloat;
 typedef __m512i vint2;
 
+typedef struct {
+  vmask x, y;
+} vmask2;
+
 //
 
 #ifndef __SLEEF_H__
@@ -528,3 +532,73 @@ static INLINE void vscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat
 }
 
 static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat v) { vscatter2_v_p_i_i_vf(ptr, offset, step, v); }
+
+//
+
+typedef Sleef_quad8 vargquad;
+
+static INLINE vmask2 vinterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) { _mm512_unpacklo_epi64(v.x, v.y), _mm512_unpackhi_epi64(v.x, v.y) };
+}
+
+static INLINE vmask2 vuninterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) { _mm512_unpacklo_epi64(v.x, v.y), _mm512_unpackhi_epi64(v.x, v.y) };
+}
+
+static vmask2 vloadu_vm2_p(void *p) {
+  vmask2 vm2 = {
+    vloadu_vi2_p((int32_t *)p),
+    vloadu_vi2_p((int32_t *)((uint8_t *)p + sizeof(vmask)))
+  };
+  return vm2;
+}
+
+static void vstoreu_v_p_vm2(void *p, vmask2 vm2) {
+  vstoreu_v_p_vi2((int32_t *)p, vcast_vi2_vm(vm2.x));
+  vstoreu_v_p_vi2((int32_t *)((uint8_t *)p + sizeof(vmask)), vcast_vi2_vm(vm2.y));
+}
+
+static INLINE vmask2 vcast_vm2_aq(vargquad aq) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.aq = aq;
+  return vinterleave_vm2_vm2(c.vm2);
+#else
+  return vinterleave_vm2_vm2(vloadu_vm2_p(&aq));
+#endif
+}
+
+static INLINE vargquad vcast_aq_vm2(vmask2 vm2) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.vm2 = vuninterleave_vm2_vm2(vm2);
+  return c.aq;
+#else
+  vargquad a;
+  vstoreu_v_p_vm2(&a, vuninterleave_vm2_vm2(vm2));
+  return a;
+#endif
+}
+
+#ifdef __INTEL_COMPILER
+static INLINE int vtestallzeros_i_vo64(vopmask g) { return _mm512_mask2int(g) == 0; }
+#else
+static INLINE int vtestallzeros_i_vo64(vopmask g) { return g == 0; }
+#endif
+
+static INLINE vmask vsel_vm_vo64_vm_vm(vopmask m, vmask x, vmask y) { return _mm512_mask_blend_epi64(m, y, x); }
+
+static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) { return _mm512_sub_epi64(x, y); }
+static INLINE vmask vneg64_vm_vm(vmask x) { return _mm512_sub_epi64(vcast_vm_i_i(0, 0), x); }
+static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) { return _mm512_cmp_epi64_mask(y, x, _MM_CMPINT_LT); } // signed compare
+
+static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return _mm512_sllv_epi64(x, c); }
+static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return _mm512_srlv_epi64(x, c); }
+#define vsll64_vm_vm_i(x, c) _mm512_slli_epi64(x, c)
+#define vsrl64_vm_vm_i(x, c) _mm512_srli_epi64(x, c)

--- a/src/arch/helperpurec.h
+++ b/src/arch/helperpurec.h
@@ -47,7 +47,7 @@ typedef union {
 typedef longdoubleVector vmaskl;
 typedef longdoubleVector vlongdouble;
 
-#ifdef Sleef_quad2_DEFINED
+#if defined(Sleef_quad2_DEFINED) && defined(ENABLEFLOAT128)
 typedef union {
   uint8_t u[sizeof(Sleef_quad)*VECTLENDP];
   Sleef_quad q[VECTLENDP];
@@ -501,7 +501,7 @@ static INLINE void vscatter2_v_p_i_i_vl(long double *ptr, int offset, int step, 
 
 static INLINE void vsscatter2_v_p_i_i_vl(long double *ptr, int offset, int step, vlongdouble v) { vscatter2_v_p_i_i_vl(ptr, offset, step, v); }
 
-#ifdef Sleef_quad2_DEFINED
+#if defined(Sleef_quad2_DEFINED) && defined(ENABLEFLOAT128)
 static INLINE vquad vcast_vq_q(Sleef_quad d) { vquad ret; for(int i=0;i<VECTLENDP;i++) ret.q[i] = d; return ret; }
 
 static INLINE vquad vrev21_vq_vq(vquad d0) {

--- a/src/arch/helperpurec_scalar.h
+++ b/src/arch/helperpurec_scalar.h
@@ -90,6 +90,10 @@ typedef int32_t vint;
 typedef float vfloat;
 typedef int64_t vint2;
 
+typedef struct {
+  vmask x, y;
+} vmask2;
+
 //
 
 static INLINE int vavailability_i(int name) { return -1; }
@@ -367,3 +371,41 @@ static INLINE vfloat vgather_vf_p_vi2(const float *ptr, vint2 vi) { return ptr[v
 static INLINE void vstore_v_p_vf(float *ptr, vfloat v) { *ptr = v; }
 static INLINE void vstoreu_v_p_vf(float *ptr, vfloat v) { *ptr = v; }
 static INLINE void vstream_v_p_vf(float *ptr, vfloat v) { *ptr = v; }
+
+//
+
+typedef Sleef_quad1 vargquad;
+
+static INLINE vmask2 vinterleave_vm2_vm2(vmask2 v) { return v; }
+static INLINE vmask2 vuninterleave_vm2_vm2(vmask2 v) { return v; }
+
+static INLINE vmask2 vcast_vm2_aq(vargquad aq) {
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.aq = aq;
+  return c.vm2;
+}
+
+static INLINE vargquad vcast_aq_vm2(vmask2 vm2) {
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.vm2 = vm2;
+  return c.aq;
+}
+
+static INLINE int vtestallzeros_i_vo64(vopmask g) { return !g ? ~(uint32_t)0 : 0; }
+static INLINE vmask vsel_vm_vo64_vm_vm(vopmask o, vmask x, vmask y) { return o ? x : y; }
+
+static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) { return (int64_t)x - (int64_t)y; }
+static INLINE vmask vneg64_vm_vm(vmask x) { return -(int64_t)x; }
+
+#define vsll64_vm_vm_i(x, c) ((uint64_t)(x) << (c))
+#define vsrl64_vm_vm_i(x, c) ((uint64_t)(x) >> (c))
+
+static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) { return (int64_t)x > (int64_t)y ? ~(uint32_t)0 : 0; }
+static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return x << c; }
+static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return x >> c; }

--- a/src/arch/helperpurec_scalar.h
+++ b/src/arch/helperpurec_scalar.h
@@ -407,5 +407,3 @@ static INLINE vmask vneg64_vm_vm(vmask x) { return -(int64_t)x; }
 #define vsrl64_vm_vm_i(x, c) ((uint64_t)(x) >> (c))
 
 static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) { return (int64_t)x > (int64_t)y ? ~(uint32_t)0 : 0; }
-static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) { return x << c; }
-static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) { return x >> c; }

--- a/src/arch/helpersse2.h
+++ b/src/arch/helpersse2.h
@@ -53,6 +53,10 @@ typedef __m128i vint;
 typedef __m128  vfloat;
 typedef __m128i vint2;
 
+typedef struct {
+  vmask x, y;
+} vmask2;
+
 //
 
 #ifndef __SLEEF_H__
@@ -435,4 +439,90 @@ static INLINE void vscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat
 static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat v) {
   _mm_storel_pd((double *)(ptr+(offset + step * 0)*2), vreinterpret_vd_vm(vreinterpret_vm_vf(v)));
   _mm_storeh_pd((double *)(ptr+(offset + step * 1)*2), vreinterpret_vd_vm(vreinterpret_vm_vf(v)));
+}
+
+//
+
+typedef Sleef_quad2 vargquad;
+
+static INLINE vmask2 vinterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) { _mm_unpacklo_epi64(v.x, v.y), _mm_unpackhi_epi64(v.x, v.y) };
+}
+
+static INLINE vmask2 vuninterleave_vm2_vm2(vmask2 v) {
+  return (vmask2) { _mm_unpacklo_epi64(v.x, v.y), _mm_unpackhi_epi64(v.x, v.y) };
+}
+
+static vmask2 vloadu_vm2_p(void *p) {
+  vmask2 vm2 = {
+    vloadu_vi2_p((int32_t *)p),
+    vloadu_vi2_p((int32_t *)((uint8_t *)p + sizeof(vmask)))
+  };
+  return vm2;
+}
+
+static void vstoreu_v_p_vm2(void *p, vmask2 vm2) {
+  vstoreu_v_p_vi2((int32_t *)p, vcast_vi2_vm(vm2.x));
+  vstoreu_v_p_vi2((int32_t *)((uint8_t *)p + sizeof(vmask)), vcast_vi2_vm(vm2.y));
+}
+
+static INLINE vmask2 vcast_vm2_aq(vargquad aq) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.aq = aq;
+  return vinterleave_vm2_vm2(c.vm2);
+#else
+  return vinterleave_vm2_vm2(vloadu_vm2_p(&aq));
+#endif
+}
+
+static INLINE vargquad vcast_aq_vm2(vmask2 vm2) {
+#if !defined(_MSC_VER)
+  union {
+    vargquad aq;
+    vmask2 vm2;
+  } c;
+  c.vm2 = vuninterleave_vm2_vm2(vm2);
+  return c.aq;
+#else
+  vargquad a;
+  vstoreu_v_p_vm2(&a, vuninterleave_vm2_vm2(vm2));
+  return a;
+#endif
+}
+
+static INLINE int vtestallzeros_i_vo64(vopmask g) { return _mm_movemask_epi8(g) == 0; }
+
+static INLINE vmask vsel_vm_vo64_vm_vm(vopmask o, vmask x, vmask y) {
+  return vor_vm_vm_vm(vand_vm_vm_vm(o, x), vandnot_vm_vm_vm(o, y));
+}
+
+static INLINE vmask vsub64_vm_vm_vm(vmask x, vmask y) { return _mm_sub_epi64(x, y); }
+static INLINE vmask vneg64_vm_vm(vmask x) { return _mm_sub_epi64(vcast_vm_i_i(0, 0), x); }
+
+#define vsll64_vm_vm_i(x, c) _mm_slli_epi64(x, c)
+#define vsrl64_vm_vm_i(x, c) _mm_srli_epi64(x, c)
+
+static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) {
+  int64_t ax[2], ay[2];
+  _mm_storeu_si128((__m128i *)ax, x);
+  _mm_storeu_si128((__m128i *)ay, y);
+  return _mm_set_epi64x(ax[1] > ay[1] ? -1 : 0, ax[0] > ay[0] ? -1 : 0);
+}
+
+static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) {
+  uint64_t ax[2], ac[2];
+  _mm_storeu_si128((__m128i *)ax, x);
+  _mm_storeu_si128((__m128i *)ac, c);
+  return _mm_set_epi64x(ac[1] > 63 ? 0 : (ax[1] << ac[1]), ac[0] > 63 ? 0 : (ax[0] << ac[0]));
+}
+
+static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) {
+  uint64_t ax[2], ac[2];
+  _mm_storeu_si128((__m128i *)ax, x);
+  _mm_storeu_si128((__m128i *)ac, c);
+  return _mm_set_epi64x(ac[1] > 63 ? 0 : (ax[1] >> ac[1]), ac[0] > 63 ? 0 : (ax[0] >> ac[0]));
 }

--- a/src/arch/helpersse2.h
+++ b/src/arch/helpersse2.h
@@ -512,17 +512,3 @@ static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) {
   _mm_storeu_si128((__m128i *)ay, y);
   return _mm_set_epi64x(ax[1] > ay[1] ? -1 : 0, ax[0] > ay[0] ? -1 : 0);
 }
-
-static INLINE vmask vsll64_vm_vm_vm(vmask x, vmask c) {
-  uint64_t ax[2], ac[2];
-  _mm_storeu_si128((__m128i *)ax, x);
-  _mm_storeu_si128((__m128i *)ac, c);
-  return _mm_set_epi64x(ac[1] > 63 ? 0 : (ax[1] << ac[1]), ac[0] > 63 ? 0 : (ax[0] << ac[0]));
-}
-
-static INLINE vmask vsrl64_vm_vm_vm(vmask x, vmask c) {
-  uint64_t ax[2], ac[2];
-  _mm_storeu_si128((__m128i *)ax, x);
-  _mm_storeu_si128((__m128i *)ac, c);
-  return _mm_set_epi64x(ac[1] > 63 ? 0 : (ax[1] >> ac[1]), ac[0] > 63 ? 0 : (ax[0] >> ac[0]));
-}

--- a/src/arch/helpervecext.h
+++ b/src/arch/helpervecext.h
@@ -37,7 +37,7 @@ typedef uint8_t vmaskl __attribute__((ext_vector_type(sizeof(long double)*VECTLE
 typedef long double vlongdouble __attribute__((ext_vector_type(VECTLENDP)));
 #endif
 
-#ifdef Sleef_quad2_DEFINED
+#if defined(Sleef_quad2_DEFINED) && defined(ENABLEFLOAT128)
 typedef uint8_t vmaskq __attribute__((ext_vector_type(sizeof(Sleef_quad)*VECTLENDP)));
 #ifdef ENABLE_LONGDOUBLE
 typedef Sleef_quad vquad __attribute__((ext_vector_type(VECTLENDP)));
@@ -60,7 +60,7 @@ typedef uint8_t vmaskl __attribute__((vector_size(sizeof(long double)*VECTLENDP)
 typedef long double vlongdouble __attribute__((vector_size(sizeof(long double)*VECTLENDP)));
 #endif
 
-#ifdef Sleef_quad2_DEFINED
+#if defined(Sleef_quad2_DEFINED) && defined(ENABLEFLOAT128)
 typedef uint8_t vmaskq __attribute__((vector_size(sizeof(Sleef_quad)*VECTLENDP)));
 typedef Sleef_quad vquad __attribute__((vector_size(sizeof(Sleef_quad)*VECTLENDP)));
 #endif
@@ -79,7 +79,7 @@ static INLINE vdouble vcast_vd_d(double d) { return (vdouble) { d, d }; }
 #ifdef ENABLE_LONGDOUBLE
 static INLINE vlongdouble vcast_vl_l(long double d) { return (vlongdouble) { d, d }; }
 #endif
-#ifdef Sleef_quad2_DEFINED
+#if defined(Sleef_quad2_DEFINED) && defined(ENABLEFLOAT128)
 static INLINE vquad vcast_vq_q(Sleef_quad d) { return (vquad) { d, d }; }
 #endif
 
@@ -101,7 +101,7 @@ static INLINE vlongdouble vposneg_vl_vl(vlongdouble vd) { return (vlongdouble) {
 static INLINE vlongdouble vnegpos_vl_vl(vlongdouble vd) { return (vlongdouble) { -vd[0], +vd[1] }; }
 #endif
 
-#ifdef Sleef_quad2_DEFINED
+#if defined(Sleef_quad2_DEFINED) && defined(ENABLEFLOAT128)
 static INLINE vquad vrev21_vq_vq(vquad vd) { return (vquad) { vd[1], vd[0] }; }
 static INLINE vquad vreva2_vq_vq(vquad vd) { return vd; }
 static INLINE vquad vposneg_vq_vq(vquad vd) { return (vquad) { +vd[0], -vd[1] }; }
@@ -839,7 +839,7 @@ static INLINE void vscatter2_v_p_i_i_vl(long double *ptr, int offset, int step, 
 static INLINE void vsscatter2_v_p_i_i_vl(long double *ptr, int offset, int step, vlongdouble v) { vscatter2_v_p_i_i_vl(ptr, offset, step, v); }
 #endif
 
-#ifdef Sleef_quad2_DEFINED
+#if defined(Sleef_quad2_DEFINED) && defined(ENABLEFLOAT128)
 static INLINE vquad vadd_vq_vq_vq(vquad x, vquad y) { return x + y; }
 static INLINE vquad vsub_vq_vq_vq(vquad x, vquad y) { return x - y; }
 static INLINE vquad vmul_vq_vq_vq(vquad x, vquad y) { return x * y; }

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -221,12 +221,7 @@ typedef union {
 #define UNLIKELY(condition) __builtin_expect(!!(condition), 0)
 #define RESTRICT __restrict__
 
-#ifndef __ARM_FEATURE_SVE
 #define INLINE __attribute__((always_inline))
-#else
-// This is a workaround of a bug in armclang
-#define INLINE
-#endif
 
 #ifndef __arm__
 #define ALIGNED(x) __attribute__((aligned(x)))

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -5,6 +5,8 @@
 
 //
 
+#include <stdint.h>
+
 #ifndef __MISC_H__
 #define __MISC_H__
 
@@ -165,12 +167,50 @@ typedef struct {
 } Sleef_longdouble2;
 #endif
 
-#if defined(ENABLEFLOAT128) && !defined(Sleef_quad2_DEFINED)
-#define Sleef_quad2_DEFINED
+#if !defined(Sleef_quad_DEFINED)
+#define Sleef_quad_DEFINED
+#if defined(ENABLEFLOAT128)
 typedef __float128 Sleef_quad;
-typedef struct {
-  __float128 x, y;
+#else
+typedef struct { uint64_t x, y; } Sleef_quad;
+#endif
+#endif
+
+#if !defined(Sleef_quad1_DEFINED)
+#define Sleef_quad1_DEFINED
+typedef union {
+  struct {
+    Sleef_quad x;
+  };
+  Sleef_quad s[1];
+} Sleef_quad1;
+#endif
+
+#if !defined(Sleef_quad2_DEFINED)
+#define Sleef_quad2_DEFINED
+typedef union {
+  struct {
+    Sleef_quad x, y;
+  };
+  Sleef_quad s[2];
 } Sleef_quad2;
+#endif
+
+#if !defined(Sleef_quad4_DEFINED)
+#define Sleef_quad4_DEFINED
+typedef union {
+  struct {
+    Sleef_quad x, y, z, w;
+  };
+  Sleef_quad s[4];
+} Sleef_quad4;
+#endif
+
+#if !defined(Sleef_quad8_DEFINED)
+#define Sleef_quad8_DEFINED
+typedef union {
+  Sleef_quad s[8];
+} Sleef_quad8;
 #endif
 
 //

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -7,6 +7,11 @@
 
 #include <stdint.h>
 
+#ifdef __ARM_FEATURE_SVE
+#include <arm_sve.h> // Needed to use svcntd()
+#endif
+
+
 #ifndef __MISC_H__
 #define __MISC_H__
 
@@ -211,6 +216,13 @@ typedef union {
 typedef union {
   Sleef_quad s[8];
 } Sleef_quad8;
+#endif
+
+#if defined(__ARM_FEATURE_SVE) && !defined(Sleef_quadx_DEFINED)
+#define Sleef_quadx_DEFINED
+typedef union {
+  Sleef_quad s[32];
+} Sleef_quadx;
 #endif
 
 //

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -8,6 +8,8 @@
 #ifndef __MISC_H__
 #define __MISC_H__
 
+#include <stdint.h>
+
 #ifndef M_PI
 #define M_PI 3.141592653589793238462643383279502884
 #endif

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -5,13 +5,6 @@
 
 //
 
-#include <stdint.h>
-
-#ifdef __ARM_FEATURE_SVE
-#include <arm_sve.h> // Needed to use svcntd()
-#endif
-
-
 #ifndef __MISC_H__
 #define __MISC_H__
 

--- a/src/libm/sleeflibm_header.h.org
+++ b/src/libm/sleeflibm_header.h.org
@@ -97,11 +97,22 @@ typedef struct {
 } Sleef_longdouble2;
 #endif
 
-#if defined(ENABLEFLOAT128) && !defined(Sleef_quad2_DEFINED)
-#define Sleef_quad2_DEFINED
+#if !defined(Sleef_quad_DEFINED)
+#define Sleef_quad_DEFINED
+#if defined(ENABLEFLOAT128)
 typedef __float128 Sleef_quad;
-typedef struct {
-  __float128 x, y;
+#else
+typedef struct { uint64_t x, y; } Sleef_quad;
+#endif
+#endif
+
+#if !defined(Sleef_quad2_DEFINED)
+#define Sleef_quad2_DEFINED
+typedef union {
+  struct {
+    Sleef_quad x, y;
+  };
+  Sleef_quad s[2];
 } Sleef_quad2;
 #endif
 

--- a/src/quad-tester/CMakeLists.txt
+++ b/src/quad-tester/CMakeLists.txt
@@ -1,0 +1,115 @@
+# Note: We are assuming SLEEF is the CMake root project.
+# TODO: Remove constraint: do not use CMAKE_BINARY_DIR and CMAKE_SOURCE_DIR
+link_directories(${CMAKE_BINARY_DIR}/lib)                 # libsleefquad
+link_directories(${CMAKE_BINARY_DIR}/src/common)          # common.a
+include_directories(${CMAKE_BINARY_DIR}/include)          # sleef.h, sleefquad.h
+include_directories(${CMAKE_SOURCE_DIR}/src/quad)         # qrename.h
+include_directories(${CMAKE_BINARY_DIR}/src/quad/include) # rename headers
+
+if(NOT LIB_MPFR)
+  find_program(TESTER_COMMAND qtester)
+endif(NOT LIB_MPFR)
+
+find_library(LIBRT rt)
+if (NOT LIBRT)
+  set(LIBRT "")
+endif()
+
+set(CMAKE_C_FLAGS ORG_CMAKE_C_FLAGS)
+string(CONCAT CMAKE_C_FLAGS ${SLEEF_C_FLAGS})
+
+if(COMPILER_SUPPORTS_FLOAT128)
+  list(APPEND COMMON_TARGET_DEFINITIONS ENABLEFLOAT128=1)
+endif()
+
+#
+
+function(add_test_iut IUT)
+  if (LIB_MPFR)
+    set(TESTER qtester)
+  elseif(TESTER_COMMAND)
+    set(TESTER ${TESTER_COMMAND})
+  endif()
+  # When we are crosscompiling using the mkrename* tools from a native
+  # build, we use the tester executable from the native build.
+  if (CMAKE_CROSSCOMPILING AND NATIVE_BUILD_DIR)
+    set(TESTER ${NATIVE_BUILD_DIR}/bin/qtester)
+  endif(CMAKE_CROSSCOMPILING AND NATIVE_BUILD_DIR)
+  if (TESTER)
+    if (NOT EMULATOR)
+      if (SDE_COMMAND)
+	set(FLAGS_SDE "--sde" ${SDE_COMMAND})
+      else()
+	set(FLAGS_SDE)
+      endif()
+      if (ARMIE_COMMAND)
+        set(FLAGS_ARMIE ${ARMIE_COMMAND} -msve-vector-bits=${SVE_VECTOR_BITS})
+      else()
+        set(FLAGS_ARMIE)
+      endif()
+      add_test(NAME ${IUT}
+	COMMAND ${TESTER} ${FLAGS_SDE} ${FLAGS_ARMIE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${IUT}
+	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+    else()
+      add_test(NAME ${IUT}
+	COMMAND ${TESTER} ${EMULATOR} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${IUT}
+	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+    endif()
+  endif()
+endfunction()
+
+# Add vector extension `iut`s
+set(IUT_SRC qiutsimd.c qiutsimdmain.c qtesterutil.c)
+
+macro(test_extension SIMD)
+  if(COMPILER_SUPPORTS_${SIMD})
+    string(TOLOWER ${SIMD} LCSIMD)
+    string(CONCAT TARGET_IUT${SIMD} "qiut" ${LCSIMD})
+
+    add_executable(${TARGET_IUT${SIMD}} ${IUT_SRC})
+    target_compile_options(${TARGET_IUT${SIMD}}
+      PRIVATE ${FLAGS_ENABLE_${SIMD}})
+    target_compile_definitions(${TARGET_IUT${SIMD}}
+      PRIVATE ENABLE_${SIMD}=1 ${COMMON_TARGET_DEFINITIONS})
+    target_link_libraries(${TARGET_IUT${SIMD}} sleefquad ${TARGET_LIBSLEEF} ${LIBM} ${LIBRT})
+
+    add_dependencies(${TARGET_IUT${SIMD}} sleefquad_headers ${TARGET_HEADERS})
+    add_dependencies(${TARGET_IUT${SIMD}} sleefquad ${TARGET_LIBSLEEF})
+    set_target_properties(${TARGET_IUT${SIMD}} PROPERTIES C_STANDARD 99)
+    add_test_iut(${TARGET_IUT${SIMD}})
+    list(APPEND IUT_LIST ${TARGET_IUT${SIMD}})
+
+    if(LIB_MPFR AND NOT MINGW)
+      # Build qtester2 SIMD
+      string(TOLOWER ${SIMD} SIMDLC)
+      set(T "tester2${SIMDLC}qp")
+      add_executable(${T} tester2simdqp.c qtesterutil.c)
+      target_compile_options(${T} PRIVATE ${FLAGS_ENABLE_${SIMD}})
+      target_compile_definitions(${T} PRIVATE ENABLE_${SIMD}=1 USEMPFR=1 ${COMMON_TARGET_DEFINITIONS})
+      set_target_properties(${T} PROPERTIES C_STANDARD 99)
+      target_link_libraries(${T} sleefquad ${TARGET_LIBSLEEF} ${LIB_MPFR} ${LIBM} ${LIBGMP})
+      add_dependencies(${T} sleefquad sleefquad_headers ${TARGET_LIBSLEEF} ${TARGET_HEADERS})
+      if (MPFR_INCLUDE_DIR)
+	target_include_directories(${T} PRIVATE ${MPFR_INCLUDE_DIR})
+      endif()
+    endif()
+  endif(COMPILER_SUPPORTS_${SIMD})
+endmacro(test_extension)
+
+foreach(SIMD ${SLEEFQUAD_SUPPORTED_EXT})
+  test_extension(${SIMD})
+endforeach()
+
+if(LIB_MPFR AND NOT MINGW)
+  # Compile executable 'qtester'
+  add_host_executable(qtester qtester.c qtesterutil.c)
+  if (NOT CMAKE_CROSSCOMPILING)
+    target_link_libraries(qtester sleefquad ${TARGET_LIBSLEEF} ${LIBM} ${LIB_MPFR} ${LIBGMP})
+    target_compile_definitions(qtester PRIVATE USEMPFR=1 ${COMMON_TARGET_DEFINITIONS})
+    target_compile_options(qtester PRIVATE -Wno-unused-result)
+    set_target_properties(qtester PROPERTIES C_STANDARD 99)
+    if (MPFR_INCLUDE_DIR)
+      target_include_directories(qtester PRIVATE ${MPFR_INCLUDE_DIR})
+    endif()
+  endif()
+endif(LIB_MPFR AND NOT MINGW)

--- a/src/quad-tester/CMakeLists.txt
+++ b/src/quad-tester/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/quad)         # qrename.h
 include_directories(${CMAKE_BINARY_DIR}/src/quad/include) # rename headers
 
 if(NOT LIB_MPFR)
-  find_program(TESTER_COMMAND qtester)
+  find_program(QTESTER_COMMAND qtester)
 endif(NOT LIB_MPFR)
 
 find_library(LIBRT rt)
@@ -26,16 +26,16 @@ endif()
 
 function(add_test_iut IUT)
   if (LIB_MPFR)
-    set(TESTER qtester)
-  elseif(TESTER_COMMAND)
-    set(TESTER ${TESTER_COMMAND})
+    set(QTESTER qtester)
+  elseif(QTESTER_COMMAND)
+    set(QTESTER ${QTESTER_COMMAND})
   endif()
   # When we are crosscompiling using the mkrename* tools from a native
   # build, we use the tester executable from the native build.
   if (CMAKE_CROSSCOMPILING AND NATIVE_BUILD_DIR)
-    set(TESTER ${NATIVE_BUILD_DIR}/bin/qtester)
+    set(QTESTER ${NATIVE_BUILD_DIR}/bin/qtester)
   endif(CMAKE_CROSSCOMPILING AND NATIVE_BUILD_DIR)
-  if (TESTER)
+  if (QTESTER)
     if (NOT EMULATOR)
       if (SDE_COMMAND)
 	set(FLAGS_SDE "--sde" ${SDE_COMMAND})
@@ -48,11 +48,11 @@ function(add_test_iut IUT)
         set(FLAGS_ARMIE)
       endif()
       add_test(NAME ${IUT}
-	COMMAND ${TESTER} ${FLAGS_SDE} ${FLAGS_ARMIE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${IUT}
+	COMMAND ${QTESTER} ${FLAGS_SDE} ${FLAGS_ARMIE} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${IUT}
 	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
     else()
       add_test(NAME ${IUT}
-	COMMAND ${TESTER} ${EMULATOR} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${IUT}
+	COMMAND ${QTESTER} ${EMULATOR} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${IUT}
 	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
     endif()
   endif()

--- a/src/quad-tester/qiutsimd.c
+++ b/src/quad-tester/qiutsimd.c
@@ -172,7 +172,7 @@ typedef union {
   }
 
 int do_test(int argc, char **argv) {
-  xsrand(0);
+  xsrand(time(NULL));
 
   {
     int k = 0;

--- a/src/quad-tester/qiutsimd.c
+++ b/src/quad-tester/qiutsimd.c
@@ -172,7 +172,7 @@ typedef union {
   }
 
 int do_test(int argc, char **argv) {
-  xsrand(time(NULL));
+  xsrand(0);
 
   {
     int k = 0;

--- a/src/quad-tester/qiutsimdmain.c
+++ b/src/quad-tester/qiutsimdmain.c
@@ -1,0 +1,43 @@
+//          Copyright Naoki Shibata 2010 - 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <signal.h>
+#include <setjmp.h>
+
+static jmp_buf sigjmp;
+
+int do_test(int argc, char **argv);
+int check_featureQP();
+
+static void sighandler(int signum) {
+  longjmp(sigjmp, 1);
+}
+
+int detectFeatureQP() {
+  signal(SIGILL, sighandler);
+
+  if (setjmp(sigjmp) == 0) {
+    int r = check_featureQP();
+    signal(SIGILL, SIG_DFL);
+    return r;
+  } else {
+    signal(SIGILL, SIG_DFL);
+    return 0;
+  }
+}
+
+int main(int argc, char **argv) {
+  if (!detectFeatureQP()) {
+    fprintf(stderr, "\n\n***** This host does not support the necessary CPU features to execute this program *****\n\n\n");
+    printf("0\n");
+    fclose(stdout);
+    exit(-1);
+  }
+
+  return do_test(argc, argv);
+}

--- a/src/quad-tester/qtester.c
+++ b/src/quad-tester/qtester.c
@@ -331,7 +331,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  printf("\n\n*** Now testing %s\n", argv[a2s]);
+  fprintf(stderr, "\n\n*** qtester : now testing %s\n", argv[a2s]);
   
   for(i=a2s;i<argc;i++) argv2[i-a2s] = argv[i];
   argv2[argc-a2s] = NULL;
@@ -368,7 +368,7 @@ int main(int argc, char **argv) {
 	  return 0;
 	}
 
-	printf("*** Using SDE\n");
+	fprintf(stderr, "*** Using SDE\n");
       } else {
 	fprintf(stderr, "\n\nTester : *** CPU does not support the necessary feature\n");
 	return 0;

--- a/src/quad-tester/qtester.c
+++ b/src/quad-tester/qtester.c
@@ -331,8 +331,6 @@ int main(int argc, char **argv) {
     }
   }
 
-  fprintf(stderr, "\n\n*** qtester : now testing %s\n", argv[a2s]);
-  
   for(i=a2s;i<argc;i++) argv2[i-a2s] = argv[i];
   argv2[argc-a2s] = NULL;
   
@@ -375,6 +373,8 @@ int main(int argc, char **argv) {
       }
     }
   }
+
+  fprintf(stderr, "\n\n*** qtester : now testing %s\n", argv2[0]);
 
   fpctop = fdopen(ctop[0], "r");
   

--- a/src/quad-tester/qtester.c
+++ b/src/quad-tester/qtester.c
@@ -1,0 +1,386 @@
+//          Copyright Naoki Shibata 2010 - 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+// This define is needed to prevent the `execvpe` function to raise a
+// warning at compile time. For more information, see
+// https://linux.die.net/man/3/execvp.
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <float.h>
+#include <limits.h>
+#include <errno.h>
+#include <inttypes.h>
+
+#if defined(POWER64_UNDEF_USE_EXTERN_INLINES)
+// This is a workaround required to cross compile for PPC64 binaries
+#include <features.h>
+#ifdef __USE_EXTERN_INLINES
+#undef __USE_EXTERN_INLINES
+#endif
+#endif
+
+#include <math.h>
+#include <mpfr.h>
+
+#include <unistd.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <signal.h>
+
+#include "misc.h"
+#include "qtesterutil.h"
+
+void stop(char *mes) {
+  fprintf(stderr, "%s\n", mes);
+  exit(-1);
+}
+
+int ptoc[2], ctop[2];
+int pid;
+FILE *fpctop;
+
+extern char **environ;
+
+void startChild(const char *path, char *const argv[]) {
+  pipe(ptoc);
+  pipe(ctop);
+
+  pid = fork();
+
+  assert(pid != -1);
+
+  if (pid == 0) {
+    // child process
+    char buf0[1], buf1[1];
+    int i;
+
+    close(ptoc[1]);
+    close(ctop[0]);
+
+    fflush(stdin);
+    fflush(stdout);
+    
+    i = dup2(ptoc[0], fileno(stdin));
+    assert(i != -1);
+
+    i = dup2(ctop[1], fileno(stdout));
+    assert(i != -1);
+
+    setvbuf(stdin, buf0, _IONBF,0);
+    setvbuf(stdout, buf1, _IONBF,0);
+
+    fflush(stdin);
+    fflush(stdout);
+
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+    execvpe(path, argv, environ);
+#else
+    execvp(path, argv);
+#endif
+
+    fprintf(stderr, "execvp in startChild : %s\n", strerror(errno));
+
+    exit(-1);
+  }
+
+  // parent process
+
+  close(ptoc[0]);
+  close(ctop[1]);
+}
+
+//
+
+typedef union {
+  Sleef_quad q;
+  struct {
+    uint64_t l, h;
+  };
+} cnv128;
+
+#define child_q_q(funcStr, arg) do {					\
+    char str[256];							\
+    cnv128 c;								\
+    c.q = arg;								\
+    sprintf(str, funcStr " %" PRIx64 ":%" PRIx64 "\n", c.h, c.l);	\
+    write(ptoc[1], str, strlen(str));					\
+    if (fgets(str, 255, fpctop) == NULL) stop("child " funcStr);	\
+    sscanf(str, "%" PRIx64 ":%" PRIx64, &c.h, &c.l);			\
+    return c.q;								\
+  } while(0)
+
+#define child_q2_q(funcStr, arg) do {					\
+    char str[256];							\
+    cnv128 c0, c1;							\
+    c0.q = arg;								\
+    sprintf(str, funcStr " %" PRIx64 ":%" PRIx64 "\n", c0.h, c0.l);	\
+    write(ptoc[1], str, strlen(str));					\
+    if (fgets(str, 255, fpctop) == NULL) stop("child " funcStr);	\
+    sscanf(str, "%" PRIx64 ":%" PRIx64 " %" PRIx64 ":%" PRIx64 , &c0.h, &c0.l, &c1.h, &c1.l); \
+    Sleef_quad2 ret = { c0.q, c1.q };					\
+    return ret;								\
+  } while(0)
+
+#define child_q_q_q(funcStr, arg0, arg1) do {				\
+    char str[256];							\
+    cnv128 c0, c1;							\
+    c0.q = arg0;							\
+    c1.q = arg1;							\
+    sprintf(str, funcStr " %" PRIx64 ":%" PRIx64 " %" PRIx64 ":%" PRIx64 "\n", c0.h, c0.l, c1.h, c1.l); \
+    write(ptoc[1], str, strlen(str));					\
+    if (fgets(str, 255, fpctop) == NULL) stop("child " funcStr);	\
+    sscanf(str, "%" PRIx64 ":%" PRIx64, &c0.h, &c0.l);			\
+    return c0.q;							\
+  } while(0)
+
+Sleef_quad child_addq_u05(Sleef_quad x, Sleef_quad y) { child_q_q_q("addq_u05", x, y); }
+Sleef_quad child_subq_u05(Sleef_quad x, Sleef_quad y) { child_q_q_q("subq_u05", x, y); }
+Sleef_quad child_mulq_u05(Sleef_quad x, Sleef_quad y) { child_q_q_q("mulq_u05", x, y); }
+Sleef_quad child_divq_u05(Sleef_quad x, Sleef_quad y) { child_q_q_q("divq_u05", x, y); }
+Sleef_quad child_sqrtq_u05(Sleef_quad x) { child_q_q("sqrtq_u05", x); }
+
+Sleef_quad child_copysignq(Sleef_quad x, Sleef_quad y) { child_q_q_q("copysignq", x, y); }
+Sleef_quad child_fabsq(Sleef_quad x) { child_q_q("fabsq", x); }
+Sleef_quad child_fmaxq(Sleef_quad x, Sleef_quad y) { child_q_q_q("fmaxq", x, y); }
+Sleef_quad child_fminq(Sleef_quad x, Sleef_quad y) { child_q_q_q("fminq", x, y); }
+
+//
+
+#define cmpDenorm_q(mpfrFunc, childFunc, argx) do {			\
+    mpfr_set_f128(frx, argx, GMP_RNDN);					\
+    mpfrFunc(frz, frx, GMP_RNDN);					\
+    Sleef_quad t = childFunc(argx);					\
+    double u = countULPf128(t, frz, 1);					\
+    if (u >= 10) {							\
+      fprintf(stderr, "\narg     = %s\ntest    = %s\ncorrect = %s\nulp = %g\n",	\
+	      sprintf128(argx), sprintf128(t), sprintfr(frz), u);	\
+      success = 0;							\
+      break;								\
+    }									\
+  } while(0)
+
+#define cmpDenorm_q_q(mpfrFunc, childFunc, argx, argy) do {		\
+    mpfr_set_f128(frx, argx, GMP_RNDN);					\
+    mpfr_set_f128(fry, argy, GMP_RNDN);					\
+    mpfrFunc(frz, frx, fry, GMP_RNDN);					\
+    Sleef_quad t = childFunc(argx, argy);				\
+    double u = countULPf128(t, frz, 1);					\
+    if (u >= 10) {							\
+      Sleef_quad qz = mpfr_get_f128(frz, GMP_RNDN);			\
+      fprintf(stderr, "\narg     = %s,\n          %s\ntest    = %s\ncorrect = %s\nulp = %g\n", \
+	      sprintf128(argx), sprintf128(argy), sprintf128(t), sprintf128(qz), u); \
+      success = 0;							\
+      break;								\
+    }									\
+  } while(0)
+
+#define checkAccuracy_q(mpfrFunc, childFunc, argx, bound) do {		\
+    mpfr_set_f128(frx, argx, GMP_RNDN);					\
+    mpfrFunc(frz, frx, GMP_RNDN);					\
+    Sleef_quad t = childFunc(argx);					\
+    double e = countULPf128(t, frz, 0);					\
+    maxError = fmax(maxError, e);					\
+    if (e > bound) {							\
+      fprintf(stderr, "\narg = %s, test = %s, correct = %s, ULP = %lf\n", \
+	      sprintf128(argx), sprintf128(childFunc(argx)), sprintfr(frz), countULPf128(t, frz, 0)); \
+      success = 0;							\
+      break;								\
+    }									\
+  } while(0)
+
+#define checkAccuracy_q_q(mpfrFunc, childFunc, argx, argy, bound) do {	\
+    mpfr_set_f128(frx, argx, GMP_RNDN);					\
+    mpfr_set_f128(fry, argy, GMP_RNDN);					\
+    mpfrFunc(frz, frx, fry, GMP_RNDN);					\
+    Sleef_quad t = childFunc(argx, argy);				\
+    double e = countULPf128(t, frz, 0);					\
+    maxError = fmax(maxError, e);					\
+    if (e > bound) {							\
+      fprintf(stderr, "\narg = %s, %s, test = %s, correct = %s, ULP = %lf\n", \
+	      sprintf128(argx), sprintf128(argy), sprintf128(childFunc(argx, argy)), sprintfr(frz), countULPf128(t, frz, 0)); \
+      success = 0;							\
+      break;								\
+    }									\
+  } while(0)
+
+//
+
+#define cmpDenormOuterLoop_q_q(mpfrFunc, childFunc, checkVals) do {	\
+    for(int i=0;i<sizeof(checkVals)/sizeof(char *);i++) {		\
+      Sleef_quad a0 = cast_q_str(checkVals[i]);				\
+      for(int j=0;j<sizeof(checkVals)/sizeof(char *) && success;j++) {	\
+	Sleef_quad a1 = cast_q_str(checkVals[j]);			\
+	cmpDenorm_q_q(mpfrFunc, childFunc, a0, a1);			\
+      }									\
+    }									\
+  } while(0)
+
+#define cmpDenormOuterLoop_q(mpfrFunc, childFunc, checkVals) do {	\
+    for(int i=0;i<sizeof(checkVals)/sizeof(char *);i++) {		\
+      Sleef_quad a0 = cast_q_str(checkVals[i]);				\
+      cmpDenorm_q(mpfrFunc, childFunc, a0);				\
+    }									\
+  } while(0)
+
+//
+
+#define checkAccuracyOuterLoop_q_q(mpfrFunc, childFunc, minStr, maxStr, nLoop, bound, seed) do { \
+    xsrand(seed);							\
+    Sleef_quad min = cast_q_str(minStr), max = cast_q_str(maxStr);	\
+    for(int i=0;i<nLoop && success;i++) {				\
+      Sleef_quad x = rndf128(min, max), y = rndf128(min, max);		\
+      checkAccuracy_q_q(mpfrFunc, childFunc, x, y, bound);		\
+    }									\
+  } while(0)
+
+#define checkAccuracyOuterLoop_q(mpfrFunc, childFunc, minStr, maxStr, nLoop, bound, seed) do { \
+    xsrand(seed);								\
+    Sleef_quad min = cast_q_str(minStr), max = cast_q_str(maxStr);	\
+    for(int i=0;i<nLoop && success;i++) {				\
+      Sleef_quad x = rndf128(min, max);					\
+      checkAccuracy_q(mpfrFunc, childFunc, x, bound);			\
+    }									\
+  } while(0)
+
+//
+
+void checkResult(int success, double e) {
+  if (!success) {
+    fprintf(stderr, "\n\n*** Test failed\n");
+    exit(-1);
+  }
+
+  fprintf(stderr, "OK (%g ulp)\n", e);
+}
+
+#define STR_QUAD_MIN "3.36210314311209350626267781732175260e-4932"
+#define STR_QUAD_MAX "1.18973149535723176508575932662800702e+4932"
+#define STR_QUAD_DENORM_MIN "6.475175119438025110924438958227646552e-4966"
+
+void do_test() {
+  mpfr_set_default_prec(256);
+  mpfr_t frx, fry, frz;
+  mpfr_inits(frx, fry, frz, NULL);
+
+  int success = 1;
+
+  static const char *stdCheckVals[] = {
+    "0.0", "-0.0", "+0.5", "-0.5", "+1.0", "-1.0", "+1.5", "-1.5", "+2.0", "-2.0", "+2.5", "-2.5",
+    "1.234", "-1.234", "+1.234e+100", "-1.234e+100", "+1.234e-100", "-1.234e-100",
+    "+1.234e+3000", "-1.234e+3000", "+1.234e-3000", "-1.234e-3000",
+    "+" STR_QUAD_MIN, "-" STR_QUAD_MIN,
+    "+" STR_QUAD_DENORM_MIN, "-" STR_QUAD_DENORM_MIN,
+    "NaN", "Inf", "-Inf"
+  };
+
+#define NTEST 1000
+
+  double errorBound = 0.5000000001;
+  double maxError;
+
+  fprintf(stderr, "addq_u05 : ");
+  maxError = 0;
+  cmpDenormOuterLoop_q_q(mpfr_add, child_addq_u05, stdCheckVals);
+  checkAccuracyOuterLoop_q_q(mpfr_add, child_addq_u05, "1e-100", "1e+100", 5 * NTEST, errorBound, 0);
+  checkAccuracyOuterLoop_q_q(mpfr_add, child_addq_u05, "0", "Inf", 5 * NTEST, errorBound, 1);
+  checkResult(success, maxError);
+
+  fprintf(stderr, "mulq_u05 : ");
+  maxError = 0;
+  cmpDenormOuterLoop_q_q(mpfr_mul, child_mulq_u05, stdCheckVals);
+  checkAccuracyOuterLoop_q_q(mpfr_mul, child_mulq_u05, "1e-100", "1e+100", 5 * NTEST, errorBound, 0);
+  checkAccuracyOuterLoop_q_q(mpfr_mul, child_mulq_u05, "0", "Inf", 5 * NTEST, errorBound, 1);
+  checkResult(success, maxError);
+
+  fprintf(stderr, "divq_u05 : ");
+  maxError = 0;
+  cmpDenormOuterLoop_q_q(mpfr_div, child_divq_u05, stdCheckVals);
+  checkAccuracyOuterLoop_q_q(mpfr_div, child_divq_u05, "1e-100", "1e+100", 5 * NTEST, errorBound, 0);
+  checkAccuracyOuterLoop_q_q(mpfr_div, child_divq_u05, "0", "Inf", 5 * NTEST, errorBound, 1);
+  checkResult(success, maxError);
+
+  fprintf(stderr, "sqrtq_u05 : ");
+  maxError = 0;
+  cmpDenormOuterLoop_q(mpfr_sqrt, child_sqrtq_u05, stdCheckVals);
+  checkAccuracyOuterLoop_q(mpfr_sqrt, child_sqrtq_u05, "1e-100", "1e+100", 5 * NTEST, errorBound, 0);
+  checkAccuracyOuterLoop_q(mpfr_sqrt, child_sqrtq_u05, "0", "Inf", 5 * NTEST, errorBound, 1);
+  checkResult(success, maxError);
+}
+
+int main(int argc, char **argv) {
+  char *argv2[argc+2], *commandSde = NULL;
+  int i, a2s;
+
+  // BUGFIX: this flush is to prevent incorrect syncing with the
+  // `iut*` executable that causes failures in the CPU detection on
+  // some CI systems.
+  fflush(stdout);
+
+  for(a2s=1;a2s<argc;a2s++) {
+    if (a2s+1 < argc && strcmp(argv[a2s], "--sde") == 0) {
+      commandSde = argv[a2s+1];
+      a2s++;
+    } else {
+      break;
+    }
+  }
+
+  printf("\n\n*** Now testing %s\n", argv[a2s]);
+  
+  for(i=a2s;i<argc;i++) argv2[i-a2s] = argv[i];
+  argv2[argc-a2s] = NULL;
+  
+  startChild(argv2[0], argv2);
+  fflush(stdin);
+  // BUGFIX: this flush is to prevent incorrect syncing with the
+  // `iut*` executable that causes failures in the CPU detection on
+  // some CI systems.
+  fflush(stdin);
+
+  {
+    char str[256];
+    int u;
+
+    if (readln(ctop[0], str, 255) < 1 ||
+	sscanf(str, "%d", &u) != 1 ||
+	(u & 1) == 0) {
+      if (commandSde != NULL) {
+	close(ctop[0]);
+	close(ptoc[1]);
+
+	argv2[0] = commandSde;
+	argv2[1] = "--";
+	for(i=a2s;i<argc;i++) argv2[i-a2s+2] = argv[i];
+	argv2[argc-a2s+2] = NULL;
+	
+	startChild(argv2[0], argv2);
+
+	if (readln(ctop[0], str, 255) < 1) stop("Feature detection(sde, readln)");
+	if (sscanf(str, "%d", &u) != 1) stop("Feature detection(sde, sscanf)");
+	if ((u & 1) == 0) {
+	  fprintf(stderr, "\n\nTester : *** CPU does not support the necessary feature(SDE)\n");
+	  return 0;
+	}
+
+	printf("*** Using SDE\n");
+      } else {
+	fprintf(stderr, "\n\nTester : *** CPU does not support the necessary feature\n");
+	return 0;
+      }
+    }
+  }
+
+  fpctop = fdopen(ctop[0], "r");
+  
+  do_test();
+
+  fprintf(stderr, "\n\n*** All tests passed\n");
+
+  exit(0);
+}

--- a/src/quad-tester/qtesterutil.c
+++ b/src/quad-tester/qtesterutil.c
@@ -1,0 +1,587 @@
+//          Copyright Naoki Shibata 2010 - 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <float.h>
+#include <limits.h>
+#include <assert.h>
+
+#if defined(POWER64_UNDEF_USE_EXTERN_INLINES)
+// This is a workaround required to cross compile for PPC64 binaries
+#include <features.h>
+#ifdef __USE_EXTERN_INLINES
+#undef __USE_EXTERN_INLINES
+#endif
+#endif
+
+#include <math.h>
+
+#ifdef USEMPFR
+#include <mpfr.h>
+#endif
+
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
+#define STDIN_FILENO 0
+#else
+#include <unistd.h>
+#include <sys/types.h>
+#include <signal.h>
+#endif
+
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#include <unistd.h>
+#endif
+
+#include "misc.h"
+#include "qtesterutil.h"
+
+//
+
+int readln(int fd, char *buf, int cnt) {
+  int i, rcnt = 0;
+
+  if (cnt < 1) return -1;
+
+  while(cnt >= 2) {
+    i = read(fd, buf, 1);
+    if (i != 1) return i;
+
+    if (*buf == '\n') break;
+
+    rcnt++;
+    buf++;
+    cnt--;
+  }
+
+  *++buf = '\0';
+  rcnt++;
+  return rcnt;
+}
+
+int startsWith(char *str, char *prefix) {
+  return strncmp(str, prefix, strlen(prefix)) == 0;
+}
+
+//
+
+typedef struct {
+  uint64_t l, h;
+} xuint128;
+
+static xuint128 sll128(uint64_t u, int c) {
+  if (c < 64) {
+    xuint128 r = { u << c, u >> (64 - c) };
+    return r;
+  }
+
+  xuint128 r = { 0, u << (c - 64) };
+  return r;
+}
+
+static xuint128 add128(xuint128 x, xuint128 y) {
+  xuint128 r = { x.l + y.l, x.h + y.h };
+  if (r.l < x.l) r.h++;
+  return r;
+}
+
+static int lt128(xuint128 x, xuint128 y) {
+  if (x.h < y.h) return 1;
+  if (x.h == y.h && x.l < y.l) return 1;
+  return 0;
+}
+
+//
+
+typedef union {
+  Sleef_quad q;
+  xuint128 x;
+  struct {
+    uint64_t l, h;
+  };
+} cnv_t;
+
+int iszerof128(Sleef_quad a) {
+  cnv_t c128 = { .q = a };
+  return (((c128.h & 0x7fffffffffffffffULL) == 0) && c128.l == 0);
+}
+
+int isnegf128(Sleef_quad a) {
+  cnv_t c128 = { .q = a };
+  return c128.h >> 63;
+}
+
+int isinff128(Sleef_quad a) {
+  cnv_t c128 = { .q = a };
+  return (((c128.h & 0x7fffffffffffffffULL) == 0x7fff000000000000ULL) && c128.l == 0);
+}
+
+int isnonnumberf128(Sleef_quad a) {
+  cnv_t c128 = { .q = a };
+  return (c128.h & 0x7fff000000000000ULL) == 0x7fff000000000000ULL;
+}
+
+int isnanf128(Sleef_quad a) {
+  return isnonnumberf128(a) && !isinff128(a);
+}
+
+//
+
+static uint64_t xseed;
+
+uint64_t xrand() {
+  uint64_t u = xseed;
+  xseed = xseed * 6364136223846793005ULL + 1;
+  u = (u & ((~0ULL) << 32)) | (xseed >> 32);
+  xseed = xseed * 6364136223846793005ULL + 1;
+  return u;
+}
+
+void xsrand(uint64_t s) {
+  xseed = s;
+  xrand();
+  xrand();
+  xrand();
+}
+
+void memrand(void *p, int size) {
+  uint64_t *q = (uint64_t *)p;
+  int i;
+  for(i=0;i<size;i+=8) *q++ = xrand();
+  uint8_t *r = (uint8_t *)q;
+  for(;i<size;i++) *r++ = xrand() & 0xff;
+}
+
+Sleef_quad rndf128(Sleef_quad min, Sleef_quad max) {
+  cnv_t cmin = { .q = min }, cmax = { .q = max }, c;
+  do {
+    memrand(&c.q, sizeof(Sleef_quad));
+    c.h &= 0x7fffffffffffffffULL;
+  } while(isnonnumberf128(c.q) || lt128(c.x, cmin.x) || lt128(cmax.x, c.x));
+  return c.q;
+}
+
+Sleef_quad rndf128x() {
+  Sleef_quad r;
+  memrand(&r, sizeof(Sleef_quad));
+  return r;
+}
+
+typedef struct {
+  double x, y, z;
+} double3;
+
+typedef struct {
+  int32_t e;
+  double3 dd;
+} TDX_t;
+
+#ifdef USEMPFR
+double countULPf128(Sleef_quad d, mpfr_t c, int checkNegZero) {
+  static mpfr_t fr_denorm_min, fr_denorm_mino2, fr_f128_max;
+  static int is_first = 1;
+  if (is_first) {
+    is_first = 0;
+    mpfr_inits(fr_denorm_min, fr_denorm_mino2, fr_f128_max, NULL);
+    mpfr_set_str(fr_denorm_min, "6.475175119438025110924438958227646552e-4966", 10, GMP_RNDN);
+    mpfr_mul_d(fr_denorm_mino2, fr_denorm_min, 0.5, GMP_RNDN);
+    mpfr_set_str(fr_f128_max  , "1.18973149535723176508575932662800702e+4932", 10, GMP_RNDN);
+  }
+
+  mpfr_t fra, frb, frc, frd;
+  mpfr_inits(fra, frb, frc, frd, NULL);
+  double ret = 0;
+
+  mpfr_abs(fra, c, GMP_RNDN);
+
+  int csign = mpfr_signbit(c), dsign = isnegf128(d);
+  int ciszero = mpfr_cmp(fra, fr_denorm_mino2) < 0, diszero = iszerof128(d);
+  int cisnan = mpfr_nan_p(c), disnan = isnanf128(d);
+  int cisinf = mpfr_cmp(fra, fr_f128_max) > 0, disinf = isinff128(d);
+
+  if (ciszero && !diszero) {
+    ret = 10000;
+  } else if (ciszero && diszero) {
+    ret = 0;
+    if (checkNegZero && csign != dsign) ret = 10003;
+  } else if (cisnan && disnan) {
+    ret = 0;
+  } else if (cisnan || disnan) {
+    ret = 10001;
+  } else if (cisinf && disinf) {
+    ret = csign == dsign ? 0 : 10002;
+  } else {
+    mpfr_set_f128(frd, d, GMP_RNDN);
+    int e = mpfr_get_exp(frd);
+    mpfr_set_d(frb, 1, GMP_RNDN);
+    assert(!mpfr_zero_p(frb));
+    mpfr_set_exp(frb, e-113+1);
+    mpfr_max(frb, frb, fr_denorm_min, GMP_RNDN);
+    mpfr_sub(fra, frd, c, GMP_RNDN);
+    mpfr_div(fra, fra, frb, GMP_RNDN);
+    ret = fabs(mpfr_get_d(fra, GMP_RNDN));
+  }
+
+  mpfr_clears(fra, frb, frc, frd, NULL);
+  return ret;
+}
+
+//
+
+char *sprintfr(mpfr_t fr) {
+  int digits = 51;
+  mpfr_t t;
+  mpfr_inits(t, NULL);
+  int sign = mpfr_signbit(fr) ? -1 : 1;
+  char *s = malloc(digits + 10);
+  if (mpfr_inf_p(fr)) {
+    sprintf(s, "%cinf", sign < 0 ? '-' : '+');
+  } else if (mpfr_nan_p(fr)) {
+    sprintf(s, "nan");
+  } else {
+    mpfr_exp_t e;
+    s[0] = sign < 0 ? '-' : '+';
+    s[1] = '0';
+    s[2] = '.';
+    mpfr_abs(t, fr, GMP_RNDN);
+    mpfr_get_str(s+3, &e, 10, digits, t, GMP_RNDN);
+    int ie = e;
+    char es[32];
+    snprintf(es, 30, "e%c%d", ie >= 0 ? '+' : '-', ie >= 0 ? ie : -ie);
+    strncat(s, es, digits+10);
+  }
+
+  mpfr_clears(t, NULL);
+  return s;
+}
+
+//
+
+#if MPFR_VERSION_MAJOR >= 4 && defined(ENABLEFLOAT128)
+void mpfr_set_f128(mpfr_t frx, Sleef_quad q, mpfr_rnd_t rnd) {
+  int mpfr_set_float128(mpfr_t rop, __float128 op, mpfr_rnd_t rnd);
+  union {
+    Sleef_quad q;
+    __float128 f;
+  } c;
+  c.q = q;
+  mpfr_set_float128(frx, c.f, rnd);
+}
+
+Sleef_quad mpfr_get_f128(mpfr_t m, mpfr_rnd_t rnd) {
+  __float128 mpfr_get_float128(mpfr_t op, mpfr_rnd_t rnd);
+  union {
+    Sleef_quad q;
+    __float128 f;
+  } c;
+  c.f = mpfr_get_float128(m, rnd);
+  return c.q;
+}
+#else
+#pragma message ( "Internal MPFR<->float128 conversion is used" )
+void mpfr_set_f128(mpfr_t frx, Sleef_quad a, mpfr_rnd_t rnd) {
+  union {
+    Sleef_quad u;
+    struct {
+      uint64_t l, h;
+    };
+  } c128 = { .u = a };
+
+  int sign = (int)(c128.h >> 63);
+  int exp = ((int)(c128.h >> 48)) & 0x7fff;
+
+  if (isnanf128(a)) {
+    mpfr_set_nan(frx);
+  } else if (isinff128(a)) {
+    mpfr_set_inf(frx, sign ? -1 : 1);
+  } else if (exp == 0) {
+    c128.h &= 0xffffffffffffULL;
+    mpfr_set_d(frx, ldexp((double)c128.h, 64), GMP_RNDN);
+    mpfr_add_d(frx, frx, (double)(c128.l & 0xffffffff00000000ULL), GMP_RNDN);
+    mpfr_add_d(frx, frx, (double)(c128.l & 0xffffffffULL), GMP_RNDN);
+    mpfr_set_exp(frx, mpfr_get_exp(frx) - 16382 - 112);
+    mpfr_setsign(frx, frx, sign, GMP_RNDN);
+  } else {
+    c128.h &= 0xffffffffffffULL;
+    mpfr_set_d(frx, ldexp(1, 112), GMP_RNDN);
+    mpfr_add_d(frx, frx, ldexp((double)c128.h, 64), GMP_RNDN);
+    mpfr_add_d(frx, frx, (double)(c128.l & 0xffffffff00000000ULL), GMP_RNDN);
+    mpfr_add_d(frx, frx, (double)(c128.l & 0xffffffffULL), GMP_RNDN);
+    mpfr_set_exp(frx, exp - 16382);
+    mpfr_setsign(frx, frx, sign, GMP_RNDN);
+  }
+}
+
+static double3 mpfr_get_d3(mpfr_t fr, mpfr_rnd_t rnd) {
+  double3 ret;
+  mpfr_t t;
+  mpfr_inits(t, NULL);
+  ret.x = mpfr_get_d(fr, GMP_RNDN);
+  mpfr_sub_d(t, fr, ret.x, GMP_RNDN);
+  ret.y = mpfr_get_d(t, GMP_RNDN);
+  mpfr_sub_d(t, t, ret.y, GMP_RNDN);
+  ret.z = mpfr_get_d(t, GMP_RNDN);
+  mpfr_clears(t, NULL);
+  return ret;
+}
+
+static TDX_t mpfr_get_tdx(mpfr_t fr, mpfr_rnd_t rnd) {
+  TDX_t td;
+
+  if (mpfr_nan_p(fr)) {
+    td.dd.x = NAN;
+    td.dd.y = 0;
+    td.dd.z = 0;
+    td.e = 0;
+    return td;
+  }
+
+  if (mpfr_inf_p(fr)) {
+    td.dd.x = copysign(INFINITY, mpfr_cmp_d(fr, 0));
+    td.dd.y = 0;
+    td.dd.z = 0;
+    td.e = 0;
+    return td;
+  }
+
+  if (mpfr_zero_p(fr)) {
+    td.dd.x = copysign(0, mpfr_signbit(fr) ? -1 : 1);
+    td.dd.y = 0;
+    td.dd.z = 0;
+    td.e = 0;
+    return td;
+  }
+
+  mpfr_t t;
+  mpfr_inits(t, NULL);
+
+  mpfr_set(t, fr, GMP_RNDN);
+  td.e = mpfr_get_exp(fr) + 16382;
+  assert(!mpfr_zero_p(t));
+  mpfr_set_exp(t, 1);
+  mpfr_setsign(t, t, mpfr_signbit(fr), GMP_RNDN);
+  td.dd = mpfr_get_d3(t, GMP_RNDN);
+
+  if (fabs(td.dd.x) == 2.0) {
+    td.dd.x *= 0.5;
+    td.dd.y *= 0.5;
+    td.dd.z *= 0.5;
+    td.e++;
+  }
+
+  mpfr_clears(t, NULL);
+
+  return td;
+}
+
+#define HBX 1.0
+#define LOGXSCALE 1
+#define XSCALE (1 << LOGXSCALE)
+#define SX 61
+#define HBY (1.0 / (1ULL << 53))
+#define LOGYSCALE 4
+#define YSCALE (1 << LOGYSCALE)
+#define SY 11
+#define HBZ (1.0 / ((1ULL << 53) * (double)(1ULL << 53)))
+#define LOGZSCALE 10
+#define ZSCALE (1 << LOGZSCALE)
+#define SZ 36
+#define HBR (1.0 / (1ULL << 60))
+
+static int64_t doubleToRawLongBits(double d) {
+  union {
+    double f;
+    int64_t i;
+  } tmp;
+  tmp.f = d;
+  return tmp.i;
+}
+
+static double longBitsToDouble(int64_t i) {
+  union {
+    double f;
+    int64_t i;
+  } tmp;
+  tmp.i = i;
+  return tmp.f;
+}
+
+static int xisnonnumber(double x) {
+  return (doubleToRawLongBits(x) & 0x7ff0000000000000ULL) == 0x7ff0000000000000ULL;
+}
+
+static double xordu(double x, uint64_t y) {
+  union {
+    double d;
+    uint64_t u;
+  } cx;
+  cx.d = x;
+  cx.u ^= y;
+  return cx.d;
+}
+
+static double pow2i(int q) {
+  return longBitsToDouble(((int64_t)(q + 0x3ff)) << 52);
+}
+
+static double ldexp2k(double d, int e) { // faster than ldexpk, short reach
+  return d * pow2i(e >> 1) * pow2i(e - (e >> 1));
+}
+
+Sleef_quad mpfr_get_f128(mpfr_t a, mpfr_rnd_t rnd) {
+  TDX_t f = mpfr_get_tdx(a, rnd);
+
+  cnv_t c128;
+
+  union {
+    double d;
+    uint64_t u;
+  } c64;
+
+  c64.d = f.dd.x;
+  uint64_t signbit = c64.u & 0x8000000000000000ULL;
+  int isZero = (f.dd.x == 0.0), denorm = 0;
+
+  f.dd.x = xordu(f.dd.x, signbit);
+  f.dd.y = xordu(f.dd.y, signbit);
+  f.dd.z = xordu(f.dd.z, signbit);
+
+  double t = 1;
+
+  if (f.e <= 0) {
+    t = ldexp2k(0.5, f.e);
+    if (f.e < -120) t = 0;
+    f.e = 1;
+    denorm = 1;
+  }
+
+  if ((fabs(f.dd.x) == 1.0 && f.dd.y <= -pow(2, -114)) && f.e != 1) {
+    t = 2;
+    f.e--;
+  }
+
+  f.dd.x *= t;
+  f.dd.y *= t;
+  f.dd.z *= t;
+
+  c64.d = f.dd.y + HBY * YSCALE;
+  c64.u &= 0xffffffffffffffffULL << LOGYSCALE;
+  f.dd.z += f.dd.y - (c64.d - (HBZ * ZSCALE + HBY * YSCALE));
+  f.dd.y = c64.d;
+
+  double c = denorm ? (HBX * XSCALE + HBX) : (HBX * XSCALE);
+  c64.d = f.dd.x + c;
+  c64.u &= 0xffffffffffffffffULL << LOGXSCALE;
+  t = f.dd.y + (f.dd.x - (c64.d - c));
+  f.dd.z += f.dd.y - t + (f.dd.x - (c64.d - c));
+  f.dd.x = c64.d;
+
+  c64.d = t;
+  c64.u &= 0xffffffffffffffffULL << LOGYSCALE;
+  f.dd.z += t - c64.d;
+  f.dd.y = c64.d;
+
+  t = f.dd.z - HBZ * ZSCALE < 0 ? HBZ * (ZSCALE/2) : 0;
+  f.dd.y -= t;
+  f.dd.z += t;
+
+  t = f.dd.y - HBY * YSCALE < 0 ? HBY * (YSCALE/2) : 0;
+  f.dd.x -= t;
+  f.dd.y += t;
+
+  f.dd.z = f.dd.z + HBR - HBR;
+
+  //
+
+  c64.d = f.dd.x;
+  c64.u &= 0xfffffffffffffULL;
+  c128.x = sll128(c64.u, SX);
+
+  c64.d = f.dd.z;
+  c64.u &= 0xfffffffffffffULL;
+  c128.l |= c64.u >> SZ;
+
+  c64.d = f.dd.y;
+  c64.u &= 0xfffffffffffffULL;
+  c128.x = add128(c128.x, sll128(c64.u, SY));
+
+  c128.h &= denorm ? 0xffffffffffffULL : 0x3ffffffffffffULL;
+  c128.h += ((f.e-1) & ~(-1UL << 15)) << 48;
+
+  if (isZero) { c128.l = c128.h = 0; }
+  if (f.e >= 32767 || f.dd.x == INFINITY) {
+    c128.h = 0x7fff000000000000ULL;
+    c128.l = 0;
+  }
+  if (xisnonnumber(f.dd.x) && f.dd.x != INFINITY) c128.h = c128.l = 0xffffffffffffffffULL;
+
+  c128.h |= signbit;
+
+  return c128.q;
+}
+#endif // #if MPFR_VERSION_MAJOR >= 4
+
+char *sprintf128(Sleef_quad q) {
+  mpfr_t fr;
+  mpfr_inits(fr, NULL);
+  mpfr_set_f128(fr, q, GMP_RNDN);
+  char *f = sprintfr(fr);
+  mpfr_clears(fr, NULL);
+  cnv_t c128 = { .q = q };
+  char *ret = malloc(128);
+  sprintf(ret, "%016llx%016llx (%s)", (unsigned long long)c128.h, (unsigned long long)c128.l, f);
+  free(f);
+  return ret;
+}
+
+double cast_d_q(Sleef_quad q) {
+  mpfr_t fr;
+  mpfr_inits(fr, NULL);
+  mpfr_set_f128(fr, q, GMP_RNDN);
+  double ret = mpfr_get_d(fr, GMP_RNDN);
+  mpfr_clears(fr, NULL);
+  return ret;
+}
+
+Sleef_quad add_q_d(Sleef_quad q, double d) {
+  mpfr_t fr;
+  mpfr_inits(fr, NULL);
+  mpfr_set_f128(fr, q, GMP_RNDN);
+  mpfr_add_d(fr, fr, d, GMP_RNDN);
+  q = mpfr_get_f128(fr, GMP_RNDN);
+  mpfr_clears(fr, NULL);
+  return q;
+}
+
+Sleef_quad cast_q_str(const char *s) {
+  mpfr_t fr;
+  mpfr_inits(fr, NULL);
+  mpfr_set_str(fr, s, 10, GMP_RNDN);
+  Sleef_quad q = mpfr_get_f128(fr, GMP_RNDN);
+  mpfr_clears(fr, NULL);
+  return q;
+}
+
+Sleef_quad add_q_q(Sleef_quad q, Sleef_quad r) {
+  mpfr_t fr0, fr1;
+  mpfr_inits(fr0, fr1, NULL);
+  mpfr_set_f128(fr0, q, GMP_RNDN);
+  mpfr_set_f128(fr1, r, GMP_RNDN);
+  mpfr_add(fr0, fr0, fr1, GMP_RNDN);
+  q = mpfr_get_f128(fr0, GMP_RNDN);
+  mpfr_clears(fr0, fr1, NULL);
+  return q;
+}
+#else // #ifdef USEMPFR
+char *sprintf128(Sleef_quad x) {
+  cnv_t c128 = { .q = x };
+  char *s = malloc(128);
+  sprintf(s, "%016llx%016llx", (unsigned long long)c128.h, (unsigned long long)c128.l);
+  return s;
+}
+#endif // #ifdef USEMPFR

--- a/src/quad-tester/qtesterutil.c
+++ b/src/quad-tester/qtesterutil.c
@@ -70,11 +70,12 @@ int startsWith(char *str, char *prefix) {
 
 //
 
-typedef struct {
-  uint64_t l, h;
-} xuint128;
+xuint128 xu(uint64_t h, uint64_t l) {
+  xuint128 r = { l, h };
+  return r;
+}
 
-static xuint128 sll128(uint64_t u, int c) {
+xuint128 sll128(uint64_t u, int c) {
   if (c < 64) {
     xuint128 r = { u << c, u >> (64 - c) };
     return r;
@@ -84,13 +85,13 @@ static xuint128 sll128(uint64_t u, int c) {
   return r;
 }
 
-static xuint128 add128(xuint128 x, xuint128 y) {
+xuint128 add128(xuint128 x, xuint128 y) {
   xuint128 r = { x.l + y.l, x.h + y.h };
   if (r.l < x.l) r.h++;
   return r;
 }
 
-static int lt128(xuint128 x, xuint128 y) {
+int lt128(xuint128 x, xuint128 y) {
   if (x.h < y.h) return 1;
   if (x.h == y.h && x.l < y.l) return 1;
   return 0;
@@ -262,7 +263,7 @@ char *sprintfr(mpfr_t fr) {
 
 //
 
-#if MPFR_VERSION_MAJOR >= 4 && defined(ENABLEFLOAT128)
+#if MPFR_VERSION_MAJOR >= 4 && defined(ENABLEFLOAT128) && !defined(__APPLE__)
 void mpfr_set_f128(mpfr_t frx, Sleef_quad q, mpfr_rnd_t rnd) {
   int mpfr_set_float128(mpfr_t rop, __float128 op, mpfr_rnd_t rnd);
   union {
@@ -511,7 +512,7 @@ Sleef_quad mpfr_get_f128(mpfr_t a, mpfr_rnd_t rnd) {
   c128.x = add128(c128.x, sll128(c64.u, SY));
 
   c128.h &= denorm ? 0xffffffffffffULL : 0x3ffffffffffffULL;
-  c128.h += ((f.e-1) & ~(-1UL << 15)) << 48;
+  c128.h += ((f.e-1) & ~((uint64_t)-1UL << 15)) << 48;
 
   if (isZero) { c128.l = c128.h = 0; }
   if (f.e >= 32767 || f.dd.x == INFINITY) {

--- a/src/quad-tester/qtesterutil.h
+++ b/src/quad-tester/qtesterutil.h
@@ -1,0 +1,32 @@
+//          Copyright Naoki Shibata 2010 - 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+void xsrand(uint64_t s);
+uint64_t xrand();
+void memrand(void *p, int size);
+Sleef_quad rndf128(Sleef_quad min, Sleef_quad max);
+Sleef_quad rndf128x();
+
+int readln(int fd, char *buf, int cnt);
+int startsWith(char *str, char *prefix);
+
+int iszerof128(Sleef_quad a);
+int isnegf128(Sleef_quad a);
+int isinff128(Sleef_quad a);
+int isnonnumberf128(Sleef_quad a);
+int isnanf128(Sleef_quad a);
+
+#ifdef USEMPFR
+void mpfr_set_f128(mpfr_t frx, Sleef_quad a, mpfr_rnd_t rnd);
+Sleef_quad mpfr_get_f128(mpfr_t m, mpfr_rnd_t rnd);
+
+double countULPf128(Sleef_quad d, mpfr_t c, int checkNegZero);
+char *sprintfr(mpfr_t fr);
+char *sprintf128(Sleef_quad x);
+
+double cast_d_q(Sleef_quad q);
+Sleef_quad cast_q_str(const char *s);
+Sleef_quad add_q_d(Sleef_quad q, double d);
+#endif

--- a/src/quad-tester/qtesterutil.h
+++ b/src/quad-tester/qtesterutil.h
@@ -3,6 +3,15 @@
 //    (See accompanying file LICENSE.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+typedef struct {
+  uint64_t l, h;
+} xuint128;
+
+xuint128 xu(uint64_t h, uint64_t l);
+xuint128 sll128(uint64_t u, int c);
+xuint128 add128(xuint128 x, xuint128 y);
+int lt128(xuint128 x, xuint128 y);
+
 void xsrand(uint64_t s);
 uint64_t xrand();
 void memrand(void *p, int size);

--- a/src/quad-tester/tester2simdqp.c
+++ b/src/quad-tester/tester2simdqp.c
@@ -1,0 +1,326 @@
+//          Copyright Naoki Shibata 2010 - 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <mpfr.h>
+#include <time.h>
+#include <float.h>
+#include <limits.h>
+
+#include <unistd.h>
+
+#if defined(POWER64_UNDEF_USE_EXTERN_INLINES)
+// This is a workaround required to cross compile for PPC64 binaries
+#include <features.h>
+#ifdef __USE_EXTERN_INLINES
+#undef __USE_EXTERN_INLINES
+#endif
+#endif
+
+#include <math.h>
+
+#include "sleef.h"
+#include "sleefquad.h"
+
+#include "misc.h"
+#include "qtesterutil.h"
+
+//
+
+#ifdef ENABLE_PUREC_SCALAR
+#define CONFIG 1
+#include "helperpurec_scalar.h"
+#include "qrenamepurec_scalar.h"
+#endif
+
+#ifdef ENABLE_PURECFMA_SCALAR
+#define CONFIG 2
+#include "helperpurec_scalar.h"
+#include "qrenamepurecfma_scalar.h"
+#endif
+
+#ifdef ENABLE_SSE2
+#define CONFIG 2
+#include "helpersse2.h"
+#include "qrenamesse2.h"
+#endif
+
+#ifdef ENABLE_AVX2128
+#define CONFIG 1
+#include "helperavx2_128.h"
+#include "qrenameavx2128.h"
+#endif
+
+#ifdef ENABLE_AVX
+#define CONFIG 1
+#include "helperavx.h"
+#include "qrenameavx.h"
+#endif
+
+#ifdef ENABLE_FMA4
+#define CONFIG 4
+#include "helperavx.h"
+#include "qrenamefma4.h"
+#endif
+
+#ifdef ENABLE_AVX2
+#define CONFIG 1
+#include "helperavx2.h"
+#include "qrenameavx2.h"
+#endif
+
+#ifdef ENABLE_AVX512F
+#define CONFIG 1
+#include "helperavx512f.h"
+#include "qrenameavx512f.h"
+#endif
+
+#ifdef ENABLE_ADVSIMD
+#define CONFIG 1
+#include "helperadvsimd.h"
+#include "qrenameadvsimd.h"
+#endif
+
+#ifdef ENABLE_SVE
+#define CONFIG 1
+#include "helpersve.h"
+#include "qrenamesve.h"
+#endif
+
+#ifdef ENABLE_VSX
+#define CONFIG 1
+#include "helperpower_128.h"
+#include "qrenamevsx.h"
+#endif
+
+#ifdef ENABLE_DSP128
+#define CONFIG 2
+#include "helpersse2.h"
+#include "qrenamedsp128.h"
+#endif
+
+#ifdef ENABLE_DSP256
+#define CONFIG 1
+#include "helperavx.h"
+#include "qrenamedsp256.h"
+#endif
+
+//
+
+#define DENORMAL_DBL_MIN (4.9406564584124654418e-324)
+
+#define POSITIVE_INFINITY INFINITY
+#define NEGATIVE_INFINITY (-INFINITY)
+
+typedef union {
+  Sleef_quad q;
+  __uint128_t u;
+  struct {
+    uint64_t l, h;
+  };
+} cnv_t;
+
+Sleef_quad nexttoward0q(Sleef_quad x, int n) {
+  cnv_t cx;
+  cx.q = x;
+  cx.u -= n;
+  return cx.q;
+}
+
+static vargquad vset(vargquad v, int idx, Sleef_quad d) { v.s[idx] = d; return v; }
+static Sleef_quad vget(vargquad v, int idx) { return v.s[idx]; }
+
+static int vgeti(vint v, int idx) {
+  int a[VECTLENDP*2];
+  vstoreu_v_p_vi(a, v);
+  return a[idx];
+}
+
+int main(int argc,char **argv)
+{
+  mpfr_set_default_prec(1024);
+  xsrand(time(NULL) + (((int)getpid()) << 12));
+  srandom(time(NULL) + (((int)getpid()) << 12));
+
+  //
+
+  const Sleef_quad oneEMinus10Q  = cast_q_str("1e-10");
+  const Sleef_quad oneEPlus10Q   = cast_q_str("1e+10");
+  const Sleef_quad oneEMinus100Q = cast_q_str("1e-100");
+  const Sleef_quad oneEPlus100Q  = cast_q_str("1e+100");
+  const Sleef_quad oneEMinus1000Q = cast_q_str("1e-1000");
+  const Sleef_quad oneEPlus1000Q  = cast_q_str("1e+1000");
+  const Sleef_quad quadMin = cast_q_str("3.36210314311209350626267781732175260e-4932");
+  const Sleef_quad quadMax = cast_q_str("1.18973149535723176508575932662800702e+4932");
+  const Sleef_quad quadDenormMin = cast_q_str("6.475175119438025110924438958227646552e-4966");
+
+  //
+
+  int cnt, ecnt = 0;
+  vargquad a0, a1, a2, a3;
+  Sleef_quad q0, q1, q2, q3, t;
+  mpfr_t frw, frx, fry, frz;
+  mpfr_inits(frw, frx, fry, frz, NULL);
+
+  for(cnt = 0;ecnt < 1000;cnt++) {
+    int e = cnt % VECTLENDP;
+
+    switch(cnt & 127) {
+    case 127:
+      q0 = nexttoward0q(quadMin, (xrand() & 63) - 31);
+      q1 = rndf128x();
+      break;
+    case 126:
+      q0 = nexttoward0q(quadMax, (xrand() & 31));
+      q1 = rndf128x();
+      break;
+    case 125:
+      q0 = nexttoward0q(quadDenormMin, -(int)(xrand() & 31));
+      q1 = rndf128x();
+      break;
+#if defined(ENABLEFLOAT128)
+#define QUAD_MIN 3.36210314311209350626267781732175260e-4932Q
+#define QUAD_MAX 1.18973149535723176508575932662800702e+4932Q
+    case 124:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q1 += q0;
+      break;
+    case 123:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q1 -= q0;
+      break;
+    case 122:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q1 += 1;
+      break;
+    case 121:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q0 += 1;
+      q1 -= 1;
+      break;
+    case 120:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q1 += copysign(1, q1) * QUAD_MIN;
+      break;
+    case 119:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q1 = copysign(1, q1) * QUAD_MIN;
+      break;
+    case 118:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q0 += copysign(1, q0);
+      q1  = copysign(1, q1) * QUAD_MIN;
+      break;
+    case 117:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q1 = copysign(1, q1) * QUAD_MIN;
+      break;
+    case 116:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q0 += copysign(1, q0);
+      q1  = copysign(1, q1) * QUAD_MIN;
+      break;
+    case 115:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q1 += copysign(1, q1) * QUAD_MAX;
+      break;
+#endif
+    default:
+      switch(cnt & 7) {
+      case 0:
+	q0 = rndf128(oneEMinus10Q, oneEPlus10Q);
+	q1 = rndf128(oneEMinus10Q, oneEPlus10Q);
+	break;
+      case 1:
+	q0 = rndf128(oneEMinus100Q, oneEPlus100Q);
+	q1 = rndf128(oneEMinus100Q, oneEPlus100Q);
+	break;
+      case 2:
+	q0 = rndf128(oneEMinus1000Q, oneEPlus1000Q);
+	q1 = rndf128(oneEMinus1000Q, oneEPlus1000Q);
+	break;
+      default:
+	q0 = rndf128x();
+	q1 = rndf128x();
+	break;
+      }
+      break;
+    }
+
+    a0 = vset(a0, e, q0);
+    a1 = vset(a1, e, q1);
+
+    {
+      mpfr_set_f128(frx, q0, GMP_RNDN);
+      mpfr_set_f128(fry, q1, GMP_RNDN);
+      mpfr_add(frz, frx, fry, GMP_RNDN);
+
+      double u0 = countULPf128(t = vget(xaddq_u05(a0, a1), e), frz, 0);
+      
+      if (u0 > 0.5000000001) {
+	printf(ISANAME " add arg=%s %s ulp=%.20g\n", sprintf128(q0), sprintf128(q1), u0);
+	printf("test = %s\n", sprintf128(t));
+	printf("corr = %s\n\n", sprintf128(mpfr_get_f128(frz, GMP_RNDN)));
+	fflush(stdout); ecnt++;
+      }
+    }
+
+    {
+      mpfr_set_f128(frx, q0, GMP_RNDN);
+      mpfr_set_f128(fry, q1, GMP_RNDN);
+      mpfr_mul(frz, frx, fry, GMP_RNDN);
+
+      double u0 = countULPf128(t = vget(xmulq_u05(a0, a1), e), frz, 0);
+      
+      if (u0 > 0.5000000001) {
+	printf(ISANAME " mul arg=%s %s ulp=%.20g\n", sprintf128(q0), sprintf128(q1), u0);
+	printf("test = %s\n", sprintf128(t));
+	printf("corr = %s\n\n", sprintf128(mpfr_get_f128(frz, GMP_RNDN)));
+	fflush(stdout); ecnt++;
+      }
+    }
+
+    {
+      mpfr_set_f128(frx, q0, GMP_RNDN);
+      mpfr_set_f128(fry, q1, GMP_RNDN);
+      mpfr_div(frz, frx, fry, GMP_RNDN);
+
+      double u0 = countULPf128(t = vget(xdivq_u05(a0, a1), e), frz, 0);
+      
+      if (u0 > 0.5000000001) {
+	printf(ISANAME " div arg=%s %s ulp=%.20g\n", sprintf128(q0), sprintf128(q1), u0);
+	printf("test = %s\n", sprintf128(t));
+	printf("corr = %s\n\n", sprintf128(mpfr_get_f128(frz, GMP_RNDN)));
+	fflush(stdout); ecnt++;
+      }
+    }
+
+    {
+      mpfr_set_f128(frx, q0, GMP_RNDN);
+      mpfr_sqrt(frz, frx, GMP_RNDN);
+
+      double u0 = countULPf128(t = vget(xsqrtq_u05(a0), e), frz, 0);
+
+      if (u0 > 0.5000000001) {
+	printf(ISANAME " sqrt arg=%s ulp=%.20g\n", sprintf128(q0), u0);
+	printf("test = %s\n", sprintf128(t));
+	printf("corr = %s\n\n", sprintf128(mpfr_get_f128(frz, GMP_RNDN)));
+	fflush(stdout); ecnt++;
+      }
+    }
+  }
+}

--- a/src/quad-tester/tester2simdqp.c
+++ b/src/quad-tester/tester2simdqp.c
@@ -169,6 +169,9 @@ int main(int argc,char **argv)
   for(cnt = 0;ecnt < 1000;cnt++) {
     int e = cnt % VECTLENDP;
 
+    // In the following switch-case statement, I am trying to test
+    // with numbers that tends to trigger bugs. Each case is executed
+    // once in 128 times of loop execution.
     switch(cnt & 127) {
     case 127:
       q0 = nexttoward0q(quadMin, (xrand() & 63) - 31);
@@ -240,6 +243,8 @@ int main(int argc,char **argv)
       break;
 #endif
     default:
+      // Each case in the following switch-case statement is executed
+      // once in 8 loops.
       switch(cnt & 7) {
       case 0:
 	q0 = rndf128(oneEMinus10Q, oneEPlus10Q);

--- a/src/quad-tester/tester2simdqp.c
+++ b/src/quad-tester/tester2simdqp.c
@@ -118,7 +118,7 @@
 
 typedef union {
   Sleef_quad q;
-  __uint128_t u;
+  xuint128 x;
   struct {
     uint64_t l, h;
   };
@@ -127,7 +127,7 @@ typedef union {
 Sleef_quad nexttoward0q(Sleef_quad x, int n) {
   cnv_t cx;
   cx.q = x;
-  cx.u -= n;
+  cx.x = add128(cx.x, xu(n < 0 ? 0 : -1, -(int64_t)n));
   return cx.q;
 }
 
@@ -183,8 +183,8 @@ int main(int argc,char **argv)
       q1 = rndf128x();
       break;
 #if defined(ENABLEFLOAT128)
-#define QUAD_MIN 3.36210314311209350626267781732175260e-4932Q
-#define QUAD_MAX 1.18973149535723176508575932662800702e+4932Q
+#define SLEEF_QUAD_MIN 3.36210314311209350626267781732175260e-4932Q
+#define SLEEF_QUAD_MAX 1.18973149535723176508575932662800702e+4932Q
     case 124:
       q0 = rndf128x();
       q1 = rndf128x();
@@ -209,34 +209,34 @@ int main(int argc,char **argv)
     case 120:
       q0 = rndf128x();
       q1 = rndf128x();
-      q1 += copysign(1, q1) * QUAD_MIN;
+      q1 += copysign(1, q1) * SLEEF_QUAD_MIN;
       break;
     case 119:
       q0 = rndf128x();
       q1 = rndf128x();
-      q1 = copysign(1, q1) * QUAD_MIN;
+      q1 = copysign(1, q1) * SLEEF_QUAD_MIN;
       break;
     case 118:
       q0 = rndf128x();
       q1 = rndf128x();
       q0 += copysign(1, q0);
-      q1  = copysign(1, q1) * QUAD_MIN;
+      q1  = copysign(1, q1) * SLEEF_QUAD_MIN;
       break;
     case 117:
       q0 = rndf128x();
       q1 = rndf128x();
-      q1 = copysign(1, q1) * QUAD_MIN;
+      q1 = copysign(1, q1) * SLEEF_QUAD_MIN;
       break;
     case 116:
       q0 = rndf128x();
       q1 = rndf128x();
       q0 += copysign(1, q0);
-      q1  = copysign(1, q1) * QUAD_MIN;
+      q1  = copysign(1, q1) * SLEEF_QUAD_MIN;
       break;
     case 115:
       q0 = rndf128x();
       q1 = rndf128x();
-      q1 += copysign(1, q1) * QUAD_MAX;
+      q1 += copysign(1, q1) * SLEEF_QUAD_MAX;
       break;
 #endif
     default:

--- a/src/quad/CMakeLists.txt
+++ b/src/quad/CMakeLists.txt
@@ -27,6 +27,7 @@ set(QUAD_HEADER_PARAMS_FMA4            4 Sleef_quad4 Sleef_quad8  __m128i   __AV
 set(QUAD_HEADER_PARAMS_AVX2            4 Sleef_quad4 Sleef_quad8  __m128i   __AVX__     avx2)
 set(QUAD_HEADER_PARAMS_AVX512F         8 Sleef_quad8 Sleef_quad16 __m256i   __AVX512F__ avx512f)
 set(QUAD_HEADER_PARAMS_ADVSIMD         2 Sleef_quad2 Sleef_quad4  int32x2_t __ARM_NEON  advsimd)
+set(QUAD_HEADER_PARAMS_SVE             x Sleef_quadx Sleef_quadx  svint32_t __ARM_FEATURE_SVE sve)
 
 set(QUAD_RENAME_PARAMS_PUREC_SCALAR    1 purec)
 set(QUAD_RENAME_PARAMS_PURECFMA_SCALAR 1 purecfma)
@@ -36,6 +37,7 @@ set(QUAD_RENAME_PARAMS_FMA4            4 fma4)
 set(QUAD_RENAME_PARAMS_AVX2            4 avx2)
 set(QUAD_RENAME_PARAMS_AVX512F         8 avx512f)
 set(QUAD_RENAME_PARAMS_ADVSIMD         2 advsimd)
+set(QUAD_RENAME_PARAMS_SVE             x sve)
 
 #
 

--- a/src/quad/CMakeLists.txt
+++ b/src/quad/CMakeLists.txt
@@ -79,6 +79,7 @@ add_custom_command(OUTPUT ${SLEEFQUAD_INCLUDE_HEADER}
 # --------------------------------------------------------------------
 # Helper executable: generates parts of the sleef header file
 add_host_executable(qmkrename qmkrename.c)
+set_target_properties(qmkrename PROPERTIES ${COMMON_TARGET_PROPERTIES})
 
 set(HEADER_FILES_GENERATED "")
 foreach(SIMD ${SLEEFQUAD_SUPPORTED_EXT})

--- a/src/quad/CMakeLists.txt
+++ b/src/quad/CMakeLists.txt
@@ -1,0 +1,151 @@
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include/)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_SOURCE_DIR}/src/libm)         # dd.h
+
+set(COMMON_TARGET_PROPERTIES C_STANDARD 99)
+
+if(COMPILER_SUPPORTS_FLOAT128)
+  list(APPEND COMMON_TARGET_DEFINITIONS ENABLEFLOAT128=1)
+endif()
+
+if(COMPILER_SUPPORTS_BUILTIN_MATH)
+  list(APPEND COMMON_TARGET_DEFINITIONS ENABLE_BUILTIN_MATH=1)
+endif()
+
+if (BUILD_SHARED_LIBS)
+  list(APPEND COMMON_TARGET_PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif()
+
+#
+
+set(QUAD_HEADER_PARAMS_PUREC_SCALAR    1 Sleef_quad1 Sleef_quad2  int32_t   __STDC__    purec)
+set(QUAD_HEADER_PARAMS_PURECFMA_SCALAR 1 Sleef_quad1 Sleef_quad2  int32_t   FP_FAST_FMA purecfma)
+set(QUAD_HEADER_PARAMS_SSE2            2 Sleef_quad2 Sleef_quad4  __m128i   __SSE2__    sse2)
+set(QUAD_HEADER_PARAMS_AVX             4 Sleef_quad4 Sleef_quad8  __m128i   __AVX__     avx)
+set(QUAD_HEADER_PARAMS_FMA4            4 Sleef_quad4 Sleef_quad8  __m128i   __AVX__     fma4)
+set(QUAD_HEADER_PARAMS_AVX2            4 Sleef_quad4 Sleef_quad8  __m128i   __AVX__     avx2)
+set(QUAD_HEADER_PARAMS_AVX512F         8 Sleef_quad8 Sleef_quad16 __m256i   __AVX512F__ avx512f)
+set(QUAD_HEADER_PARAMS_ADVSIMD         2 Sleef_quad2 Sleef_quad4  int32x2_t __ARM_NEON  advsimd)
+
+set(QUAD_RENAME_PARAMS_PUREC_SCALAR    1 purec)
+set(QUAD_RENAME_PARAMS_PURECFMA_SCALAR 1 purecfma)
+set(QUAD_RENAME_PARAMS_SSE2            2 sse2)
+set(QUAD_RENAME_PARAMS_AVX             4 avx)
+set(QUAD_RENAME_PARAMS_FMA4            4 fma4)
+set(QUAD_RENAME_PARAMS_AVX2            4 avx2)
+set(QUAD_RENAME_PARAMS_AVX512F         8 avx512f)
+set(QUAD_RENAME_PARAMS_ADVSIMD         2 advsimd)
+
+#
+
+set(CMAKE_C_FLAGS ORG_CMAKE_C_FLAGS)
+string(CONCAT CMAKE_C_FLAGS ${SLEEF_C_FLAGS})
+
+# --------------------------------------------------------------------
+# sleefquad.h
+# --------------------------------------------------------------------
+set(SLEEFQUAD_ORG_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/sleefquad_header.h.org)
+set(SLEEFQUAD_ORG_FOOTER ${CMAKE_CURRENT_SOURCE_DIR}/sleefquad_footer.h.org)
+set(SLEEFQUAD_INCLUDE_HEADER ${CMAKE_BINARY_DIR}/include/sleefquad.h)
+
+set(SLEEF_HEADER_COMMANDS "")
+list(APPEND SLEEF_HEADER_COMMANDS COMMAND ${CMAKE_COMMAND} -E copy ${SLEEFQUAD_ORG_HEADER} ${SLEEFQUAD_INCLUDE_HEADER})
+foreach(SIMD ${SLEEFQUAD_SUPPORTED_EXT})
+  if(COMPILER_SUPPORTS_${SIMD})
+    list(APPEND SLEEF_HEADER_COMMANDS COMMAND echo Generating sleefquad.h: qmkrename ${QUAD_HEADER_PARAMS_${SIMD}})
+    list(APPEND SLEEF_HEADER_COMMANDS COMMAND $<TARGET_FILE:qmkrename> ${QUAD_HEADER_PARAMS_${SIMD}} >> ${SLEEFQUAD_INCLUDE_HEADER})
+  endif()
+endforeach()
+
+if(MSVC)
+  string(REPLACE "/" "\\" sleef_footer_input_file "${SLEEFQUAD_ORG_FOOTER}")
+  list(APPEND SLEEF_HEADER_COMMANDS COMMAND type ${sleef_footer_input_file} >> ${SLEEFQUAD_INCLUDE_HEADER})
+else()
+  list(APPEND SLEEF_HEADER_COMMANDS COMMAND cat ${SLEEFQUAD_ORG_FOOTER} >> ${SLEEFQUAD_INCLUDE_HEADER})
+endif()
+
+add_custom_command(OUTPUT ${SLEEFQUAD_INCLUDE_HEADER}
+  ${SLEEF_HEADER_COMMANDS}
+  DEPENDS
+    ${SLEEFQUAD_ORG_HEADER}
+    ${SLEEFQUAD_ORG_FOOTER}
+    qmkrename
+)
+
+# --------------------------------------------------------------------
+# qmkrename
+# qrenameXXX.h for each vector extension
+# --------------------------------------------------------------------
+# Helper executable: generates parts of the sleef header file
+add_host_executable(qmkrename qmkrename.c)
+
+set(HEADER_FILES_GENERATED "")
+foreach(SIMD ${SLEEFQUAD_SUPPORTED_EXT})
+  if(COMPILER_SUPPORTS_${SIMD})
+    string(TOLOWER ${SIMD} SIMDLC)
+    set(HEADER_${SIMD} ${CMAKE_CURRENT_BINARY_DIR}/include/qrename${SIMDLC}.h)
+    list(APPEND HEADER_FILES_GENERATED ${HEADER_${SIMD}})
+
+    # Generate qmkrename commands
+    add_custom_command(OUTPUT ${HEADER_${SIMD}}
+      COMMAND echo Generating qrename${vecarch}.h: qmkrename ${QUAD_RENAME_PARAMS_${SIMD}}
+      COMMAND $<TARGET_FILE:qmkrename> ${QUAD_RENAME_PARAMS_${SIMD}} > ${HEADER_${SIMD}}
+      DEPENDS qmkrename
+    )
+    add_custom_target(qrename${SIMD}.h_generated DEPENDS ${HEADER_${SIMD}})
+  endif()
+endforeach()
+
+# --------------------------------------------------------------------
+# sleefquad_headers
+# --------------------------------------------------------------------
+add_custom_target(sleefquad_headers ALL
+  DEPENDS
+    ${SLEEFQUAD_INCLUDE_HEADER}
+    ${HEADER_FILES_GENERATED}
+)
+
+# --------------------------------------------------------------------
+# libsleefquad
+# --------------------------------------------------------------------
+
+foreach(SIMD ${SLEEFQUAD_SUPPORTED_EXT})
+  if(COMPILER_SUPPORTS_${SIMD})
+    string(TOLOWER ${SIMD} SIMDLC)
+    set(OBJECT "sleefquad${SIMDLC}_obj")
+    add_library(${OBJECT} OBJECT sleefsimdqp.c ${HEADER_${SIMD}})    
+
+    if(COMPILER_SUPPORTS_BUILTIN_MATH)
+      target_compile_definitions(${OBJECT} PRIVATE ENABLE_BUILTIN_MATH=1)
+    endif()
+    target_compile_definitions(${OBJECT} PRIVATE ENABLE_${SIMD}=1 DORENAME=1 ${COMMON_TARGET_DEFINITIONS})
+
+    set_target_properties(${OBJECT} PROPERTIES ${COMMON_TARGET_PROPERTIES})
+    add_dependencies(${OBJECT} qrename${SIMD}.h_generated)
+    target_compile_options(${OBJECT} PRIVATE ${FLAGS_ENABLE_${SIMD}})
+
+    list(APPEND SLEEFQUAD_OBJECTS $<TARGET_OBJECTS:${OBJECT}>)
+  endif()
+endforeach()
+
+add_library(sleefquad ${SLEEFQUAD_OBJECTS})
+
+set_target_properties(sleefquad PROPERTIES
+  VERSION ${SLEEF_VERSION}
+  SOVERSION ${SLEEF_SOVERSION}
+  ${COMMON_TARGET_PROPERTIES}
+)
+
+set_target_properties(sleefquad PROPERTIES ${COMMON_TARGET_PROPERTIES})
+
+if(LIBM AND NOT COMPILER_SUPPORTS_BUILTIN_MATH)
+  target_link_libraries(sleefquad ${LIBM})
+endif()
+
+# --------------------------------------------------------------------
+# Install
+# --------------------------------------------------------------------
+# Install libsleef and sleef.h
+install(FILES ${SLEEFQUAD_INCLUDE_HEADER} DESTINATION include)
+install(TARGETS sleefquad DESTINATION lib)

--- a/src/quad/qfuncproto.h
+++ b/src/quad/qfuncproto.h
@@ -1,0 +1,45 @@
+//          Copyright Naoki Shibata 2010 - 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+typedef struct {
+  char *name;
+  int ulp;
+  int ulpSuffix;
+  int funcType;
+  int flags;
+} funcSpec;
+
+/*
+  ulp : (error bound in ulp) * 10
+
+  ulpSuffix:
+  0 : ""
+  1 : "_u1"
+  2 : "_u05"
+
+  funcType:
+  0 : vargquad func(vargquad);
+  1 : vargquad func(vargquad, vargquad);
+  2 : vargquad2 func(vargquad);   GNUABI : void func(vargquad, double *, double *);
+  3 : vargquad func(vargquad, vint);
+  4 : vint func(vargquad);
+  5 : vargquad func(vargquad, vargquad, vargquad);
+  6 : vargquad2 func(vargquad);   GNUABI : vargquad func(vargquad, double *);
+  7 : int func(int);
+  8 : void *func(int);
+ */
+
+funcSpec funcList[] = {
+  { "add", 5, 2, 1, 0 },
+  { "mul", 5, 2, 1, 0 },
+  { "div", 5, 2, 1, 0 },
+  { "sqrt", 5, 2, 0, 0 },
+  //{ "sincos", 10, 1, 2, 0 },
+  //{ "ldexp", -1, 0, 3, 0 },
+  //{ "ilogb", -1, 0, 4, 0 },
+  //{ "fma", -1, 0, 5, 0 },
+  
+  { NULL, -1, 0, 0, 0 },
+};

--- a/src/quad/qmkrename.c
+++ b/src/quad/qmkrename.c
@@ -1,0 +1,167 @@
+//          Copyright Naoki Shibata 2010 - 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "qfuncproto.h"
+
+int main(int argc, char **argv) {
+  if (argc < 3) {
+    fprintf(stderr, "Generate a header for renaming functions\n");
+    fprintf(stderr, "Usage : %s <width> [<isa>]\n", argv[0]);
+    fprintf(stderr, "\n");
+
+    fprintf(stderr, "Generate a part of header for library functions\n");
+    fprintf(stderr, "Usage : %s <width> <vargquad type> <vargquad2 type> <vint type> <Macro to enable> [<isa>]\n", argv[0]);
+    fprintf(stderr, "\n");
+
+    exit(-1);
+  }
+
+  static char *ulpSuffixStr[] = { "", "_u1", "_u05" };
+  
+  if (argc == 2 || argc == 3) {
+    char *wqp = argv[1];
+    char *isaname = argc == 2 ? "" : argv[2];
+    char *isaub = argc == 3 ? "_" : "";
+
+    if (strcmp(isaname, "sve") == 0) wqp = "x";
+
+    for(int i=0;funcList[i].name != NULL;i++) {
+      if (funcList[i].ulp >= 0) {
+	printf("#define x%sq%s Sleef_%sq%s_u%02d%s\n",
+	       funcList[i].name, ulpSuffixStr[funcList[i].ulpSuffix],
+	       funcList[i].name, wqp,
+	       funcList[i].ulp, isaname);
+      } else {
+	printf("#define x%sq Sleef_%sq%s%s%s\n", funcList[i].name, funcList[i].name, wqp, isaub, isaname);
+      }
+    }
+  } else {
+    char *wqp = argv[1];
+    char *vargquadname = argv[2];
+    char *vargquad2name = argv[3];
+    char *vintname = argv[4];
+    char *architecture = argv[5];
+    char *isaname = argc == 7 ? argv[6] : "";
+    char *isaub = argc == 7 ? "_" : "";
+
+    if (strcmp(isaname, "sve") == 0) wqp = "x";
+
+    printf("#ifdef %s\n", architecture);
+
+    if (strcmp(vargquadname, "-") != 0) {
+      for(int i=0;funcList[i].name != NULL;i++) {
+	switch(funcList[i].funcType) {
+	case 0:
+	  if (funcList[i].ulp >= 0) {
+	    printf("IMPORT CONST %s Sleef_%sq%s_u%02d%s(%s);\n",
+		   vargquadname,
+		   funcList[i].name, wqp,
+		   funcList[i].ulp, isaname,
+		   vargquadname);
+	  } else {
+	    printf("IMPORT CONST %s Sleef_%sq%s%s%s(%s);\n",
+		   vargquadname,
+		   funcList[i].name, wqp,
+		   isaub, isaname,
+		   vargquadname);
+	  }
+	  break;
+	case 1:
+	  if (funcList[i].ulp >= 0) {
+	    printf("IMPORT CONST %s Sleef_%sq%s_u%02d%s(%s, %s);\n",
+		   vargquadname,
+		   funcList[i].name, wqp,
+		   funcList[i].ulp, isaname,
+		   vargquadname, vargquadname);
+	  } else {
+	    printf("IMPORT CONST %s Sleef_%sq%s%s%s(%s, %s);\n",
+		   vargquadname,
+		   funcList[i].name, wqp,
+		   isaub, isaname,
+		   vargquadname, vargquadname);
+	  }
+	  break;
+	case 2:
+	case 6:
+	  if (funcList[i].ulp >= 0) {
+	    printf("IMPORT CONST %s Sleef_%sq%s_u%02d%s(%s);\n",
+		   vargquad2name,
+		   funcList[i].name, wqp,
+		   funcList[i].ulp, isaname,
+		   vargquadname);
+	  } else {
+	    printf("IMPORT CONST %s Sleef_%sq%s%s%s(%s);\n",
+		   vargquad2name,
+		   funcList[i].name, wqp,
+		   isaub, isaname,
+		   vargquadname);
+	  }
+	  break;
+	case 3:
+	  if (funcList[i].ulp >= 0) {
+	    printf("IMPORT CONST %s Sleef_%sq%s_u%02d%s(%s, %s);\n",
+		   vargquadname,
+		   funcList[i].name, wqp,
+		   funcList[i].ulp, isaname,
+		   vargquadname, vintname);
+	  } else {
+	    printf("IMPORT CONST %s Sleef_%sq%s%s%s(%s, %s);\n",
+		   vargquadname,
+		   funcList[i].name, wqp,
+		   isaub, isaname,
+		   vargquadname, vintname);
+	  }
+	  break;
+	case 4:
+	  if (funcList[i].ulp >= 0) {
+	    printf("IMPORT CONST %s Sleef_%sq%s_u%02d%s(%s);\n",
+		   vintname,
+		   funcList[i].name, wqp,
+		   funcList[i].ulp, isaname,
+		   vargquadname);
+	  } else {
+	    printf("IMPORT CONST %s Sleef_%sq%s%s%s(%s);\n",
+		   vintname,
+		   funcList[i].name, wqp,
+		   isaub, isaname,
+		   vargquadname);
+	  }
+	  break;
+	case 5:
+	  if (funcList[i].ulp >= 0) {
+	    printf("IMPORT CONST %s Sleef_%sq%s_u%02d%s(%s, %s, %s);\n",
+		   vargquadname,
+		   funcList[i].name, wqp,
+		   funcList[i].ulp, isaname,
+		   vargquadname, vargquadname, vargquadname);
+	  } else {
+	    printf("IMPORT CONST %s Sleef_%sq%s%s%s(%s, %s, %s);\n",
+		   vargquadname,
+		   funcList[i].name, wqp,
+		   isaub, isaname,
+		   vargquadname, vargquadname, vargquadname);
+	  }
+	  break;
+	case 7:
+	  printf("IMPORT CONST int Sleef_%sq%s%s%s(int);\n", funcList[i].name, wqp, isaub, isaname);
+	  break;
+	case 8:
+	  printf("IMPORT CONST void *Sleef_%sq%s%s%s(int);\n", funcList[i].name, wqp, isaub, isaname);
+	  break;
+	}
+      }
+    }
+
+    printf("#endif\n");
+  }
+
+  exit(0);
+}
+  

--- a/src/quad/sleefquad_footer.h.org
+++ b/src/quad/sleefquad_footer.h.org
@@ -1,0 +1,6 @@
+#ifdef __cplusplus
+}
+#endif
+
+#undef IMPORT
+#endif // #ifndef __SLEEFQUAD_H__

--- a/src/quad/sleefquad_header.h.org
+++ b/src/quad/sleefquad_header.h.org
@@ -1,0 +1,78 @@
+//          Copyright Naoki Shibata 2010 - 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef __SLEEFQUAD_H__
+#define __SLEEFQUAD_H__
+
+#include "sleef.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if (defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__) || defined(_MSC_VER)) && !defined(SLEEF_STATIC_LIBS)
+#ifdef IMPORT_IS_EXPORT
+#define IMPORT __declspec(dllexport)
+#else // #ifdef IMPORT_IS_EXPORT
+#define IMPORT __declspec(dllimport)
+#if (defined(_MSC_VER))
+#pragma comment(lib,"sleefquad.lib")
+#endif // #if (defined(_MSC_VER))
+#endif // #ifdef IMPORT_IS_EXPORT
+#else // #if (defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__) || defined(_MSC_VER)) && !defined(SLEEF_STATIC_LIBS)
+#define IMPORT
+#endif // #if (defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__) || defined(_MSC_VER)) && !defined(SLEEF_STATIC_LIBS)
+
+//
+
+#if !defined(Sleef_quad_DEFINED)
+#define Sleef_quad_DEFINED
+#if defined(ENABLEFLOAT128)
+typedef __float128 Sleef_quad;
+#else
+typedef struct { uint64_t x, y; } Sleef_quad;
+#endif
+#endif
+
+#if !defined(Sleef_quad1_DEFINED)
+#define Sleef_quad1_DEFINED
+typedef union {
+  struct {
+    Sleef_quad x;
+  };
+  Sleef_quad s[1];
+} Sleef_quad1;
+#endif
+
+#if !defined(Sleef_quad2_DEFINED)
+#define Sleef_quad2_DEFINED
+typedef union {
+  struct {
+    Sleef_quad x, y;
+  };
+  Sleef_quad s[2];
+} Sleef_quad2;
+#endif
+
+#if !defined(Sleef_quad4_DEFINED)
+#define Sleef_quad4_DEFINED
+typedef union {
+  struct {
+    Sleef_quad x, y, z, w;
+  };
+  Sleef_quad s[4];
+} Sleef_quad4;
+#endif
+
+#if !defined(Sleef_quad8_DEFINED)
+#define Sleef_quad8_DEFINED
+typedef union {
+  Sleef_quad s[8];
+} Sleef_quad8;
+#endif
+
+//
+

--- a/src/quad/sleefquad_header.h.org
+++ b/src/quad/sleefquad_header.h.org
@@ -74,5 +74,12 @@ typedef union {
 } Sleef_quad8;
 #endif
 
+#if defined(__ARM_FEATURE_SVE) && !defined(Sleef_quadx_DEFINED)
+#define Sleef_quadx_DEFINED
+typedef union {
+  Sleef_quad s[32];
+} Sleef_quadx;
+#endif
+
 //
 

--- a/src/quad/sleefsimdqp.c
+++ b/src/quad/sleefsimdqp.c
@@ -190,27 +190,6 @@ static INLINE CONST vmask2 imdvm2(vmask x, vmask y) { vmask2 r = { x, y }; retur
 #define vsrl128_vm2_vm2_i(m, imm)					\
   imdvm2(vor_vm_vm_vm(vsrl64_vm_vm_i(m.x, imm), vsll64_vm_vm_i(m.y, 64-imm)), vsrl64_vm_vm_i(m.y, imm))
 
-static INLINE CONST vmask2 vsrl128_vm2_vm2_vm(vmask2 m, vmask c) {
-  vmask2 r = { .y = vsrl64_vm_vm_vm(m.y, c), .x = vsrl64_vm_vm_vm(m.x, c) };
-  r.x = vor_vm_vm_vm(r.x, vsll64_vm_vm_vm(m.y, vsub64_vm_vm_vm(vcast_vm_i_i(0, 64), c)));
-  r.x = vor_vm_vm_vm(r.x, vsrl64_vm_vm_vm(m.y, vsub64_vm_vm_vm(c, vcast_vm_i_i(0, 64))));
-  return r;
-}
-
-static INLINE CONST vmask2 vsll128_vm2_vm_vm(vmask m, vmask c) {
-  vmask2 r = { .x = vsll64_vm_vm_vm(m, c) };
-  r.y = vsll64_vm_vm_vm(m, vsub64_vm_vm_vm(c, vcast_vm_i_i(0, 64)));
-  r.y = vor_vm_vm_vm(r.y, vsrl64_vm_vm_vm(m, vsub64_vm_vm_vm(vcast_vm_i_i(0, 64), c)));
-  return r;
-}
-
-static INLINE CONST vmask2 vsrlx128_vm2_vm_vm(vmask u, vmask n) {
-  return (vmask2) {
-    vsrl64_vm_vm_vm(u, vadd64_vm_vm_vm(vcast_vm_i_i(0, 64), n)), 
-    vor_vm_vm_vm(vsrl64_vm_vm_vm(u, n), vsll64_vm_vm_vm(u, vneg64_vm_vm(n)))
-  };
-}
-
 static INLINE CONST vopmask visnonnumberq_vo_vm2(vmask2 a) {
   return veq64_vo_vm_vm(vand_vm_vm_vm(a.y, vcast_vm_i_i(0x7fff0000, 0)), vcast_vm_i_i(0x7fff0000, 0));
 }

--- a/src/quad/sleefsimdqp.c
+++ b/src/quad/sleefsimdqp.c
@@ -524,6 +524,7 @@ static tdx vcast_tdx_vf128(vmask2 f) {
 
     vdouble t = vreinterpret_vd_vm(vor_vm_vm_vm(signbit, vreinterpret_vm_vd(vcast_vd_d(SLEEF_INFINITY))));
     r.dd.x = vsel_vd_vo_vd_vd(fisnan, vcast_vd_d(SLEEF_INFINITY - SLEEF_INFINITY), vsel_vd_vo_vd_vd(fisinf, t, r.dd.x));
+    r.dd.x = vreinterpret_vd_vm(vandnot_vm_vo64_vm(iszero, vreinterpret_vm_vd(r.dd.x)));
   }
 
   return r;

--- a/src/quad/sleefsimdqp.c
+++ b/src/quad/sleefsimdqp.c
@@ -116,16 +116,21 @@ typedef __sizeless_struct vdouble3 {
   svfloat64_t y;
   svfloat64_t z;
 } vdouble3;
+
+typedef __sizeless_struct {
+  vmask e;
+  vdouble3 dd;
+} tdx;
 #else
 typedef struct {
   vdouble x, y, z;
 } vdouble3;
-#endif
 
 typedef struct {
   vmask e;
   vdouble3 dd;
 } tdx;
+#endif
 
 //
 

--- a/src/quad/sleefsimdqp.c
+++ b/src/quad/sleefsimdqp.c
@@ -1,0 +1,984 @@
+//          Copyright Naoki Shibata 2010 - 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+// Always use -ffp-contract=off option to compile SLEEF.
+
+#include <stdint.h>
+#include <assert.h>
+#include <limits.h>
+#include <float.h>
+
+#include "misc.h"
+
+#define __SLEEFSIMDQP_C__
+
+#if (defined(_MSC_VER))
+#pragma fp_contract (off)
+#endif
+
+#ifdef ENABLE_PUREC_SCALAR
+#define CONFIG 1
+#include "helperpurec_scalar.h"
+#ifdef DORENAME
+#include "qrenamepurec_scalar.h"
+#endif
+#endif
+
+#ifdef ENABLE_PURECFMA_SCALAR
+#define CONFIG 2
+#include "helperpurec_scalar.h"
+#ifdef DORENAME
+#include "qrenamepurecfma_scalar.h"
+#endif
+#endif
+
+#ifdef ENABLE_SSE2
+#define CONFIG 2
+#include "helpersse2.h"
+#ifdef DORENAME
+#include "qrenamesse2.h"
+#endif
+#endif
+
+#ifdef ENABLE_AVX2128
+#define CONFIG 1
+#include "helperavx2_128.h"
+#ifdef DORENAME
+#include "qrenameavx2128.h"
+#endif
+#endif
+
+#ifdef ENABLE_AVX
+#define CONFIG 1
+#include "helperavx.h"
+#ifdef DORENAME
+#include "qrenameavx.h"
+#endif
+#endif
+
+#ifdef ENABLE_FMA4
+#define CONFIG 4
+#include "helperavx.h"
+#ifdef DORENAME
+#include "qrenamefma4.h"
+#endif
+#endif
+
+#ifdef ENABLE_AVX2
+#define CONFIG 1
+#include "helperavx2.h"
+#ifdef DORENAME
+#include "qrenameavx2.h"
+#endif
+#endif
+
+#ifdef ENABLE_AVX512F
+#define CONFIG 1
+#include "helperavx512f.h"
+#ifdef DORENAME
+#include "qrenameavx512f.h"
+#endif
+#endif
+
+#ifdef ENABLE_ADVSIMD
+#define CONFIG 1
+#include "helperadvsimd.h"
+#ifdef DORENAME
+#include "qrenameadvsimd.h"
+#endif
+#endif
+
+#ifdef ENABLE_SVE
+#define CONFIG 1
+#include "helpersve.h"
+#ifdef DORENAME
+#include "qrenamesve.h"
+#endif
+#endif
+
+#ifdef ENABLE_VSX
+#define CONFIG 1
+#include "helperpower_128.h"
+#ifdef DORENAME
+#include "qrenamevsx.h"
+#endif
+#endif
+
+//
+
+#include "dd.h"
+
+#ifdef ENABLE_SVE
+typedef __sizeless_struct vdouble3 {
+  svfloat64_t x;
+  svfloat64_t y;
+  svfloat64_t z;
+} vdouble3;
+#else
+typedef struct {
+  vdouble x, y, z;
+} vdouble3;
+#endif
+
+typedef struct {
+  vmask e;
+  vdouble3 dd;
+} tdx;
+
+//
+
+static INLINE CONST vopmask visnonnumber(vdouble x) {
+  return veq64_vo_vm_vm(vand_vm_vm_vm(vreinterpret_vm_vd(x), vcast_vm_i_i(0x7ff00000, 0)), vcast_vm_i_i(0x7ff00000, 0));
+}
+
+static INLINE CONST vmask vsignbit_vm_vd(vdouble d) {
+  return vand_vm_vm_vm(vreinterpret_vm_vd(d), vreinterpret_vm_vd(vcast_vd_d(-0.0)));
+}
+
+static INLINE CONST vdouble vmulsign_vd_vd_vd(vdouble x, vdouble y) {
+  return vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(x), vsignbit_vm_vd(y)));
+}
+
+static INLINE CONST vopmask vnot_vo64_vo64(vopmask x) {
+  return vxor_vo_vo_vo(x, veq64_vo_vm_vm(vcast_vm_i_i(0, 0), vcast_vm_i_i(0, 0)));
+}
+
+static INLINE CONST vopmask vugt64_vo_vm_vm(vmask x, vmask y) { // unsigned compare
+  x = vxor_vm_vm_vm(vcast_vm_i_i(0x80000000, 0), x);
+  y = vxor_vm_vm_vm(vcast_vm_i_i(0x80000000, 0), y);
+  return vgt64_vo_vm_vm(x, y);
+}
+
+static INLINE CONST vmask vilogb2k_vm_vd(vdouble d) {
+  vmask m = vreinterpret_vm_vd(d);
+  m = vsrl64_vm_vm_i(m, 20 + 32);
+  m = vand_vm_vm_vm(m, vcast_vm_i_i(0, 0x7ff));
+  m = vsub64_vm_vm_vm(m, vcast_vm_i_i(0, 0x3ff));
+  return m;
+}
+
+static INLINE CONST vmask vilogb3k_vm_vd(vdouble d) {
+  vmask m = vreinterpret_vm_vd(d);
+  m = vsrl64_vm_vm_i(m, 20 + 32);
+  m = vand_vm_vm_vm(m, vcast_vm_i_i(0, 0x7ff));
+  return m;
+}
+
+static INLINE CONST vdouble vldexp3_vd_vd_vm(vdouble d, vmask q) {
+  return vreinterpret_vd_vm(vadd64_vm_vm_vm(vreinterpret_vm_vd(d), vsll64_vm_vm_i(q, 52)));
+}
+
+static INLINE CONST vopmask vsignbit_vo_vd(vdouble d) {
+  return veq64_vo_vm_vm(vand_vm_vm_vm(vreinterpret_vm_vd(d), vreinterpret_vm_vd(vcast_vd_d(-0.0))), vreinterpret_vm_vd(vcast_vd_d(-0.0)));
+}
+
+static INLINE CONST vmask2 vsel_vm2_vo_vm2_vm2(vopmask o, vmask2 x, vmask2 y) {
+  return (vmask2) { .y = vsel_vm_vo64_vm_vm(o, x.y, y.y), .x = vsel_vm_vo64_vm_vm(o, x.x, y.x) };
+}
+
+static INLINE CONST vmask2 vadd128_vm2_vm2_vm2(vmask2 x, vmask2 y) {
+  vmask2 r = { .y = vadd64_vm_vm_vm(x.y, y.y), .x = vadd64_vm_vm_vm(x.x, y.x) };
+  r.y = vadd64_vm_vm_vm(r.y, vand_vm_vo64_vm(vugt64_vo_vm_vm(x.x, r.x), vcast_vm_i_i(0, 1)));
+  return r;
+}
+
+static INLINE CONST vmask2 imdvm2(vmask x, vmask y) { vmask2 r = { x, y }; return r; }
+
+// imm must be smaller than 64
+#define vsrl128_vm2_vm2_i(m, imm)					\
+  imdvm2(vor_vm_vm_vm(vsrl64_vm_vm_i(m.x, imm), vsll64_vm_vm_i(m.y, 64-imm)), vsrl64_vm_vm_i(m.y, imm))
+
+static INLINE CONST vmask2 vsrl128_vm2_vm2_vm(vmask2 m, vmask c) {
+  vmask2 r = { .y = vsrl64_vm_vm_vm(m.y, c), .x = vsrl64_vm_vm_vm(m.x, c) };
+  r.x = vor_vm_vm_vm(r.x, vsll64_vm_vm_vm(m.y, vsub64_vm_vm_vm(vcast_vm_i_i(0, 64), c)));
+  r.x = vor_vm_vm_vm(r.x, vsrl64_vm_vm_vm(m.y, vsub64_vm_vm_vm(c, vcast_vm_i_i(0, 64))));
+  return r;
+}
+
+static INLINE CONST vmask2 vsll128_vm2_vm_vm(vmask m, vmask c) {
+  vmask2 r = { .x = vsll64_vm_vm_vm(m, c) };
+  r.y = vsll64_vm_vm_vm(m, vsub64_vm_vm_vm(c, vcast_vm_i_i(0, 64)));
+  r.y = vor_vm_vm_vm(r.y, vsrl64_vm_vm_vm(m, vsub64_vm_vm_vm(vcast_vm_i_i(0, 64), c)));
+  return r;
+}
+
+static INLINE CONST vmask2 vsrlx128_vm2_vm_vm(vmask u, vmask n) {
+  return (vmask2) {
+    vsrl64_vm_vm_vm(u, vadd64_vm_vm_vm(vcast_vm_i_i(0, 64), n)), 
+    vor_vm_vm_vm(vsrl64_vm_vm_vm(u, n), vsll64_vm_vm_vm(u, vneg64_vm_vm(n)))
+  };
+}
+
+static INLINE CONST vopmask visnonnumberq_vo_vm2(vmask2 a) {
+  return veq64_vo_vm_vm(vand_vm_vm_vm(a.y, vcast_vm_i_i(0x7fff0000, 0)), vcast_vm_i_i(0x7fff0000, 0));
+}
+
+static INLINE CONST vopmask visnonnumberq_vo_vm2_vm2(vmask2 a, vmask2 b) {
+  vmask ma = vxor_vm_vm_vm(vand_vm_vm_vm(a.y, vcast_vm_i_i(0x7fff0000, 0)), vcast_vm_i_i(0x7fff0000, 0));
+  vmask mb = vxor_vm_vm_vm(vand_vm_vm_vm(b.y, vcast_vm_i_i(0x7fff0000, 0)), vcast_vm_i_i(0x7fff0000, 0));
+  return veq64_vo_vm_vm(vand_vm_vm_vm(ma, mb), vcast_vm_i_i(0, 0));
+}
+
+static INLINE CONST vopmask visnonnumberq_vo_vm2_vm2_vm2(vmask2 a, vmask2 b, vmask2 c) {
+  vmask ma = vxor_vm_vm_vm(vand_vm_vm_vm(a.y, vcast_vm_i_i(0x7fff0000, 0)), vcast_vm_i_i(0x7fff0000, 0));
+  vmask mb = vxor_vm_vm_vm(vand_vm_vm_vm(b.y, vcast_vm_i_i(0x7fff0000, 0)), vcast_vm_i_i(0x7fff0000, 0));
+  vmask mc = vxor_vm_vm_vm(vand_vm_vm_vm(c.y, vcast_vm_i_i(0x7fff0000, 0)), vcast_vm_i_i(0x7fff0000, 0));
+  return veq64_vo_vm_vm(vand_vm_vm_vm(vand_vm_vm_vm(ma, mb), mc), vcast_vm_i_i(0, 0));
+}
+
+static INLINE CONST vopmask visinfq_vo_vm2(vmask2 a) {
+  vopmask o = veq64_vo_vm_vm(vand_vm_vm_vm(a.y, vcast_vm_i_i(0x7fffffff, 0xffffffff)), vcast_vm_i_i(0x7fff0000, 0));
+  return vand_vo_vo_vo(o, veq64_vo_vm_vm(a.x, vcast_vm_i_i(0, 0)));
+}
+
+static INLINE CONST vopmask vispinfq_vo_vm2(vmask2 a) {
+  return vand_vo_vo_vo(veq64_vo_vm_vm(a.y, vcast_vm_i_i(0x7fff0000, 0)), veq64_vo_vm_vm(a.x, vcast_vm_i_i(0, 0)));
+}
+
+static INLINE CONST vopmask visnanq_vo_vm2(vmask2 a) {
+  return vandnot_vo_vo_vo(visinfq_vo_vm2(a), visnonnumberq_vo_vm2(a));
+}
+
+static INLINE CONST vopmask viszeroq_vo_vm2(vmask2 a) {
+  return veq64_vo_vm_vm(vor_vm_vm_vm(vand_vm_vm_vm(a.y, vcast_vm_i_i(~0x80000000, ~0)), a.x), vcast_vm_i_i(0, 0));
+}
+
+//
+
+static INLINE CONST vdouble2 ddscale_vd2_vd2_d(vdouble2 d, double s) { return ddscale_vd2_vd2_vd(d, vcast_vd_d(s)); }
+
+static INLINE CONST vdouble3 vsel_vd3_vo_vd3_vd3(vopmask m, vdouble3 x, vdouble3 y) {
+  vdouble3 r;
+  r.x = vsel_vd_vo_vd_vd(m, x.x, y.x);
+  r.y = vsel_vd_vo_vd_vd(m, x.y, y.y);
+  r.z = vsel_vd_vo_vd_vd(m, x.z, y.z);
+  return r;
+}
+
+// TD algorithms are based on Y. Hida et al., Library for double-double and quad-double arithmetic (2007).
+static INLINE CONST vdouble2 twosum_vd2_vd_vd(vdouble x, vdouble y) {
+  vdouble2 r;
+  r.x  = vadd_vd_vd_vd(x, y);
+  vdouble v = vsub_vd_vd_vd(r.x, x);
+  r.y = vadd_vd_vd_vd(vsub_vd_vd_vd(x, vsub_vd_vd_vd(r.x, v)), vsub_vd_vd_vd(y, v));
+  return r;
+}
+
+static INLINE CONST vdouble2 twosumx_vd2_vd_vd_vd(vdouble x, vdouble y, vdouble s) {
+  vdouble2 r;
+  r.x  = vmla_vd_vd_vd_vd(y, s, x);
+  vdouble v = vsub_vd_vd_vd(r.x, x);
+  r.y = vadd_vd_vd_vd(vsub_vd_vd_vd(x, vsub_vd_vd_vd(r.x, v)), vmlapn_vd_vd_vd_vd(y, s, v));
+  return r;
+}
+
+static INLINE CONST vdouble2 quicktwosum_vd2_vd_vd(vdouble x, vdouble y) {
+  vdouble2 r;
+  r.x = vadd_vd_vd_vd(x, y);
+  r.y = vadd_vd_vd_vd(vsub_vd_vd_vd(x, r.x), y);
+  return r;
+}
+
+static INLINE CONST vdouble2 twoprod_vd2_vd_vd(vdouble x, vdouble y) {
+  vdouble2 r;
+#ifdef ENABLE_FMA_DP
+  r.x = vmul_vd_vd_vd(x, y);
+  r.y = vfmapn_vd_vd_vd_vd(x, y, r.x);
+#else
+  vdouble xh = vmul_vd_vd_vd(x, vcast_vd_d((1 << 27)+1));
+  xh = vsub_vd_vd_vd(xh, vsub_vd_vd_vd(xh, x));
+  vdouble xl = vsub_vd_vd_vd(x, xh);
+  vdouble yh = vmul_vd_vd_vd(y, vcast_vd_d((1 << 27)+1));
+  yh = vsub_vd_vd_vd(yh, vsub_vd_vd_vd(yh, y));
+  vdouble yl = vsub_vd_vd_vd(y, yh);
+
+  r.x = vmul_vd_vd_vd(x, y);
+  r.y = vadd_vd_5vd(vmul_vd_vd_vd(xh, yh), vneg_vd_vd(r.x), vmul_vd_vd_vd(xl, yh), vmul_vd_vd_vd(xh, yl), vmul_vd_vd_vd(xl, yl));
+#endif
+  return r;
+}
+
+static INLINE CONST vdouble3 tdscale_vd3_vd3_vd(vdouble3 d, vdouble s) {
+  return (vdouble3) { vmul_vd_vd_vd(d.x, s), vmul_vd_vd_vd(d.y, s), vmul_vd_vd_vd(d.z, s) };
+}
+
+static INLINE CONST vdouble3 tdscale_vd3_vd3_d(vdouble3 d, double s) { return tdscale_vd3_vd3_vd(d, vcast_vd_d(s)); }
+
+static INLINE CONST vdouble3 tdquickrenormalize_vd3_vd3(vdouble3 td) {
+  vdouble2 u = quicktwosum_vd2_vd_vd(td.x, td.y);
+  vdouble2 v = quicktwosum_vd2_vd_vd(u.y, td.z);
+  return (vdouble3) { u.x, v.x, v.y };
+}
+
+static INLINE CONST vdouble3 tdnormalize_vd3_vd3(vdouble3 td) {
+  vdouble2 u = quicktwosum_vd2_vd_vd(td.x, td.y);
+  vdouble2 v = quicktwosum_vd2_vd_vd(u.y, td.z);
+  td.x = u.x; td.y = v.x; td.z = v.y;
+  u = quicktwosum_vd2_vd_vd(td.x, td.y);
+  return (vdouble3) { u.x, u.y, td.z };
+}
+
+static INLINE CONST vdouble3 tdadd2_vd3_vd3_vd3(vdouble3 x, vdouble3 y) {
+  vdouble2 d0 = twosum_vd2_vd_vd(x.x, y.x);
+  vdouble2 d1 = twosum_vd2_vd_vd(x.y, y.y);
+  vdouble2 d3 = twosum_vd2_vd_vd(d0.y, d1.x);
+  return tdnormalize_vd3_vd3((vdouble3) { d0.x, d3.x, vadd_vd_4vd(x.z, y.z, d1.y, d3.y) });
+}
+
+static INLINE CONST vdouble3 tdadd2_vd3_vd2_vd3(vdouble2 x, vdouble3 y) {
+  vdouble2 d0 = twosum_vd2_vd_vd(x.x, y.x);
+  vdouble2 d1 = twosum_vd2_vd_vd(x.y, y.y);
+  vdouble2 d3 = twosum_vd2_vd_vd(d0.y, d1.x);
+  return tdnormalize_vd3_vd3((vdouble3) { d0.x, d3.x, vadd_vd_3vd(d1.y, d3.y, y.z) });
+}
+
+static INLINE CONST vdouble3 tdadd_vd3_vd2_vd3(vdouble2 x, vdouble3 y) {
+  vdouble2 d0 = twosum_vd2_vd_vd(x.x, y.x);
+  vdouble2 d1 = twosum_vd2_vd_vd(x.y, y.y);
+  vdouble2 d3 = twosum_vd2_vd_vd(d0.y, d1.x);
+  return (vdouble3) { d0.x, d3.x, vadd_vd_3vd(d1.y, d3.y, y.z) };
+}
+
+static INLINE CONST vdouble3 tdadd2_vd3_vd_vd3(vdouble x, vdouble3 y) {
+  vdouble2 d0 = twosum_vd2_vd_vd(x, y.x);
+  vdouble2 d3 = twosum_vd2_vd_vd(d0.y, y.y);
+  return tdnormalize_vd3_vd3((vdouble3) { d0.x, d3.x, vadd_vd_vd_vd(d3.y, y.z) });
+}
+
+static INLINE CONST vdouble3 tdadd_vd3_vd_vd3(vdouble x, vdouble3 y) {
+  vdouble2 d0 = twosum_vd2_vd_vd(x, y.x);
+  vdouble2 d3 = twosum_vd2_vd_vd(d0.y, y.y);
+  return (vdouble3) { d0.x, d3.x, vadd_vd_vd_vd(d3.y, y.z) };
+}
+
+static INLINE CONST vdouble3 tdscaleadd2_vd3_vd3_vd3_vd(vdouble3 x, vdouble3 y, vdouble s) {
+  vdouble2 d0 = twosumx_vd2_vd_vd_vd(x.x, y.x, s);
+  vdouble2 d1 = twosumx_vd2_vd_vd_vd(x.y, y.y, s);
+  vdouble2 d3 = twosum_vd2_vd_vd(d0.y, d1.x);
+  return tdnormalize_vd3_vd3((vdouble3) { d0.x, d3.x, vadd_vd_3vd(vmla_vd_vd_vd_vd(y.z, s, x.z), d1.y, d3.y) });
+}
+
+static INLINE CONST vdouble3 tdmul2_vd3_vd3_vd3(vdouble3 x, vdouble3 y) {
+  vdouble2 d0 = twoprod_vd2_vd_vd(x.x, y.x);
+  vdouble2 d1 = twoprod_vd2_vd_vd(x.x, y.y);
+  vdouble2 d2 = twoprod_vd2_vd_vd(x.y, y.x);
+  vdouble2 d4 = twosum_vd2_vd_vd(d0.y, d1.x);
+  vdouble2 d5 = twosum_vd2_vd_vd(d4.x, d2.x);
+
+  vdouble t2 = vadd_vd_3vd(vmla_vd_vd_vd_vd(x.z, y.x, vmla_vd_vd_vd_vd(x.y, y.y, vmla_vd_vd_vd_vd(x.x, y.z, vadd_vd_vd_vd(d1.y, d2.y)))), d4.y, d5.y);
+
+  return tdnormalize_vd3_vd3((vdouble3){ d0.x, d5.x, t2 });
+}
+
+static INLINE CONST vdouble3 tdmul_vd3_vd3_vd3(vdouble3 x, vdouble3 y) {
+  vdouble2 d0 = twoprod_vd2_vd_vd(x.x, y.x);
+  vdouble2 d1 = twoprod_vd2_vd_vd(x.x, y.y);
+  vdouble2 d2 = twoprod_vd2_vd_vd(x.y, y.x);
+  vdouble2 d4 = twosum_vd2_vd_vd(d0.y, d1.x);
+  vdouble2 d5 = twosum_vd2_vd_vd(d4.x, d2.x);
+
+  vdouble t2 = vadd_vd_3vd(vmla_vd_vd_vd_vd(x.z, y.x, vmla_vd_vd_vd_vd(x.y, y.y, vmla_vd_vd_vd_vd(x.x, y.z, vadd_vd_vd_vd(d1.y, d2.y)))), d4.y, d5.y);
+
+  return tdquickrenormalize_vd3_vd3((vdouble3){ d0.x, d5.x, t2 });
+}
+
+static INLINE CONST vdouble3 tdmul_vd3_vd2_vd3(vdouble2 x, vdouble3 y) {
+  vdouble2 d0 = twoprod_vd2_vd_vd(x.x, y.x);
+  vdouble2 d1 = twoprod_vd2_vd_vd(x.x, y.y);
+  vdouble2 d2 = twoprod_vd2_vd_vd(x.y, y.x);
+  vdouble2 d4 = twosum_vd2_vd_vd(d0.y, d1.x);
+  vdouble2 d5 = twosum_vd2_vd_vd(d4.x, d2.x);
+
+  vdouble t2 = vadd_vd_3vd(vmla_vd_vd_vd_vd(x.y, y.y, vmla_vd_vd_vd_vd(x.x, y.z, vadd_vd_vd_vd(d1.y, d2.y))), d4.y, d5.y);
+
+  return (vdouble3){ d0.x, d5.x, t2 };
+}
+
+static INLINE CONST vdouble3 tdmul_vd3_vd2_vd2(vdouble2 x, vdouble2 y) {
+  vdouble2 d0 = twoprod_vd2_vd_vd(x.x, y.x);
+  vdouble2 d1 = twoprod_vd2_vd_vd(x.x, y.y);
+  vdouble2 d2 = twoprod_vd2_vd_vd(x.y, y.x);
+  vdouble2 d4 = twosum_vd2_vd_vd(d0.y, d1.x);
+  vdouble2 d5 = twosum_vd2_vd_vd(d4.x, d2.x);
+
+  vdouble t2 = vadd_vd_3vd(vmla_vd_vd_vd_vd(x.y, y.y, vadd_vd_vd_vd(d1.y, d2.y)), d4.y, d5.y);
+
+  return (vdouble3){ d0.x, d5.x, t2 };
+}
+
+static INLINE CONST vdouble3 tddiv2_vd3_vd3_vd3(vdouble3 n, vdouble3 q) {
+  vdouble2 d = ddrec_vd2_vd2((vdouble2) {q.x, q.y});
+  return tdmul2_vd3_vd3_vd3(n, tdadd_vd3_vd2_vd3(d, tdmul_vd3_vd2_vd3(ddscale_vd2_vd2_d(d, -1),
+								      tdadd_vd3_vd_vd3(vcast_vd_d(-1), tdmul_vd3_vd2_vd3(d, q)))));
+}
+
+static INLINE CONST vdouble3 tddiv_vd3_vd3_vd3(vdouble3 n, vdouble3 q) {
+  vdouble2 d = ddrec_vd2_vd2((vdouble2) {q.x, q.y});
+  return tdmul_vd3_vd3_vd3(n, tdadd_vd3_vd2_vd3(d, tdmul_vd3_vd2_vd3(ddscale_vd2_vd2_d(d, -1),
+								     tdadd_vd3_vd_vd3(vcast_vd_d(-1), tdmul_vd3_vd2_vd3(d, q)))));
+}
+
+static INLINE CONST vdouble3 tdrec_vd3_vd3(vdouble3 q) {
+  vdouble2 d = ddrec_vd2_vd2((vdouble2) {q.x, q.y});
+  return tdadd2_vd3_vd2_vd3(d, tdmul_vd3_vd2_vd3(ddscale_vd2_vd2_d(d, -1),
+						 tdadd_vd3_vd_vd3(vcast_vd_d(-1), tdmul_vd3_vd2_vd3(d, q))));
+}
+
+static INLINE CONST vdouble3 tdrec_vd3_vd2(vdouble2 q) {
+  vdouble2 d = ddrec_vd2_vd2((vdouble2) {q.x, q.y});
+  return tdadd2_vd3_vd2_vd3(d, tdmul_vd3_vd2_vd3(ddscale_vd2_vd2_d(d, -1),
+						 tdadd_vd3_vd_vd3(vcast_vd_d(-1), tdmul_vd3_vd2_vd2(d, q))));
+}
+
+static INLINE CONST vdouble3 tdsqrt_vd3_vd3(vdouble3 d) {
+  vdouble2 t = ddsqrt_vd2_vd2((vdouble2) {d.x, d.y});
+  vdouble3 r = tdmul2_vd3_vd3_vd3(tdadd2_vd3_vd3_vd3(d, tdmul_vd3_vd2_vd2(t, t)), tdrec_vd3_vd2(t));
+  return tdscale_vd3_vd3_d(r, 0.5);
+}
+
+//
+
+static INLINE CONST tdx vsel_tdx_vo64_tdx_tdx(vopmask o, tdx x, tdx y) {
+  tdx r = { .dd = vsel_vd3_vo_vd3_vd3(o, x.dd, y.dd) };
+  r.e = vsel_vm_vo64_vm_vm(o, x.e, y.e);
+  return r;
+}
+
+static INLINE CONST tdx add2_tdx_tdx_tdx(tdx dd0, tdx dd1) {
+  vmask ed = vsub64_vm_vm_vm(dd1.e, dd0.e);
+  vdouble t = vldexp3_vd_vd_vm(vcast_vd_d(1), ed);
+
+  tdx r = { .dd = tdscaleadd2_vd3_vd3_vd3_vd(dd0.dd, dd1.dd, t) };
+  r.e = vilogb2k_vm_vd(r.dd.x);
+  t = vldexp3_vd_vd_vm(vcast_vd_d(1), vneg64_vm_vm(r.e));
+
+  vopmask o = veq_vo_vd_vd(dd0.dd.x, vcast_vd_d(0));
+  r.e = vsel_vm_vo64_vm_vm(o, dd1.e, vadd64_vm_vm_vm(r.e, dd0.e));
+  r.dd = tdscale_vd3_vd3_vd(r.dd, t);
+
+  r = vsel_tdx_vo64_tdx_tdx(vgt64_vo_vm_vm(ed, vcast_vm_i_i(0, 200)), dd1, r);
+  r = vsel_tdx_vo64_tdx_tdx(vgt64_vo_vm_vm(vcast_vm_i_i(-1, -200), ed), dd0, r);
+
+  return r;
+}
+
+static INLINE CONST tdx mul2_tdx_tdx_tdx(tdx dd0, tdx dd1) {
+  tdx r = { .dd = tdmul2_vd3_vd3_vd3(dd0.dd, dd1.dd) };
+  r.e = vilogb2k_vm_vd(r.dd.x);
+  r.dd = tdscale_vd3_vd3_vd(r.dd, vldexp3_vd_vd_vm(vcast_vd_d(1), vneg64_vm_vm(r.e)));
+  r.e = vadd64_vm_vm_vm(vadd64_vm_vm_vm(vadd64_vm_vm_vm(dd0.e, dd1.e), vcast_vm_i_i(-1, -16383)), r.e);
+  return r;
+}
+
+static INLINE CONST tdx mul_tdx_tdx_tdx(tdx dd0, tdx dd1) {
+  tdx r = { .dd = tdmul_vd3_vd3_vd3(dd0.dd, dd1.dd) };
+  r.e = vilogb2k_vm_vd(r.dd.x);
+  r.dd = tdscale_vd3_vd3_vd(r.dd, vldexp3_vd_vd_vm(vcast_vd_d(1), vneg64_vm_vm(r.e)));
+  r.e = vadd64_vm_vm_vm(vadd64_vm_vm_vm(vadd64_vm_vm_vm(dd0.e, dd1.e), vcast_vm_i_i(-1, -16383)), r.e);
+  return r;
+}
+
+static INLINE CONST tdx div2_tdx_tdx_tdx(tdx dd0, tdx dd1) {
+  tdx r = { .dd = tddiv2_vd3_vd3_vd3(dd0.dd, dd1.dd) };
+  r.e = vilogb2k_vm_vd(r.dd.x);
+  r.dd = tdscale_vd3_vd3_vd(r.dd, vldexp3_vd_vd_vm(vcast_vd_d(1), vneg64_vm_vm(r.e)));
+  r.e = vadd64_vm_vm_vm(vadd64_vm_vm_vm(vsub64_vm_vm_vm(dd0.e, dd1.e), vcast_vm_i_i(0, 16383)), r.e);
+  return r;
+}
+
+static INLINE CONST tdx sqrt_tdx_tdx(tdx dd0) {
+  vopmask o = veq64_vo_vm_vm(vand_vm_vm_vm(dd0.e, vcast_vm_i_i(0, 1)), vcast_vm_i_i(0, 1));
+  dd0.dd = tdscale_vd3_vd3_vd(dd0.dd, vsel_vd_vo_vd_vd(o, vcast_vd_d(1), vcast_vd_d(2)));
+  tdx r = { .dd = tdsqrt_vd3_vd3(dd0.dd) };
+  r.e = vilogb2k_vm_vd(r.dd.x);
+  r.dd = tdscale_vd3_vd3_vd(r.dd, vldexp3_vd_vd_vm(vcast_vd_d(1), vneg64_vm_vm(r.e)));
+  r.e = vadd64_vm_vm_vm(vcast_vm_vi2(vsra_vi2_vi2_i(vcast_vi2_vm(vadd64_vm_vm_vm(dd0.e, vcast_vm_i_i(0, 16383))), 1)), r.e);
+  o = vneq_vo_vd_vd(dd0.dd.x, vcast_vd_d(0));
+  r.dd.x = vreinterpret_vd_vm(vand_vm_vo64_vm(o, vreinterpret_vm_vd(r.dd.x)));
+  r.dd.y = vreinterpret_vd_vm(vand_vm_vo64_vm(o, vreinterpret_vm_vd(r.dd.y)));
+  r.dd.z = vreinterpret_vd_vm(vand_vm_vo64_vm(o, vreinterpret_vm_vd(r.dd.z)));
+  return r;
+}
+
+//
+
+static tdx vcast_tdx_vf128(vmask2 f) {
+  tdx r = { .e = vand_vm_vm_vm(vsrl64_vm_vm_i(f.y, 48), vcast_vm_i_i(0, 0x7fff)) };
+
+  vmask signbit = vand_vm_vm_vm(f.y, vcast_vm_i_i(0x80000000, 0)), mx, my, mz;
+  vopmask iszero = viszeroq_vo_vm2(f);
+
+  mx = vand_vm_vm_vm(vsrl128_vm2_vm2_i(f, 60).x, vcast_vm_i_i(0xfffff, 0xffffffff));
+  my = vand_vm_vm_vm(vsrl64_vm_vm_i(f.x, 8), vcast_vm_i_i(0xfffff, 0xffffffff));
+  mz = vand_vm_vm_vm(vsll64_vm_vm_i(f.x, 44), vcast_vm_i_i(0xfffff, 0xffffffff));
+
+  mx = vor_vm_vm_vm(mx, vcast_vm_i_i(0x3ff00000, 0));
+  my = vor_vm_vm_vm(my, vcast_vm_i_i(0x3cb00000, 0));
+  mz = vor_vm_vm_vm(mz, vcast_vm_i_i(0x39700000, 0));
+
+  mx = vandnot_vm_vo64_vm(iszero, mx);
+  my = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(my), vcast_vd_d(1.0 / (1ULL << 52))));
+  mz = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(mz), vcast_vd_d(1.0 / ((1ULL << 52) * (double)(1ULL << 52)))));
+
+  r.dd.x = vreinterpret_vd_vm(vor_vm_vm_vm(mx, signbit));
+  r.dd.y = vreinterpret_vd_vm(vor_vm_vm_vm(my, signbit));
+  r.dd.z = vreinterpret_vd_vm(vor_vm_vm_vm(mz, signbit));
+
+  vopmask fisdenorm = veq64_vo_vm_vm(r.e, vcast_vm_i_i(0, 0));
+
+  if (UNLIKELY(!vtestallzeros_i_vo64(vor_vo_vo_vo(veq64_vo_vm_vm(r.e, vcast_vm_i_i(0, 0x7fff)),
+						  vandnot_vo_vo_vo(iszero, fisdenorm))))) {
+    vopmask fisinf = vand_vo_vo_vo(veq64_vo_vm_vm(vand_vm_vm_vm(f.y, vcast_vm_i_i(0x7fffffff, 0xffffffff)),
+						  vcast_vm_i_i(0x7fff0000, 0)),
+				   veq64_vo_vm_vm(f.x, vcast_vm_i_i(0, 0)));
+    vopmask fisnan = vandnot_vo_vo_vo(fisinf, veq64_vo_vm_vm(r.e, vcast_vm_i_i(0, 0x7fff)));
+
+    tdx g = r;
+    g.dd.x = vsub_vd_vd_vd(g.dd.x, vmulsign_vd_vd_vd(vcast_vd_d(1), g.dd.x));
+    g.dd = tdnormalize_vd3_vd3(g.dd);
+    g.e = vilogb2k_vm_vd(g.dd.x);
+    g.dd = tdscale_vd3_vd3_vd(g.dd, vldexp3_vd_vd_vm(vcast_vd_d(1), vneg64_vm_vm(g.e)));
+    g.e = vadd64_vm_vm_vm(g.e, vcast_vm_i_i(0, 1));
+    r = vsel_tdx_vo64_tdx_tdx(fisdenorm, g, r);
+
+    vdouble t = vreinterpret_vd_vm(vor_vm_vm_vm(signbit, vreinterpret_vm_vd(vcast_vd_d(SLEEF_INFINITY))));
+    r.dd.x = vsel_vd_vo_vd_vd(fisnan, vcast_vd_d(SLEEF_INFINITY - SLEEF_INFINITY), vsel_vd_vo_vd_vd(fisinf, t, r.dd.x));
+  }
+
+  return r;
+}
+
+static INLINE CONST tdx vcast_tdx_vf128_fast(vmask2 f) {
+  tdx r = { .e = vand_vm_vm_vm(vsrl64_vm_vm_i(f.y, 48), vcast_vm_i_i(0, 0x7fff)) };
+
+  vmask signbit = vand_vm_vm_vm(f.y, vcast_vm_i_i(0x80000000, 0)), mx, my, mz;
+  vopmask iszero = viszeroq_vo_vm2(f);
+
+  mx = vand_vm_vm_vm(vsrl128_vm2_vm2_i(f, 60).x, vcast_vm_i_i(0xfffff, 0xffffffff));
+  my = vand_vm_vm_vm(vsrl64_vm_vm_i(f.x, 8), vcast_vm_i_i(0xfffff, 0xffffffff));
+  mz = vand_vm_vm_vm(vsll64_vm_vm_i(f.x, 44), vcast_vm_i_i(0xfffff, 0xffffffff));
+
+  mx = vor_vm_vm_vm(mx, vcast_vm_i_i(0x3ff00000, 0));
+  my = vor_vm_vm_vm(my, vcast_vm_i_i(0x3cb00000, 0));
+  mz = vor_vm_vm_vm(mz, vcast_vm_i_i(0x39700000, 0));
+
+  mx = vandnot_vm_vo64_vm(iszero, mx);
+  my = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(my), vcast_vd_d(1.0 / (1ULL << 52))));
+  mz = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(mz), vcast_vd_d(1.0 / ((1ULL << 52) * (double)(1ULL << 52)))));
+
+  r.dd.x = vreinterpret_vd_vm(vor_vm_vm_vm(mx, signbit));
+  r.dd.y = vreinterpret_vd_vm(vor_vm_vm_vm(my, signbit));
+  r.dd.z = vreinterpret_vd_vm(vor_vm_vm_vm(mz, signbit));
+
+  return r;
+}
+
+#define HBX 1.0
+#define LOGXSCALE 1
+#define XSCALE (1 << LOGXSCALE)
+#define SX 61
+#define HBY (1.0 / (1ULL << 53))
+#define LOGYSCALE 4
+#define YSCALE (1 << LOGYSCALE)
+#define SY 11
+#define HBZ (1.0 / ((1ULL << 53) * (double)(1ULL << 53)))
+#define LOGZSCALE 10
+#define ZSCALE (1 << LOGZSCALE)
+#define SZ 36
+#define HBR (1.0 / (1ULL << 60))
+
+static vmask2 vcast_vf128_tdx_slowpath(tdx f) {
+  vmask signbit = vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.x), vcast_vm_i_i(0x80000000, 0));
+  vopmask iszero = veq_vo_vd_vd(f.dd.x, vcast_vd_d(0.0));
+
+  f.dd.x = vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(f.dd.x), signbit));
+  f.dd.y = vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(f.dd.y), signbit));
+  f.dd.z = vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(f.dd.z), signbit));
+
+  vopmask denorm = vgt64_vo_vm_vm(vcast_vm_i_i(0, 1), f.e);
+  vdouble t = vldexp3_vd_vd_vm(vcast_vd_d(0.5), f.e);
+  t = vreinterpret_vd_vm(vandnot_vm_vo64_vm(vgt64_vo_vm_vm(vcast_vm_i_i(-1, -120), f.e), vreinterpret_vm_vd(t)));
+  t = vsel_vd_vo_vd_vd(denorm, t, vcast_vd_d(1));
+  f.e = vsel_vm_vo64_vm_vm(denorm, vcast_vm_i_i(0, 1), f.e);
+
+  vopmask o = vlt_vo_vd_vd(f.dd.y, vcast_vd_d(-1.0/(1ULL << 57)/(1ULL << 57)));
+  o = vand_vo_vo_vo(o, veq_vo_vd_vd(f.dd.x, vcast_vd_d(1)));
+  o = vandnot_vo_vo_vo(veq64_vo_vm_vm(f.e, vcast_vm_i_i(0, 1)), o);
+  t = vsel_vd_vo_vd_vd(o, vcast_vd_d(2), t);
+  f.e = vsub64_vm_vm_vm(f.e, vsel_vm_vo64_vm_vm(o, vcast_vm_i_i(0, 2), vcast_vm_i_i(0, 1)));
+
+  f.dd.x = vmul_vd_vd_vd(f.dd.x, t);
+  f.dd.y = vmul_vd_vd_vd(f.dd.y, t);
+  f.dd.z = vmul_vd_vd_vd(f.dd.z, t);
+
+  t = vadd_vd_vd_vd(f.dd.y, vcast_vd_d(HBY * (1 << LOGYSCALE)));
+  t = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(t), vcast_vm_i_i(0xffffffff, 0xffffffff << LOGYSCALE)));
+  f.dd.z = vadd_vd_vd_vd(f.dd.z, vsub_vd_vd_vd(f.dd.y, vsub_vd_vd_vd(t, vcast_vd_d(HBZ * (1 << LOGZSCALE) + HBY * (1 << LOGYSCALE)))));
+  f.dd.y = t;
+
+  vdouble c = vsel_vd_vo_vd_vd(denorm, vcast_vd_d(HBX * XSCALE + HBX), vcast_vd_d(HBX * XSCALE));
+  vdouble d = vadd_vd_vd_vd(f.dd.x, c);
+  d = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(d), vcast_vm_i_i(0xffffffff, 0xffffffff << LOGXSCALE)));
+  t = vadd_vd_vd_vd(f.dd.y, vsub_vd_vd_vd(f.dd.x, vsub_vd_vd_vd(d, c)));
+  f.dd.z = vadd_vd_vd_vd(f.dd.z, vadd_vd_vd_vd(vsub_vd_vd_vd(f.dd.y, t), vsub_vd_vd_vd(f.dd.x, vsub_vd_vd_vd(d, c))));
+  f.dd.x = d;
+
+  d = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(t), vcast_vm_i_i(0xffffffff, 0xffffffff << LOGYSCALE)));
+  f.dd.z = vadd_vd_vd_vd(f.dd.z, vsub_vd_vd_vd(t, d));
+  f.dd.y = d;
+
+  t = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(f.dd.z, vcast_vd_d(HBZ * ZSCALE)),
+		       vcast_vd_d(HBZ * (ZSCALE/2)), vcast_vd_d(0));
+  f.dd.y = vsub_vd_vd_vd(f.dd.y, t);
+  f.dd.z = vadd_vd_vd_vd(f.dd.z, t);
+
+  t = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(f.dd.y, vcast_vd_d(HBY * YSCALE)),
+		       vcast_vd_d(HBY * (YSCALE/2)), vcast_vd_d(0));
+  f.dd.x = vsub_vd_vd_vd(f.dd.x, t);
+  f.dd.y = vadd_vd_vd_vd(f.dd.y, t);
+
+  f.dd.z = vadd_vd_vd_vd(f.dd.z, vcast_vd_d(HBR));
+  f.dd.z = vsub_vd_vd_vd(f.dd.z, vcast_vd_d(HBR));
+
+  //
+
+  vmask m = vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.x), vcast_vm_i_i(0xfffff, 0xffffffff));
+  vmask2 r = { .y = vsrl64_vm_vm_i(vreinterpret_vm_vd(f.dd.x), 64-SX), .x = vsll64_vm_vm_i(m, SX) };
+
+  f.dd.z = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.z), vcast_vm_i_i(0xfffff, 0xffffffff)));
+  r.x = vor_vm_vm_vm(r.x, vsrl64_vm_vm_i(vreinterpret_vm_vd(f.dd.z), SZ));
+
+  f.dd.y = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.y), vcast_vm_i_i(0xfffff, 0xffffffff)));
+  vmask2 s = { .y = vsrl64_vm_vm_i(vreinterpret_vm_vd(f.dd.y), 64-SY), .x = vsll64_vm_vm_i(vreinterpret_vm_vd(f.dd.y), SY) };
+  r = vadd128_vm2_vm2_vm2(r, s);
+
+  r.y = vand_vm_vm_vm(r.y, vsel_vm_vo64_vm_vm(denorm, vcast_vm_i_i(0xffff, 0xffffffff), vcast_vm_i_i(0x3ffff, 0xffffffff)));
+  m = vsll64_vm_vm_i(vand_vm_vm_vm(f.e, vcast_vm_i_i(0xffffffff, ~(~0UL << 15))), 48);
+  r.y = vcast_vm_vi2(vadd_vi2_vi2_vi2(vcast_vi2_vm(r.y), vcast_vi2_vm(m)));
+
+  r.y = vandnot_vm_vo64_vm(iszero, r.y);
+  r.x = vandnot_vm_vo64_vm(iszero, r.x);
+
+  o = vor_vo_vo_vo(vgt64_vo_vm_vm(f.e, vcast_vm_i_i(0, 32765)), veq_vo_vd_vd(f.dd.x, vcast_vd_d(SLEEF_INFINITY)));
+  r.y = vsel_vm_vo64_vm_vm(o, vcast_vm_i_i(0x7fff0000, 0), r.y);
+  r.x = vandnot_vm_vo64_vm(o, r.x);
+
+  o = vandnot_vo_vo_vo(veq_vo_vd_vd(f.dd.x, vcast_vd_d(SLEEF_INFINITY)), visnonnumber(f.dd.x));
+  r.y = vor_vm_vo64_vm(o, r.y);
+  r.x = vor_vm_vo64_vm(o, r.x);
+
+  r.y = vor_vm_vm_vm(r.y, signbit);
+
+  return r;
+}
+
+static vmask2 vcast_vf128_tdx(tdx f) {
+  vopmask o = vor_vo_vo_vo(vgt64_vo_vm_vm(vcast_vm_i_i(0, 2), f.e), vgt64_vo_vm_vm(f.e, vcast_vm_i_i(0, 0x7ffd)));
+  o = vor_vo_vo_vo(o, visnonnumber(f.dd.x));
+  o = vandnot_vo_vo_vo(veq_vo_vd_vd(vcast_vd_d(0), f.dd.x), o);
+  if (UNLIKELY(!vtestallzeros_i_vo64(o))) return vcast_vf128_tdx_slowpath(f);
+
+  vmask signbit = vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.x), vcast_vm_i_i(0x80000000, 0));
+  vopmask iszero = veq_vo_vd_vd(f.dd.x, vcast_vd_d(0.0));
+
+  f.dd.x = vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(f.dd.x), signbit));
+  f.dd.y = vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(f.dd.y), signbit));
+  f.dd.z = vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(f.dd.z), signbit));
+
+  o = vand_vo_vo_vo(veq_vo_vd_vd(f.dd.x, vcast_vd_d(1.0)), vlt_vo_vd_vd(f.dd.y, vcast_vd_d(0.0)));
+  vint2 i2 = vcast_vi2_vm(vand_vm_vo64_vm(o, vcast_vm_vi2(vcast_vi2_vm(vcast_vm_i_i(1 << 20, 0)))));
+  f.dd.x = vreinterpret_vd_vi2(vadd_vi2_vi2_vi2(vreinterpret_vi2_vd(f.dd.x), i2));
+  f.dd.y = vreinterpret_vd_vi2(vadd_vi2_vi2_vi2(vreinterpret_vi2_vd(f.dd.y), i2));
+  f.dd.z = vreinterpret_vd_vi2(vadd_vi2_vi2_vi2(vreinterpret_vi2_vd(f.dd.z), i2));
+  f.e = vsub64_vm_vm_vm(f.e, vsel_vm_vo64_vm_vm(o, vcast_vm_i_i(0, 2), vcast_vm_i_i(0, 1)));
+  
+  vdouble t = vadd_vd_vd_vd(f.dd.y, vcast_vd_d(HBY * (1 << LOGYSCALE)));
+  t = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(t), vcast_vm_i_i(0xffffffff, 0xffffffff << LOGYSCALE)));
+  f.dd.z = vadd_vd_vd_vd(f.dd.z, vsub_vd_vd_vd(f.dd.y, vsub_vd_vd_vd(t, vcast_vd_d(HBZ * (1 << LOGZSCALE) + HBY * (1 << LOGYSCALE)))));
+  f.dd.y = t;
+
+  t = vadd_vd_vd_vd(f.dd.x, vcast_vd_d(HBX * (1 << LOGXSCALE)));
+  t = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(t), vcast_vm_i_i(0xffffffff, 0xffffffff << LOGXSCALE)));
+  f.dd.y = vadd_vd_vd_vd(f.dd.y, vsub_vd_vd_vd(f.dd.x, vsub_vd_vd_vd(t, vcast_vd_d(HBX * (1 << LOGXSCALE)))));
+  f.dd.x = t;
+
+  f.dd.z = vadd_vd_vd_vd(f.dd.z, vcast_vd_d(HBZ * ((1 << LOGZSCALE)/2) + HBR));
+  f.dd.z = vsub_vd_vd_vd(f.dd.z, vcast_vd_d(HBR));
+  f.dd.y = vadd_vd_vd_vd(f.dd.y, vcast_vd_d(HBY * ((1 << LOGYSCALE)/2) - HBZ * ((1 << LOGZSCALE)/2)));
+  f.dd.x = vsub_vd_vd_vd(f.dd.x, vcast_vd_d(HBY * ((1 << LOGYSCALE)/2)));
+
+  //
+
+  f.dd.x = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.x), vcast_vm_i_i(0xfffff, 0xffffffff)));
+  vmask2 r = { .y = vsrl64_vm_vm_i(vreinterpret_vm_vd(f.dd.x), 64-SX), .x = vsll64_vm_vm_i(vreinterpret_vm_vd(f.dd.x), SX) };
+
+  f.dd.z = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.z), vcast_vm_i_i(0xfffff, 0xffffffff)));
+  r.x = vor_vm_vm_vm(r.x, vsrl64_vm_vm_i(vreinterpret_vm_vd(f.dd.z), SZ));
+
+  f.dd.y = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.y), vcast_vm_i_i(0xfffff, 0xffffffff)));
+  vmask2 s = { .y = vsrl64_vm_vm_i(vreinterpret_vm_vd(f.dd.y), 64-SY), .x = vsll64_vm_vm_i(vreinterpret_vm_vd(f.dd.y), SY) };
+  r = vadd128_vm2_vm2_vm2(r, s);
+
+  r.y = vand_vm_vm_vm(r.y, vcast_vm_i_i(0x3ffff, 0xffffffff));
+  f.e = vsll64_vm_vm_i(vand_vm_vm_vm(f.e, vcast_vm_i_i(0xffffffff, ~(~0UL << 15))), 48);
+  r.y = vcast_vm_vi2(vadd_vi2_vi2_vi2(vcast_vi2_vm(r.y), vcast_vi2_vm(f.e)));
+
+  r.y = vandnot_vm_vo64_vm(iszero, r.y);
+  r.x = vandnot_vm_vo64_vm(iszero, r.x);
+
+  r.y = vor_vm_vm_vm(r.y, signbit);
+
+  return r;
+}
+
+static INLINE CONST vmask2 vcast_vf128_tdx_fast(tdx f) {
+  vmask signbit = vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.x), vcast_vm_i_i(0x80000000, 0));
+  vopmask iszero = veq_vo_vd_vd(f.dd.x, vcast_vd_d(0.0));
+
+  f.dd.x = vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(f.dd.x), signbit));
+  f.dd.y = vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(f.dd.y), signbit));
+  f.dd.z = vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(f.dd.z), signbit));
+
+  vopmask o = vand_vo_vo_vo(veq_vo_vd_vd(f.dd.x, vcast_vd_d(1.0)), vlt_vo_vd_vd(f.dd.y, vcast_vd_d(0.0)));
+  vint2 i2 = vcast_vi2_vm(vand_vm_vo64_vm(o, vcast_vm_vi2(vcast_vi2_vm(vcast_vm_i_i(1 << 20, 0)))));
+  f.dd.x = vreinterpret_vd_vi2(vadd_vi2_vi2_vi2(vreinterpret_vi2_vd(f.dd.x), i2));
+  f.dd.y = vreinterpret_vd_vi2(vadd_vi2_vi2_vi2(vreinterpret_vi2_vd(f.dd.y), i2));
+  f.dd.z = vreinterpret_vd_vi2(vadd_vi2_vi2_vi2(vreinterpret_vi2_vd(f.dd.z), i2));
+  f.e = vsub64_vm_vm_vm(f.e, vsel_vm_vo64_vm_vm(o, vcast_vm_i_i(0, 2), vcast_vm_i_i(0, 1)));
+  
+  vdouble t = vadd_vd_vd_vd(f.dd.y, vcast_vd_d(HBY * (1 << LOGYSCALE)));
+  t = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(t), vcast_vm_i_i(0xffffffff, 0xffffffff << LOGYSCALE)));
+  f.dd.z = vadd_vd_vd_vd(f.dd.z, vsub_vd_vd_vd(f.dd.y, vsub_vd_vd_vd(t, vcast_vd_d(HBZ * (1 << LOGZSCALE) + HBY * (1 << LOGYSCALE)))));
+  f.dd.y = t;
+
+  t = vadd_vd_vd_vd(f.dd.x, vcast_vd_d(HBX * (1 << LOGXSCALE)));
+  t = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(t), vcast_vm_i_i(0xffffffff, 0xffffffff << LOGXSCALE)));
+  f.dd.y = vadd_vd_vd_vd(f.dd.y, vsub_vd_vd_vd(f.dd.x, vsub_vd_vd_vd(t, vcast_vd_d(HBX * (1 << LOGXSCALE)))));
+  f.dd.x = t;
+
+  f.dd.z = vadd_vd_vd_vd(f.dd.z, vcast_vd_d(HBZ * ((1 << LOGZSCALE)/2) + HBR));
+  f.dd.z = vsub_vd_vd_vd(f.dd.z, vcast_vd_d(HBR));
+  f.dd.y = vadd_vd_vd_vd(f.dd.y, vcast_vd_d(HBY * ((1 << LOGYSCALE)/2) - HBZ * ((1 << LOGZSCALE)/2)));
+  f.dd.x = vsub_vd_vd_vd(f.dd.x, vcast_vd_d(HBY * ((1 << LOGYSCALE)/2)));
+
+  //
+
+  f.dd.x = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.x), vcast_vm_i_i(0xfffff, 0xffffffff)));
+  vmask2 r = { .y = vsrl64_vm_vm_i(vreinterpret_vm_vd(f.dd.x), 64-SX), .x = vsll64_vm_vm_i(vreinterpret_vm_vd(f.dd.x), SX) };
+
+  f.dd.z = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.z), vcast_vm_i_i(0xfffff, 0xffffffff)));
+  r.x = vor_vm_vm_vm(r.x, vsrl64_vm_vm_i(vreinterpret_vm_vd(f.dd.z), SZ));
+
+  f.dd.y = vreinterpret_vd_vm(vand_vm_vm_vm(vreinterpret_vm_vd(f.dd.y), vcast_vm_i_i(0xfffff, 0xffffffff)));
+  vmask2 s = { .y = vsrl64_vm_vm_i(vreinterpret_vm_vd(f.dd.y), 64-SY), .x = vsll64_vm_vm_i(vreinterpret_vm_vd(f.dd.y), SY) };
+  r = vadd128_vm2_vm2_vm2(r, s);
+
+  r.y = vand_vm_vm_vm(r.y, vcast_vm_i_i(0x3ffff, 0xffffffff));
+  f.e = vsll64_vm_vm_i(vand_vm_vm_vm(f.e, vcast_vm_i_i(0xffffffff, ~(~0UL << 15))), 48);
+  r.y = vcast_vm_vi2(vadd_vi2_vi2_vi2(vcast_vi2_vm(r.y), vcast_vi2_vm(f.e)));
+
+  r.y = vandnot_vm_vo64_vm(iszero, r.y);
+  r.x = vandnot_vm_vo64_vm(iszero, r.x);
+
+  r.y = vor_vm_vm_vm(r.y, signbit);
+
+  return r;
+}
+
+//
+
+EXPORT CONST vargquad xaddq_u05(vargquad aa, vargquad ab) {
+  vmask2 a = vcast_vm2_aq(aa);
+  vmask2 b = vcast_vm2_aq(ab);
+
+  vmask ea = vand_vm_vm_vm(vsrl64_vm_vm_i(a.y, 48), vcast_vm_i_i(0, 0x7fff));
+  vmask eb = vand_vm_vm_vm(vsrl64_vm_vm_i(b.y, 48), vcast_vm_i_i(0, 0x7fff));
+
+  vopmask oa = vor_vo_vo_vo(viszeroq_vo_vm2(a), 
+			    vand_vo_vo_vo(vgt64_vo_vm_vm(ea, vcast_vm_i_i(0, 120)),
+					  vgt64_vo_vm_vm(vcast_vm_i_i(0, 0x7ffe), ea)));
+  vopmask ob = vor_vo_vo_vo(viszeroq_vo_vm2(b), 
+			    vand_vo_vo_vo(vgt64_vo_vm_vm(eb, vcast_vm_i_i(0, 120)),
+					  vgt64_vo_vm_vm(vcast_vm_i_i(0, 0x7ffe), eb)));
+
+  if (LIKELY(vtestallones_i_vo64(vand_vo_vo_vo(oa, ob)))) {
+    vmask2 r = vcast_vf128_tdx_fast(add2_tdx_tdx_tdx(vcast_tdx_vf128_fast(a), vcast_tdx_vf128_fast(b)));
+    r.y = vor_vm_vm_vm(r.y, vand_vm_vm_vm(vand_vm_vm_vm(a.y, b.y), vcast_vm_i_i(0x80000000, 0)));
+    return vcast_aq_vm2(r);
+  }
+
+  vmask2 r = vcast_vf128_tdx(add2_tdx_tdx_tdx(vcast_tdx_vf128(a), vcast_tdx_vf128(b)));
+
+  r.y = vor_vm_vm_vm(r.y, vand_vm_vm_vm(vand_vm_vm_vm(a.y, b.y), vcast_vm_i_i(0x80000000, 0)));
+
+  if (UNLIKELY(!vtestallzeros_i_vo64(visnonnumberq_vo_vm2_vm2(a, b)))) {
+    vopmask aisinf = visinfq_vo_vm2(a), bisinf = visinfq_vo_vm2(b);
+    vopmask aisnan = visnanq_vo_vm2(a), bisnan = visnanq_vo_vm2(b);
+    vopmask o = veq64_vo_vm_vm(a.y, vxor_vm_vm_vm(b.y, vcast_vm_i_i(0x80000000, 0)));
+    r = vsel_vm2_vo_vm2_vm2(vandnot_vo_vo_vo(o, vandnot_vo_vo_vo(bisnan, aisinf)), a, r);
+    r = vsel_vm2_vo_vm2_vm2(vandnot_vo_vo_vo(o, vandnot_vo_vo_vo(aisnan, bisinf)), b, r);
+  }
+
+  return vcast_aq_vm2(r);
+}
+
+EXPORT CONST vargquad xmulq_u05(vargquad aa, vargquad ab) {
+  vmask2 a = vcast_vm2_aq(aa);
+  vmask2 b = vcast_vm2_aq(ab);
+
+  vmask ea = vand_vm_vm_vm(vsrl64_vm_vm_i(a.y, 48), vcast_vm_i_i(0, 0x7fff));
+  vmask eb = vand_vm_vm_vm(vsrl64_vm_vm_i(b.y, 48), vcast_vm_i_i(0, 0x7fff));
+  vopmask oa = vand_vo_vo_vo(vgt64_vo_vm_vm(ea, vcast_vm_i_i(0, 120)),
+			     vgt64_vo_vm_vm(vcast_vm_i_i(0, 0x7ffe), ea));
+  vopmask ob = vand_vo_vo_vo(vgt64_vo_vm_vm(eb, vcast_vm_i_i(0, 120)),
+			     vgt64_vo_vm_vm(vcast_vm_i_i(0, 0x7ffe), eb));
+  vopmask oc = vand_vo_vo_vo(vgt64_vo_vm_vm(vadd64_vm_vm_vm(ea, eb), vcast_vm_i_i(0, 120+16383)),
+			     vgt64_vo_vm_vm(vcast_vm_i_i(0, 0x7ffe +16383), vadd64_vm_vm_vm(ea, eb)));
+  if (LIKELY(vtestallones_i_vo64(vandnot_vo_vo_vo(visnonnumberq_vo_vm2_vm2(a, b), 
+						  vor_vo_vo_vo(vor_vo_vo_vo(viszeroq_vo_vm2(a), viszeroq_vo_vm2(b)),
+							       vand_vo_vo_vo(vand_vo_vo_vo(oa, ob), oc)))))) {
+    vmask2 r = vcast_vf128_tdx_fast(mul_tdx_tdx_tdx(vcast_tdx_vf128_fast(a), vcast_tdx_vf128_fast(b)));
+    r.y = vor_vm_vm_vm(r.y, vand_vm_vm_vm(vxor_vm_vm_vm(a.y, b.y), vcast_vm_i_i(0x80000000, 0)));
+    return vcast_aq_vm2(r);
+  }
+
+  vmask2 r = vcast_vf128_tdx(mul2_tdx_tdx_tdx(vcast_tdx_vf128(a), vcast_tdx_vf128(b)));
+
+  r.y = vor_vm_vm_vm(r.y, vand_vm_vm_vm(vxor_vm_vm_vm(a.y, b.y), vcast_vm_i_i(0x80000000, 0)));
+
+  if (UNLIKELY(!vtestallzeros_i_vo64(visnonnumberq_vo_vm2_vm2(a, b)))) {
+    vopmask aisinf = visinfq_vo_vm2(a), bisinf = visinfq_vo_vm2(b);
+    vopmask aisnan = visnanq_vo_vm2(a), bisnan = visnanq_vo_vm2(b);
+    vopmask aiszero = viszeroq_vo_vm2(a), biszero = viszeroq_vo_vm2(b);
+    vopmask o = vor_vo_vo_vo(aisinf, bisinf);
+    r.y = vsel_vm_vo64_vm_vm(o, vor_vm_vm_vm(vcast_vm_i_i(0x7fff0000, 0),
+					   vand_vm_vm_vm(vxor_vm_vm_vm(a.y, b.y), vcast_vm_i_i(0x80000000, 0))), r.y);
+    r.x = vandnot_vm_vo64_vm(o, r.x);
+
+    o = vor_vo_vo_vo(vand_vo_vo_vo(aiszero, bisinf), vand_vo_vo_vo(biszero, aisinf));
+    o = vor_vo_vo_vo(vor_vo_vo_vo(o, aisnan), bisnan);
+    r.y = vor_vm_vo64_vm(o, r.y);
+    r.x = vor_vm_vo64_vm(o, r.x);
+  }
+
+  return vcast_aq_vm2(r);
+}
+
+EXPORT CONST vargquad xdivq_u05(vargquad aa, vargquad ab) {
+  vmask2 a = vcast_vm2_aq(aa);
+  vmask2 b = vcast_vm2_aq(ab);
+  vmask2 r = vcast_vf128_tdx(div2_tdx_tdx_tdx(vcast_tdx_vf128(a), vcast_tdx_vf128(b)));
+
+  r.y = vor_vm_vm_vm(r.y, vand_vm_vm_vm(vxor_vm_vm_vm(a.y, b.y), vcast_vm_i_i(0x80000000, 0)));
+
+  if (UNLIKELY(!vtestallzeros_i_vo64(visnonnumberq_vo_vm2_vm2_vm2(a, b, r)))) {
+    vopmask aisinf = visinfq_vo_vm2(a), bisinf = visinfq_vo_vm2(b);
+    vopmask aisnan = visnanq_vo_vm2(a), bisnan = visnanq_vo_vm2(b);
+    vopmask aiszero = viszeroq_vo_vm2(a), biszero = viszeroq_vo_vm2(b);
+    vmask signbit = vand_vm_vm_vm(vxor_vm_vm_vm(a.y, b.y), vcast_vm_i_i(0x80000000, 0));
+
+    r.y = vsel_vm_vo64_vm_vm(bisinf, signbit, r.y);
+    r.x = vandnot_vm_vo64_vm(bisinf, r.x);
+
+    vopmask o = vor_vo_vo_vo(aisinf, biszero);
+    vmask m = vor_vm_vm_vm(vcast_vm_i_i(0x7fff0000, 0), signbit);
+    r.y = vsel_vm_vo64_vm_vm(o, m, r.y);
+    r.x = vandnot_vm_vo64_vm(o, r.x);
+
+    o = vand_vo_vo_vo(aiszero, biszero);
+    o = vor_vo_vo_vo(o, vand_vo_vo_vo(aisinf, bisinf));
+    o = vor_vo_vo_vo(o, vor_vo_vo_vo(aisnan, bisnan));
+    r.y = vor_vm_vo64_vm(o, r.y);
+    r.x = vor_vm_vo64_vm(o, r.x);
+  }  
+
+  return vcast_aq_vm2(r);
+}
+
+EXPORT CONST vargquad xsqrtq_u05(vargquad aa) {
+  vmask2 a = vcast_vm2_aq(aa);
+  vmask2 r = vcast_vf128_tdx(sqrt_tdx_tdx(vcast_tdx_vf128(a)));
+
+  r.y = vor_vm_vm_vm(r.y, vand_vm_vm_vm(a.y, vcast_vm_i_i(0x80000000, 0)));
+  vopmask aispinf = vispinfq_vo_vm2(a);
+
+  r.y = vsel_vm_vo64_vm_vm(aispinf, vcast_vm_i_i(0x7fff0000, 0), r.y);
+  r.x = vandnot_vm_vo64_vm(aispinf, r.x);
+
+  return vcast_aq_vm2(r);
+}
+
+//
+
+#ifdef ENABLE_MAIN
+// gcc -DENABLE_MAIN -Wno-attributes -I../libm -I../quad-tester -I../common -I../arch -DUSEMPFR -DENABLE_AVX2 -mavx2 -mfma sleefsimdqp.c ../common/common.c ../quad-tester/qtesterutil.c -lm -lmpfr
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mpfr.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "qtesterutil.h"
+
+int main(int argc, char **argv) {
+  xsrand(time(NULL) + (int)getpid());
+  int lane = xrand() % VECTLENDP;
+  printf("lane = %d\n", lane);
+
+  char s[200];
+  mpfr_set_default_prec(1024);
+  mpfr_t fr0, fr1, fr2;
+  mpfr_inits(fr0, fr1, fr2, NULL);
+
+  mpfr_set_d(fr0, 0, GMP_RNDN);
+  if (argc >= 2) mpfr_set_str(fr0, argv[1], 10, GMP_RNDN);
+  Sleef_quad q0 = mpfr_get_f128(fr0, GMP_RNDN);
+  mpfr_set_f128(fr0, q0, GMP_RNDN);
+  if (argc >= 2) printf("arg0 : %s\n", sprintfr(fr0));
+  vargquad a0;
+  memrand(&a0, sizeof(vargquad));
+  a0.s[lane] = q0;
+
+  mpfr_set_d(fr1, 0, GMP_RNDN);
+  if (argc >= 3) mpfr_set_str(fr1, argv[2], 10, GMP_RNDN);
+  Sleef_quad q1 = mpfr_get_f128(fr1, GMP_RNDN);
+  mpfr_set_f128(fr1, q1, GMP_RNDN);
+  if (argc >= 3) printf("arg1 : %s\n", sprintfr(fr1));
+  vargquad a1;
+  memrand(&a1, sizeof(vargquad));
+  a1.s[lane] = q1;
+
+  //
+
+#if 1
+  vargquad a2 = xaddq_u05(a0, a1);
+  mpfr_add(fr2, fr0, fr1, GMP_RNDN);
+#endif
+
+#if 0
+  vargquad a2 = xmulq_u05(a0, a1);
+  mpfr_mul(fr2, fr0, fr1, GMP_RNDN);
+#endif
+
+#if 0
+  vargquad a2 = xdivq_u05(a0, a1);
+  mpfr_div(fr2, fr0, fr1, GMP_RNDN);
+#endif
+
+#if 0
+  vargquad a2 = xsqrtq_u05(a0);
+  mpfr_sqrt(fr2, fr0, GMP_RNDN);
+#endif
+
+  //
+
+  mpfr_set_f128(fr2, mpfr_get_f128(fr2, GMP_RNDN), GMP_RNDN);
+  printf("corr : %s\n", sprintfr(fr2));
+  Sleef_quad q2 = a2.s[lane];
+  mpfr_set_f128(fr2, q2, GMP_RNDN);
+  printf("test : %s\n", sprintfr(fr2));
+}
+#endif

--- a/travis/before_script.aarch64-gcc.sh
+++ b/travis/before_script.aarch64-gcc.sh
@@ -3,7 +3,7 @@ set -ev
 cd /build
 mkdir build-native
 cd build-native
-cmake ..
+cmake -DBUILD_QUAD=TRUE ..
 make -j 2 all
 cd /build
 mkdir build-cross

--- a/travis/before_script.aarch64-gcc.sh
+++ b/travis/before_script.aarch64-gcc.sh
@@ -8,4 +8,4 @@ make -j 2 all
 cd /build
 mkdir build-cross
 cd build-cross
-cmake -DCMAKE_TOOLCHAIN_FILE=../travis/toolchain-aarch64.cmake -DNATIVE_BUILD_DIR=`pwd`/../build-native -DEMULATOR=qemu-aarch64-static -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+cmake -DCMAKE_TOOLCHAIN_FILE=../travis/toolchain-aarch64.cmake -DNATIVE_BUILD_DIR=`pwd`/../build-native -DEMULATOR=qemu-aarch64-static -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..

--- a/travis/before_script.armhf-gcc.sh
+++ b/travis/before_script.armhf-gcc.sh
@@ -3,7 +3,7 @@ set -ev
 cd /build
 mkdir build-native
 cd build-native
-cmake ..
+cmake -DBUILD_QUAD=TRUE ..
 make -j 2 all
 cd /build
 mkdir build-cross

--- a/travis/before_script.armhf-gcc.sh
+++ b/travis/before_script.armhf-gcc.sh
@@ -8,4 +8,4 @@ make -j 2 all
 cd /build
 mkdir build-cross
 cd build-cross
-cmake -DCMAKE_TOOLCHAIN_FILE=../travis/toolchain-armhf.cmake -DNATIVE_BUILD_DIR=`pwd`/../build-native -DEMULATOR=qemu-arm-static -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+cmake -DCMAKE_TOOLCHAIN_FILE=../travis/toolchain-armhf.cmake -DNATIVE_BUILD_DIR=`pwd`/../build-native -DEMULATOR=qemu-arm-static -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..

--- a/travis/before_script.osx-clang.sh
+++ b/travis/before_script.osx-clang.sh
@@ -2,4 +2,4 @@
 set -ev
 mkdir sleef.build
 cd sleef.build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DENFORCE_TESTER3=TRUE ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..

--- a/travis/before_script.osx-gcc.sh
+++ b/travis/before_script.osx-gcc.sh
@@ -3,4 +3,4 @@ set -ev
 mkdir sleef.build
 cd sleef.build
 export CC=gcc-6
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DENFORCE_TESTER3=TRUE ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..

--- a/travis/before_script.x86_64-clang.sh
+++ b/travis/before_script.x86_64-clang.sh
@@ -4,4 +4,4 @@ mkdir sleef.build
 cd sleef.build
 export CC=clang-5.0
 export CXX=clang++-5.0
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..

--- a/travis/before_script.x86_64-gcc.sh
+++ b/travis/before_script.x86_64-gcc.sh
@@ -4,4 +4,4 @@ mkdir sleef.build
 cd sleef.build
 export CC=gcc-7
 export CXX=g++-7
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..


### PR DESCRIPTION
This is a part of implementation of issue https://github.com/shibatch/sleef/issues/233.
At this point, add, mul, div and sqrt are implemented. Remaining functions will be committed in the succeeding PRs.
As for vector extensions, SSE2, AVX, FMA4, AVX2, AV2_128, AVX512F and AdvSIMD are supported.

This quadprecision math library is built only if -DBUILD_QUAD option is given to cmake. For some time(1 year?), this subproject is positioned at alpha development stage.