### PR TITLE
Export defines PUBLIC so that headers work properly

### DIFF
--- a/src/dft/CMakeLists.txt
+++ b/src/dft/CMakeLists.txt
@@ -351,5 +351,9 @@ set_target_properties(${TARGET_LIBDFT} PROPERTIES
 
 # Install
 
+target_compile_definitions(${TARGET_LIBDFT}
+    PUBLIC ${COMMON_TARGET_DEFINITIONS}
+)
+
 install(FILES ${PROJECT_SOURCE_DIR}/include/sleefdft.h DESTINATION include)
 install(TARGETS ${TARGET_LIBDFT} DESTINATION lib)

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -184,14 +184,14 @@ set_target_properties(${TARGET_LIBSLEEF} PROPERTIES
 )
 
 target_compile_definitions(${TARGET_LIBSLEEF}
-  PRIVATE DORENAME=1 ${COMMON_TARGET_DEFINITIONS}
+  PRIVATE DORENAME=1 PUBLIC ${COMMON_TARGET_DEFINITIONS}
 )
 
 if(COMPILER_SUPPORTS_FLOAT128)
   # TODO: Not supported for LLVM bitcode gen as it has a specific compilation flags
   target_sources(${TARGET_LIBSLEEF} PRIVATE sleefqp.c)
   target_compile_definitions(${TARGET_LIBSLEEF}
-    PRIVATE ENABLEFLOAT128=1 ${COMMON_TARGET_DEFINITIONS})
+    PUBLIC ENABLEFLOAT128=1)
 endif()
 
 if(COMPILER_SUPPORTS_BUILTIN_MATH)


### PR DESCRIPTION
COMMON_TARGET_DEFINITIONS needs to be PUBLIC on the built libraries so that it is exported to the sleefConfig.cmake.

Otherwise, the sleef.h header does not work properly.
SLEEF_STATIC_LIBS and ENABLEFLOAT128 are two examples that need to be exported. I am unsure if all defines need to be exported but currently the defines are not distinguished in any way.