### PR TITLE
Change settins for build and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ dist: trusty
 matrix:
   include:
     - os: osx
-      osx_image: xcode8
-      compiler: gcc
-      env:
-        - LABEL="osx-gcc"
-    - os: osx
       compiler: clang # use default apple clang
       env:
         - LABEL="osx-clang"

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -278,8 +278,6 @@ set(CLANG_FLAGS_ENABLE_AVX512FNOFMA "-mavx512f")
 set(CLANG_FLAGS_ENABLE_NEON32 "--target=arm-linux-gnueabihf;-mcpu=cortex-a8")
 set(CLANG_FLAGS_ENABLE_NEON32VFPV4 "-march=armv7-a;-mfpu=neon-vfpv4")
 # Arm AArch64 vector extensions.
-set(CLANG_FLAGS_ENABLE_ADVSIMD "-march=armv8-a+simd")
-set(CLANG_FLAGS_ENABLE_ADVSIMDNOFMA "-march=armv8-a+simd")
 set(CLANG_FLAGS_ENABLE_SVE "-march=armv8-a+sve")
 set(CLANG_FLAGS_ENABLE_SVENOFMA "-march=armv8-a+sve")
 # PPC64

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,17 +9,16 @@ pipeline {
             	     steps {
 	    	     	 sh '''
                 	 echo "AArch64 SVE on" `hostname`
-			 export PATH=$PATH:/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/bin
-			 export LD_LIBRARY_PATH=/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/lib:/opt/arm/arm-hpc-compiler-18.1_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib
-			 export CC=/opt/arm/arm-hpc-compiler-18.4_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin/armclang
+			 export PATH=$PATH:/opt/bin
+			 export CC=armclang
 			 rm -rf build
  			 mkdir build
 			 cd build
 			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE ..
-			 make -j 4 all
+			 make -j 6 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
-		         ctest -j 4
+		         ctest -j 6
 		         make install
 			 '''
             	     }
@@ -30,17 +29,16 @@ pipeline {
             	     steps {
 	    	     	 sh '''
                 	 echo "AArch64 SVE on" `hostname`
-			 export PATH=$PATH:/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/bin
-			 export LD_LIBRARY_PATH=/opt/arm/arm-instruction-emulator-1.2.1_Generic-AArch64_Ubuntu-14.04_aarch64-linux/lib:/opt/arm/arm-hpc-compiler-18.1_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib
-			 export CC=/opt/arm/arm-hpc-compiler-18.4_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin/armclang
+			 export PATH=$PATH:/opt/bin
+			 export CC=armclang
 			 rm -rf build
  			 mkdir build
 			 cd build
 			 cmake -DCMAKE_INSTALL_PREFIX=../install -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DFORCE_AAVPCS=On -DENABLE_GNUABI=On ..
-			 make -j 4 all
+			 make -j 6 all
 			 export OMP_WAIT_POLICY=passive
 		         export CTEST_OUTPUT_ON_FAILURE=TRUE
-		         ctest -j 4
+		         ctest -j 6
 		         make install
 			 '''
             	     }
@@ -114,6 +112,7 @@ pipeline {
 	    	     	 sh '''
                 	 echo "On" `hostname`
 			 export PATH=$PATH:/opt/local/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
+		         export CC=gcc-7
 			 rm -rf build
  			 mkdir build
 			 cd build

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -237,7 +237,7 @@ foreach(SIMD ${SLEEF_SUPPORTED_EXTENSIONS})
 	)
     else()
       add_custom_command(
-	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/alias${SIMD}.h ${CMAKE_CURRENT_BINARY_DIR}/include/alias_${SIMDLC}.h
+	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/alias_${SIMDLC}.h
        	COMMENT "Generating alias_${SIMDLC}.h"
        	COMMAND $<TARGET_FILE:${TARGET_MKALIAS}> ${ALIAS_PARAMS_${SIMD}_SP} >  ${CMAKE_CURRENT_BINARY_DIR}/include/alias_${SIMDLC}.h
        	COMMAND $<TARGET_FILE:${TARGET_MKALIAS}> ${ALIAS_PARAMS_${SIMD}_DP} >> ${CMAKE_CURRENT_BINARY_DIR}/include/alias_${SIMDLC}.h


### PR DESCRIPTION
This patch includes fix for issue https://github.com/shibatch/sleef/issues/232 and PR https://github.com/shibatch/sleef/pull/231.

It also includes changes of CI setting for removing GCC/OSX testing on travis. This is because updating gcc with brew takes too much time now. Instead of this, build with gcc is now tested on Jenkins.

