### PR TITLE
[Quad] Add functions for conversion between quad and string

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
 			 '''
             	     }
                 }
-
+/*
                 stage('Intel Compiler') {
                     agent { label 'icc' }
                     steps {
@@ -64,7 +64,7 @@ pipeline {
 		        '''
                     }
                 }
-
+*/
                 stage('FMA4') {
             	     agent { label 'fma4' }
             	     steps {

--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -215,9 +215,11 @@ static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) { return _mm256_min_pd
 #if CONFIG == 1
 static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vadd_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
 static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vsub_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
+static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vsub_vd_vd_vd(z, vmul_vd_vd_vd(x, y)); }
 #else
 static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm256_macc_pd(x, y, z); }
 static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm256_msub_pd(x, y, z); }
+static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm256_nmacc_pd(x, y, z); }
 static INLINE vdouble vfma_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm256_macc_pd(x, y, z); }
 static INLINE vdouble vfmapp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm256_macc_pd(x, y, z); }
 static INLINE vdouble vfmapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return _mm256_msub_pd(x, y, z); }

--- a/src/arch/helperpower_128.h
+++ b/src/arch/helperpower_128.h
@@ -211,6 +211,7 @@ static INLINE vdouble vsqrt_vd_vd(vdouble d) { return vec_sqrt(d); }
 #if CONFIG == 1
 static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_madd(x, y, z); }
 static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_msub(x, y, z); }
+static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_nmsub(x, y, z); }
 #else
 static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vadd_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
 static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vsub_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }

--- a/src/arch/helperpurec_scalar.h
+++ b/src/arch/helperpurec_scalar.h
@@ -205,6 +205,7 @@ static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) { return x < y ? x : y
 #ifndef ENABLE_FMA_DP
 static INLINE vdouble vmla_vd_vd_vd_vd  (vdouble x, vdouble y, vdouble z) { return x * y + z; }
 static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return x * y - z; }
+static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return -x * y + z; }
 #else
 static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(x, y, z); }
 static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return FMA(x, y, -z); }

--- a/src/arch/helpersse2.h
+++ b/src/arch/helpersse2.h
@@ -191,6 +191,7 @@ static INLINE vdouble vabs_vd_vd(vdouble d) { return _mm_andnot_pd(_mm_set1_pd(-
 static INLINE vdouble vneg_vd_vd(vdouble d) { return _mm_xor_pd(_mm_set1_pd(-0.0), d); }
 static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vadd_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
 static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vsub_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
+static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vsub_vd_vd_vd(z, vmul_vd_vd_vd(x, y)); }
 static INLINE vdouble vmax_vd_vd_vd(vdouble x, vdouble y) { return _mm_max_pd(x, y); }
 static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) { return _mm_min_pd(x, y); }
 

--- a/src/arch/helpersve.h
+++ b/src/arch/helpersve.h
@@ -547,7 +547,7 @@ static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y,
                                          vdouble z) { // z = x * y - z
   return svnmsb_f64_x(ptrue, x, y, z);
 }
-static INLINE vfloat vmlanp_vd_vd_vd_vd(vfloat x, vfloat y, vfloat z) {
+static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) {
   return svnmsb_f64_x(ptrue, x, y, z);
 }
 #else

--- a/src/arch/helpersve.h
+++ b/src/arch/helpersve.h
@@ -547,6 +547,9 @@ static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y,
                                          vdouble z) { // z = x * y - z
   return svnmsb_f64_x(ptrue, x, y, z);
 }
+static INLINE vfloat vmlanp_vd_vd_vd_vd(vfloat x, vfloat y, vfloat z) {
+  return svnmsb_f64_x(ptrue, x, y, z);
+}
 #else
 static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vadd_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
 static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vsub_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }

--- a/src/arch/helpersve.h
+++ b/src/arch/helpersve.h
@@ -548,7 +548,7 @@ static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y,
   return svnmsb_f64_x(ptrue, x, y, z);
 }
 static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) {
-  return svnmsb_f64_x(ptrue, x, y, z);
+  return svmsb_f64_x(ptrue, x, y, z);
 }
 #else
 static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vadd_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }

--- a/src/quad-tester/qiutsimd.c
+++ b/src/quad-tester/qiutsimd.c
@@ -171,12 +171,45 @@ typedef union {
     }									\
   }
 
