### PR TITLE
Add (no-op) VECTOR_CC to sse/avx dispatch

### DIFF
--- a/src/libm/dispavx.c.org
+++ b/src/libm/dispavx.c.org
@@ -66,76 +66,76 @@ static int cpuSupportsFMA4() {
 #endif
 
 #define DISPATCH_vf_vf(fptype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static CONST fptype (*pfn)(fptype arg0);				\
-  static CONST fptype dfn(fptype arg0) {				\
-    fptype CONST (*p)(fptype arg0) = funcavx;				\
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0);			\
+  static CONST VECTOR_CC fptype dfn(fptype arg0) {			\
+    fptype CONST VECTOR_CC (*p)(fptype arg0) = funcavx;		\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static CONST fptype (*pfn)(fptype arg0) = dfn;			\
-  EXPORT CONST fptype funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0) = dfn;		\
+  EXPORT CONST VECTOR_CC fptype funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_vf_vf_vf(fptype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static CONST fptype (*pfn)(fptype arg0, fptype arg1);			\
-  static CONST fptype dfn(fptype arg0, fptype arg1) {			\
-    fptype CONST (*p)(fptype arg0, fptype arg1) = funcavx;		\
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, fptype arg1);	\
+  static CONST VECTOR_CC fptype dfn(fptype arg0, fptype arg1) {	\
+    fptype CONST VECTOR_CC (*p)(fptype arg0, fptype arg1) = funcavx;	\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1);						\
   }									\
-  static CONST fptype (*pfn)(fptype arg0, fptype arg1) = dfn;		\
-  EXPORT CONST fptype funcName(fptype arg0, fptype arg1) { return (*pfn)(arg0, arg1); }
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, fptype arg1) = dfn;	\
+  EXPORT CONST VECTOR_CC fptype funcName(fptype arg0, fptype arg1) { return (*pfn)(arg0, arg1); }
 
 #define DISPATCH_vf2_vf(fptype, fptype2, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static CONST fptype2 (*pfn)(fptype arg0);				\
