### PR TITLE
Add basic config install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,18 @@ project(SLEEF
 	VERSION ${SLEEF_VERSION}
 	LANGUAGES C)
 
+###############
+### Install ###
+###############
+set(PN sleef)
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(config_install_dir "lib/cmake/${PN}")
+set(include_install_dir "include")
+set(version_config "${generated_dir}/${PN}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PN}Config.cmake")
+set(targets_export_name "${PN}Targets")
+set(namespace "${PN}::")
+
 # Sanity check for in-source builds which we do not want to happen
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(FATAL_ERROR "SLEEF does not allow in-source builds.
@@ -153,3 +165,28 @@ if (MSVC)
   message("")
   message("*** Note: Parallel build is not supported on Microsoft Visual Studio")
 endif()
+
+## install
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Note: use 'targets_export_name'
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/Config.cmake.in"
+  "${project_config}"
+  INSTALL_DESTINATION "${config_install_dir}"
+)
+
+install(
+  FILES "${project_config}" "${version_config}"
+  DESTINATION "${config_install_dir}"
+)
+
+install(
+  EXPORT "${targets_export_name}"
+  NAMESPACE "${namespace}"
+  DESTINATION "${config_install_dir}"
+)

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+if (NOT @DISABLE_OPENMP@)
+    find_package(OpenMP REQUIRED)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PN@")

--- a/src/dft/CMakeLists.txt
+++ b/src/dft/CMakeLists.txt
@@ -352,4 +352,10 @@ set_target_properties(${TARGET_LIBDFT} PROPERTIES
 # Install
 
 install(FILES ${PROJECT_SOURCE_DIR}/include/sleefdft.h DESTINATION include)
-install(TARGETS ${TARGET_LIBDFT} DESTINATION lib)
+install(TARGETS ${TARGET_LIBDFT}
+        EXPORT "${targets_export_name}"
+        LIBRARY DESTINATION "lib"
+        ARCHIVE DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+        INCLUDES DESTINATION "${include_install_dir}"
+)

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -441,8 +441,20 @@ endif()
 # --------------------------------------------------------------------
 # Install libsleef and sleef.h
 install(FILES ${SLEEF_INCLUDE_HEADER} DESTINATION include)
-install(TARGETS ${TARGET_LIBSLEEF} DESTINATION lib)
+install(TARGETS ${TARGET_LIBSLEEF}
+        EXPORT "${targets_export_name}"
+        LIBRARY DESTINATION "lib"
+        ARCHIVE DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+        INCLUDES DESTINATION "${include_install_dir}"
+)
 
 if(ENABLE_GNUABI)
-  install(TARGETS ${TARGET_LIBSLEEFGNUABI} DESTINATION lib)
+  install(TARGETS ${TARGET_LIBSLEEFGNUABI}
+        EXPORT "${targets_export_name}"
+        LIBRARY DESTINATION "lib"
+        ARCHIVE DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+        INCLUDES DESTINATION "${include_install_dir}"
+)
 endif()


### PR DESCRIPTION
Will allow you to find with find_package(sleef) and use with target_link_libraries(${TARGET_NAME} sleef::sleef).

Only basic right now as I am unfamilar with the project and not sure if there are any special cmake defines that need to be passed through.