+#define func_strtoq(funcStr) {						\
+    while (startsWith(buf, funcStr " ")) {				\
+      sentinel = 0;							\
+      char s[64];							\
+      sscanf(buf, funcStr " %63s", s);					\
+      Sleef_quad1 a0;							\
+      a0 = Sleef_strtoq(s, NULL, 10);					\
+      cnv128 c0;							\
+      c0.q = a0.s[0];							\
+      printf("%" PRIx64 ":%" PRIx64 "\n", c0.h, c0.l);			\
+      fflush(stdout);							\
+      if (fgets(buf, BUFSIZE-1, stdin) == NULL) break;			\
+    }									\
+  }
+
+#define func_qtostr(funcStr) {						\
+    while (startsWith(buf, funcStr " ")) {				\
+      sentinel = 0;							\
+      cnv128 c0;							\
+      sscanf(buf, funcStr " %" PRIx64 ":%" PRIx64, &c0.h, &c0.l);	\
+      Sleef_quad1 a0;							\
+      a0.s[0] = c0.q;							\
+      char s[64];							\
+      Sleef_qtostr(s, 63, a0, 10);					\
+      printf("%s\n", s);						\
+      fflush(stdout);							\
+      if (fgets(buf, BUFSIZE-1, stdin) == NULL) break;			\
+    }									\
+  }
+
 int do_test(int argc, char **argv) {
   xsrand(time(NULL));
 
   {
     int k = 0;
     k += 1;
+#ifdef ENABLE_PUREC_SCALAR
+    k += 2; // Enable string testing
+#endif
     printf("%d\n", k);
     fflush(stdout);
   }
@@ -187,9 +220,13 @@ int do_test(int argc, char **argv) {
 
   while(!feof(stdin) && sentinel < 2) {
     func_q_q_q("addq_u05", xaddq_u05);
+    func_q_q_q("subq_u05", xsubq_u05);
     func_q_q_q("mulq_u05", xmulq_u05);
     func_q_q_q("divq_u05", xdivq_u05);
     func_q_q("sqrtq_u05", xsqrtq_u05);
+    func_q_q("negq", xnegq);
+    func_strtoq("strtoq");
+    func_qtostr("qtostr");
     sentinel++;
   }
 

--- a/src/quad-tester/tester2simdqp.c
+++ b/src/quad-tester/tester2simdqp.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
 #include <mpfr.h>
 #include <time.h>
 #include <float.h>
@@ -287,6 +288,21 @@ int main(int argc,char **argv)
     {
       mpfr_set_f128(frx, q0, GMP_RNDN);
       mpfr_set_f128(fry, q1, GMP_RNDN);
+      mpfr_sub(frz, frx, fry, GMP_RNDN);
+
+      double u0 = countULPf128(t = vget(xsubq_u05(a0, a1), e), frz, 0);
+      
+      if (u0 > 0.5000000001) {
+	printf(ISANAME " sub arg=%s %s ulp=%.20g\n", sprintf128(q0), sprintf128(q1), u0);
+	printf("test = %s\n", sprintf128(t));
+	printf("corr = %s\n\n", sprintf128(mpfr_get_f128(frz, GMP_RNDN)));
+	fflush(stdout); ecnt++;
+      }
+    }
+
+    {
+      mpfr_set_f128(frx, q0, GMP_RNDN);
+      mpfr_set_f128(fry, q1, GMP_RNDN);
       mpfr_mul(frz, frx, fry, GMP_RNDN);
 
       double u0 = countULPf128(t = vget(xmulq_u05(a0, a1), e), frz, 0);
@@ -327,5 +343,17 @@ int main(int argc,char **argv)
 	fflush(stdout); ecnt++;
       }
     }
+
+#ifdef ENABLE_PUREC_SCALAR
+    if ((cnt & 15) == 1) {
+      char s[64];
+      Sleef_qtostr(s, 63, a0, 10);
+      Sleef_quad q1 = vget(Sleef_strtoq(s, NULL, 10), e);
+      if (memcmp(&q0, &q1, sizeof(Sleef_quad)) != 0 && !(isnanf128(q0) && isnanf128(q1))) {
+	printf("qtostr/strtoq arg=%s\n", sprintf128(q0));
+	fflush(stdout); ecnt++;
+      }
+    }
+#endif
   }
 }

--- a/src/quad/qfuncproto.h
+++ b/src/quad/qfuncproto.h
@@ -22,19 +22,21 @@ typedef struct {
   funcType:
   0 : vargquad func(vargquad);
   1 : vargquad func(vargquad, vargquad);
-  2 : vargquad2 func(vargquad);   GNUABI : void func(vargquad, double *, double *);
+  2 : vargquad2 func(vargquad);
   3 : vargquad func(vargquad, vint);
   4 : vint func(vargquad);
   5 : vargquad func(vargquad, vargquad, vargquad);
-  6 : vargquad2 func(vargquad);   GNUABI : vargquad func(vargquad, double *);
+  6 : vargquad2 func(vargquad);
   7 : int func(int);
   8 : void *func(int);
  */
 
 funcSpec funcList[] = {
   { "add", 5, 2, 1, 0 },
+  { "sub", 5, 2, 1, 0 },
   { "mul", 5, 2, 1, 0 },
   { "div", 5, 2, 1, 0 },
+  { "neg", -1, 0, 0, 0 },
   { "sqrt", 5, 2, 0, 0 },
   //{ "sincos", 10, 1, 2, 0 },
   //{ "ldexp", -1, 0, 3, 0 },

--- a/src/quad/sleefquad_header.h.org
+++ b/src/quad/sleefquad_header.h.org
@@ -83,3 +83,7 @@ typedef union {
 
 //
 
+IMPORT Sleef_quad1 Sleef_strtoq(const char *str, char **endptr, int base);
+IMPORT void Sleef_qtostr(char *s, int n, Sleef_quad1 a, int base);
+
+//


### PR DESCRIPTION
This patch adds Sleef_strtoq and Sleef_qtostr which can be used to convert between a quad value and a string. These functions are not vectorized. The corresponding testers are also added.

This patch also adds functions for subtraction.

Intel compiler testing is temporarily disabled because of license expiration.