### PR TITLE
Fix typo in html doc

### DIFF
--- a/doc/html/aarch64.xhtml
+++ b/doc/html/aarch64.xhtml
@@ -390,10 +390,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_cosf_u35"><b class
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_float64x2_t_2</b> <b class="func">Sleef_sincosd2_u10</b>(<b class="type">float64x2_t</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_float64x2_t_2</b> <b class="func">Sleef_sincosd2_u10advsimd</b>(<b class="type">float64x2_t</b> <i class="var">a</i>);<br/>
@@ -423,10 +423,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincos_u10"><b cla
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_float32x4_t_2</b> <b class="func">Sleef_sincosf4_u10</b>(<b class="type">float32x4_t</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_float32x4_t_2</b> <b class="func">Sleef_sincosf4_u10advsimd</b>(<b class="type">float32x4_t</b> <i class="var">a</i>);<br/>
@@ -457,10 +457,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincosf_u10"><b cl
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_float64x2_t_2</b> <b class="func">Sleef_sincosd2_u35</b>(<b class="type">float64x2_t</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_float64x2_t_2</b> <b class="func">Sleef_sincosd2_u35advsimd</b>(<b class="type">float64x2_t</b> <i class="var">a</i>);<br/>
@@ -491,10 +491,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincos_u35"><b cla
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_float32x4_t_2</b> <b class="func">Sleef_sincosf4_u35</b>(<b class="type">float32x4_t</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_float32x4_t_2</b> <b class="func">Sleef_sincosf4_u35advsimd</b>(<b class="type">float32x4_t</b> <i class="var">a</i>);<br/>
@@ -656,10 +656,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_cospif_u05"><b cla
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_float64x2_t_2</b> <b class="func">Sleef_sincospid2_u05</b>(<b class="type">float64x2_t</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_float64x2_t_2</b> <b class="func">Sleef_sincospid2_u05advsimd</b>(<b class="type">float64x2_t</b> <i class="var">a</i>);<br/>
@@ -689,10 +689,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincospi_u05"><b c
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_float32x4_t_2</b> <b class="func">Sleef_sincospif4_u05</b>(<b class="type">float32x4_t</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_float32x4_t_2</b> <b class="func">Sleef_sincospif4_u05advsimd</b>(<b class="type">float32x4_t</b> <i class="var">a</i>);<br/>
@@ -723,10 +723,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincospif_u05"><b 
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_float64x2_t_2</b> <b class="func">Sleef_sincospid2_u35</b>(<b class="type">float64x2_t</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_float64x2_t_2</b> <b class="func">Sleef_sincospid2_u35advsimd</b>(<b class="type">float64x2_t</b> <i class="var">a</i>);<br/>
@@ -757,10 +757,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincospi_u35"><b c
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_float32x4_t_2</b> <b class="func">Sleef_sincospif4_u35</b>(<b class="type">float32x4_t</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_float32x4_t_2</b> <b class="func">Sleef_sincospif4_u35advsimd</b>(<b class="type">float32x4_t</b> <i class="var">a</i>);<br/>

--- a/doc/html/ppc64.xhtml
+++ b/doc/html/ppc64.xhtml
@@ -317,10 +317,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_cosf_u35"><b class
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_vector_double_2</b> <b class="func">Sleef_sincosd2_u10</b>(<b class="type">vector double</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_vector_double_2</b> <b class="func">Sleef_sincosd2_u10vsx</b>(<b class="type">vector double</b> <i class="var">a</i>);<br/>
@@ -345,10 +345,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincos_u10"><b cla
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_vector_float_2</b> <b class="func">Sleef_sincosf4_u10</b>(<b class="type">vector float</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_vector_float_2</b> <b class="func">Sleef_sincosf4_u10vsx</b>(<b class="type">vector float</b> <i class="var">a</i>);<br/>
@@ -374,10 +374,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincosf_u10"><b cl
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_vector_double_2</b> <b class="func">Sleef_sincosd2_u35</b>(<b class="type">vector double</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_vector_double_2</b> <b class="func">Sleef_sincosd2_u35vsx</b>(<b class="type">vector double</b> <i class="var">a</i>);<br/>
@@ -403,10 +403,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincos_u35"><b cla
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_vector_float_2</b> <b class="func">Sleef_sincosf4_u35</b>(<b class="type">vector float</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_vector_float_2</b> <b class="func">Sleef_sincosf4_u35vsx</b>(<b class="type">vector float</b> <i class="var">a</i>);<br/>
@@ -543,10 +543,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_cospif_u05"><b cla
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_vector_double_2</b> <b class="func">Sleef_sincospid2_u05</b>(<b class="type">vector double</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_vector_double_2</b> <b class="func">Sleef_sincospid2_u05vsx</b>(<b class="type">vector double</b> <i class="var">a</i>);<br/>
@@ -571,10 +571,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincospi_u05"><b c
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_vector_float_2</b> <b class="func">Sleef_sincospif4_u05</b>(<b class="type">vector float</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_vector_float_2</b> <b class="func">Sleef_sincospif4_u05vsx</b>(<b class="type">vector float</b> <i class="var">a</i>);<br/>
@@ -600,10 +600,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincospif_u05"><b 
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_vector_double_2</b> <b class="func">Sleef_sincospid2_u35</b>(<b class="type">vector double</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_vector_double_2</b> <b class="func">Sleef_sincospid2_u35vsx</b>(<b class="type">vector double</b> <i class="var">a</i>);<br/>
@@ -629,10 +629,10 @@ This is the vectorized function of <a href="purec.xhtml#Sleef_sincospi_u35"><b c
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef_vector_float_2</b> <b class="func">Sleef_sincospif4_u35</b>(<b class="type">vector float</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef_vector_float_2</b> <b class="func">Sleef_sincospif4_u35vsx</b>(<b class="type">vector float</b> <i class="var">a</i>);<br/>

--- a/doc/html/x86.xhtml
+++ b/doc/html/x86.xhtml
@@ -566,10 +566,10 @@ These are the vectorized functions of <a href="purec.xhtml#Sleef_cosf_u35"><b cl
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincosd1_u10purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincosd1_u10purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef___m128d_2</b> <b class="func">Sleef_sincosd2_u10</b>(<b class="type">__m128d</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef___m128d_2</b> <b class="func">Sleef_sincosd2_u10sse2</b>(<b class="type">__m128d</b> <i class="var">a</i>);<br/>
@@ -610,10 +610,10 @@ These are the vectorized functions of <a href="purec.xhtml#Sleef_sincos_u10"><b 
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincosf1_u10purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincosf1_u10purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef___m128_2</b> <b class="func">Sleef_sincosf4_u10</b>(<b class="type">__m128</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef___m128_2</b> <b class="func">Sleef_sincosf4_u10sse2</b>(<b class="type">__m128</b> <i class="var">a</i>);<br/>
@@ -655,10 +655,10 @@ These are the vectorized functions of <a href="purec.xhtml#Sleef_sincosf_u10"><b
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincosd1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincosd1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef___m128d_2</b> <b class="func">Sleef_sincosd2_u35</b>(<b class="type">__m128d</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef___m128d_2</b> <b class="func">Sleef_sincosd2_u35sse2</b>(<b class="type">__m128d</b> <i class="var">a</i>);<br/>
@@ -700,10 +700,10 @@ These are the vectorized functions of <a href="purec.xhtml#Sleef_sincos_u35"><b 
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincosf1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincosf1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef___m128_2</b> <b class="func">Sleef_sincosf4_u35</b>(<b class="type">__m128</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef___m128_2</b> <b class="func">Sleef_sincosf4_u35sse2</b>(<b class="type">__m128</b> <i class="var">a</i>);<br/>
@@ -920,10 +920,10 @@ These are the vectorized functions of <a href="purec.xhtml#Sleef_cospif_u05"><b 
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincospid1_u05purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincospid1_u05purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef___m128d_2</b> <b class="func">Sleef_sincospid2_u05</b>(<b class="type">__m128d</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef___m128d_2</b> <b class="func">Sleef_sincospid2_u05sse2</b>(<b class="type">__m128d</b> <i class="var">a</i>);<br/>
@@ -964,10 +964,10 @@ These are the vectorized functions of <a href="purec.xhtml#Sleef_sincospi_u05"><
 <p class="synopsis">
 #include &lt;sleef.h&gt;<br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincospif1_u05purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincospif1_u05purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef___m128_2</b> <b class="func">Sleef_sincospif4_u05</b>(<b class="type">__m128</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef___m128_2</b> <b class="func">Sleef_sincospif4_u05sse2</b>(<b class="type">__m128</b> <i class="var">a</i>);<br/>
@@ -1009,10 +1009,10 @@ These are the vectorized functions of <a href="purec.xhtml#Sleef_sincospif_u05">
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_cinz_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_double_2</b> <b class="func">Sleef_finz_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_cinz_sincospid1_u35purec</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_double2</b> <b class="func">Sleef_finz_sincospid1_u35purecfma</b>(<b class="type">double</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef___m128d_2</b> <b class="func">Sleef_sincospid2_u35</b>(<b class="type">__m128d</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef___m128d_2</b> <b class="func">Sleef_sincospid2_u35sse2</b>(<b class="type">__m128d</b> <i class="var">a</i>);<br/>
@@ -1054,10 +1054,10 @@ These are the vectorized functions of <a href="purec.xhtml#Sleef_sincospi_u35"><
 #include &lt;sleef.h&gt;<br/>
 <br/>
 <br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_cinz_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
-<b class="type">Sleef_float_2</b> <b class="func">Sleef_finz_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_cinz_sincospif1_u35purec</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
+<b class="type">Sleef_float2</b> <b class="func">Sleef_finz_sincospif1_u35purecfma</b>(<b class="type">float</b> <i class="var">a</i>);<br/>
 <br/>
 <b class="type">Sleef___m128_2</b> <b class="func">Sleef_sincospif4_u35</b>(<b class="type">__m128</b> <i class="var">a</i>);<br/>
 <b class="type">Sleef___m128_2</b> <b class="func">Sleef_sincospif4_u35sse2</b>(<b class="type">__m128</b> <i class="var">a</i>);<br/>


### PR DESCRIPTION
This fix the following typo
* Sleef_double_2 -> Sleef_double2
* Sleef_float_2 -> Sleef_float2