### PR TITLE
Fix FMA4 detection

### DIFF
--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -63,7 +63,7 @@ static int cpuSupportsAVX() {
 static int cpuSupportsFMA4() {
     int32_t reg[4];
     Sleef_x86CpuID(reg, 0x80000001, 0);
-    return (reg[3] & (1 << 16)) != 0;
+    return (reg[2] & (1 << 16)) != 0;
 }
 
 #if CONFIG == 4 && defined(__AVX__) && defined(__FMA4__)

--- a/src/libm/dispavx.c.org
+++ b/src/libm/dispavx.c.org
@@ -48,7 +48,7 @@ static int cpuSupportsFMA4() {
   if (ret == -1) {
     int32_t reg[4];
     Sleef_x86CpuID(reg, 0x80000001, 0);
-    ret = (reg[3] & (1 << 16)) != 0;
+    ret = (reg[2] & (1 << 16)) != 0;
   }
   return ret;
 }


### PR DESCRIPTION
FMA4 support is in bit 16 of register ECX, not EDX of the "extended
processor info" (0x80000001).

The mapping of registers to reg is:

  reg[0] = eax
  reg[1] = ebx
  reg[2] = ecx <---
  reg[3] = edx

Bit 16 of EDX is PAT (Page Attribute Table) on AMD CPUs, which is widely
supported. Intel CPUs do not set this bit. This causes "Illegal instruction"
errors on AMD CPUs that do not support FMA4.

See https://github.com/pytorch/pytorch/issues/12112
See https://github.com/shibatch/sleef/issues/261

http://developer.amd.com/wordpress/media/2012/10/254811.pdf (Page 20)

Fixes #261