-  static CONST fptype2 dfn(fptype arg0) {				\
-    fptype2 CONST (*p)(fptype arg0) = funcavx;				\
+  static CONST VECTOR_CC fptype2 (*pfn)(fptype arg0);			\
+  static CONST VECTOR_CC fptype2 dfn(fptype arg0) {			\
+    fptype2 CONST VECTOR_CC (*p)(fptype arg0) = funcavx;		\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static CONST fptype2 (*pfn)(fptype arg0) = dfn;			\
-  EXPORT CONST fptype2 funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST VECTOR_CC fptype2 (*pfn)(fptype arg0) = dfn;		\
+  EXPORT CONST VECTOR_CC fptype2 funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_vf_vf_vi(fptype, itype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static CONST fptype (*pfn)(fptype arg0, itype arg1);			\
-  static CONST fptype dfn(fptype arg0, itype arg1) {			\
-    fptype CONST (*p)(fptype arg0, itype arg1) = funcavx;		\
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, itype arg1);	\
+  static CONST VECTOR_CC fptype dfn(fptype arg0, itype arg1) {		\
+    fptype CONST VECTOR_CC (*p)(fptype arg0, itype arg1) = funcavx;	\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1);						\
   }									\
-  static CONST fptype (*pfn)(fptype arg0, itype arg1) = dfn;		\
-  EXPORT CONST fptype funcName(fptype arg0, itype arg1) { return (*pfn)(arg0, arg1); }
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, itype arg1) = dfn;	\
+  EXPORT CONST VECTOR_CC fptype funcName(fptype arg0, itype arg1) { return (*pfn)(arg0, arg1); }
 
 #define DISPATCH_vi_vf(fptype, itype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static CONST itype (*pfn)(fptype arg0);				\
-  static CONST itype dfn(fptype arg0) {					\
-    itype CONST (*p)(fptype arg0) = funcavx;				\
+  static CONST VECTOR_CC itype (*pfn)(fptype arg0);			\
+  static CONST VECTOR_CC itype dfn(fptype arg0) {			\
+    itype CONST VECTOR_CC (*p)(fptype arg0) = funcavx;			\
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static CONST itype (*pfn)(fptype arg0) = dfn;				\
-  EXPORT CONST itype funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST VECTOR_CC itype (*pfn)(fptype arg0) = dfn;		\
+  EXPORT CONST VECTOR_CC itype funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_vf_vf_vf_vf(fptype, funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
-  static CONST fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2);	\
-  static CONST fptype dfn(fptype arg0, fptype arg1, fptype arg2) {	\
-    fptype CONST (*p)(fptype arg0, fptype arg1, fptype arg2) = funcavx;	\
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2); \
+  static CONST VECTOR_CC fptype dfn(fptype arg0, fptype arg1, fptype arg2) { \
+    fptype CONST VECTOR_CC (*p)(fptype arg0, fptype arg1, fptype arg2) = funcavx; \
     SUBST_IF_FMA4(funcfma4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1, arg2);					\
   }									\
-  static CONST fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2) = dfn; \
-  EXPORT CONST fptype funcName(fptype arg0, fptype arg1, fptype arg2) { return (*pfn)(arg0, arg1, arg2); }
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2) = dfn; \
+  EXPORT CONST VECTOR_CC fptype funcName(fptype arg0, fptype arg1, fptype arg2) { return (*pfn)(arg0, arg1, arg2); }
 
 #define DISPATCH_i_i(funcName, pfn, dfn, funcavx, funcfma4, funcavx2) \
   static CONST int (*pfn)(int arg0);					\

--- a/src/libm/dispsse.c.org
+++ b/src/libm/dispsse.c.org
@@ -79,76 +79,76 @@ static int cpuSupportsFMA() {
  */
 
 #define DISPATCH_vf_vf(fptype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static CONST fptype (*pfn)(fptype arg0);				\
-  static CONST fptype dfn(fptype arg0) {				\
-    fptype CONST (*p)(fptype arg0) = funcsse2;				\
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0);			\
+  static CONST VECTOR_CC fptype dfn(fptype arg0) {			\
+    fptype CONST VECTOR_CC (*p)(fptype arg0) = funcsse2;		\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static CONST fptype (*pfn)(fptype arg0) = dfn;			\
-  EXPORT CONST fptype funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0) = dfn;		\
+  EXPORT CONST VECTOR_CC fptype funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_vf_vf_vf(fptype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static CONST fptype (*pfn)(fptype arg0, fptype arg1);			\
-  static CONST fptype dfn(fptype arg0, fptype arg1) {			\
-    fptype CONST (*p)(fptype arg0, fptype arg1) = funcsse2;		\
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, fptype arg1);	\
+  static CONST VECTOR_CC fptype dfn(fptype arg0, fptype arg1) {	\
+    fptype CONST VECTOR_CC (*p)(fptype arg0, fptype arg1) = funcsse2;	\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1);						\
   }									\
-  static CONST fptype (*pfn)(fptype arg0, fptype arg1) = dfn;		\
-  EXPORT CONST fptype funcName(fptype arg0, fptype arg1) { return (*pfn)(arg0, arg1); }
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, fptype arg1) = dfn; \
+  EXPORT CONST VECTOR_CC fptype funcName(fptype arg0, fptype arg1) { return (*pfn)(arg0, arg1); }
 
 #define DISPATCH_vf2_vf(fptype, fptype2, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static CONST fptype2 (*pfn)(fptype arg0);				\
-  static CONST fptype2 dfn(fptype arg0) {				\
-    fptype2 CONST (*p)(fptype arg0) = funcsse2;				\
+  static CONST VECTOR_CC fptype2 (*pfn)(fptype arg0);			\
+  static CONST VECTOR_CC fptype2 dfn(fptype arg0) {			\
+    fptype2 CONST VECTOR_CC (*p)(fptype arg0) = funcsse2;		\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static CONST fptype2 (*pfn)(fptype arg0) = dfn;			\
-  EXPORT CONST fptype2 funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST VECTOR_CC fptype2 (*pfn)(fptype arg0) = dfn;		\
+  EXPORT CONST VECTOR_CC fptype2 funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_vf_vf_vi(fptype, itype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static CONST fptype (*pfn)(fptype arg0, itype arg1);			\
-  static CONST fptype dfn(fptype arg0, itype arg1) {			\
-    fptype CONST (*p)(fptype arg0, itype arg1) = funcsse2;		\
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, itype arg1);	\
+  static CONST VECTOR_CC fptype dfn(fptype arg0, itype arg1) {		\
+    fptype CONST VECTOR_CC (*p)(fptype arg0, itype arg1) = funcsse2;	\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1);						\
   }									\
-  static CONST fptype (*pfn)(fptype arg0, itype arg1) = dfn;		\
-  EXPORT CONST fptype funcName(fptype arg0, itype arg1) { return (*pfn)(arg0, arg1); }
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, itype arg1) = dfn;	\
+  EXPORT CONST VECTOR_CC fptype funcName(fptype arg0, itype arg1) { return (*pfn)(arg0, arg1); }
 
 #define DISPATCH_vi_vf(fptype, itype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static CONST itype (*pfn)(fptype arg0);				\
-  static CONST itype dfn(fptype arg0) {					\
-    itype CONST (*p)(fptype arg0) = funcsse2;				\
+  static CONST VECTOR_CC itype (*pfn)(fptype arg0);			\
+  static CONST VECTOR_CC itype dfn(fptype arg0) {			\
+    itype CONST VECTOR_CC (*p)(fptype arg0) = funcsse2;		\
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0);						\
   }									\
-  static CONST itype (*pfn)(fptype arg0) = dfn;				\
-  EXPORT CONST itype funcName(fptype arg0) { return (*pfn)(arg0); }
+  static CONST VECTOR_CC itype (*pfn)(fptype arg0) = dfn;		\
+  EXPORT CONST VECTOR_CC itype funcName(fptype arg0) { return (*pfn)(arg0); }
 
 #define DISPATCH_vf_vf_vf_vf(fptype, funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
-  static CONST fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2);	\
-  static CONST fptype dfn(fptype arg0, fptype arg1, fptype arg2) {	\
-    fptype CONST (*p)(fptype arg0, fptype arg1, fptype arg2) = funcsse2; \
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2); \
+  static CONST VECTOR_CC fptype dfn(fptype arg0, fptype arg1, fptype arg2) { \
+    fptype CONST VECTOR_CC (*p)(fptype arg0, fptype arg1, fptype arg2) = funcsse2; \
     SUBST_IF_SSE4(funcsse4);						\
     SUBST_IF_AVX2(funcavx2);						\
     pfn = p;								\
     return (*pfn)(arg0, arg1, arg2);					\
   }									\
-  static CONST fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2) = dfn; \
-  EXPORT CONST fptype funcName(fptype arg0, fptype arg1, fptype arg2) { return (*pfn)(arg0, arg1, arg2); }
+  static CONST VECTOR_CC fptype (*pfn)(fptype arg0, fptype arg1, fptype arg2) = dfn; \
+  EXPORT CONST VECTOR_CC fptype funcName(fptype arg0, fptype arg1, fptype arg2) { return (*pfn)(arg0, arg1, arg2); }
 
 #define DISPATCH_i_i(funcName, pfn, dfn, funcsse2, funcsse4, funcavx2) \
   static CONST int (*pfn)(int arg0);					\


### PR DESCRIPTION
Currently a no-op but this makes it easier to support vector call attribute on x86,
which might be necessary on windows.

This is not a bug fix but it should also be harmless. This is likely the last part of the change I had to compile with clang+vectorcall ABI that is mergable. The [rest of the changes](https://github.com/shibatch/sleef/commit/5ccf30a25cbb98c91a2637ad4a12254b76021434) are fairly small (in line number) and much dirtier so it will certainly require cleanup and may or may not be wanted due to GCC compatibility... (since the two ABI uses different symbols, however, it might be possible to ship a binary with both version with the same function names....)
