### PR TITLE
Fix compilation under Windows with MinGW

### DIFF
--- a/src/common/arraymap.c
+++ b/src/common/arraymap.c
@@ -28,6 +28,7 @@ static FILE *OPENTMPFILE() { return tmpfile(); }
 static void CLOSETMPFILE(FILE *fp) { fclose(fp); }
 #else
 #include <Windows.h>
+#include <io.h>
 
 static void FLOCK(FILE *fp) { }
 static void FUNLOCK(FILE *fp) { }

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach(SIMD ${SLEEF_HEADER_LIST})
   list(APPEND SLEEF_HEADER_COMMANDS COMMAND $<TARGET_FILE:${TARGET_MKRENAME}> ${HEADER_PARAMS_${SIMD}} >> ${SLEEF_INCLUDE_HEADER})
 endforeach()
 
-if(MSVC)
+if(WIN32)
   string(REPLACE "/" "\\" sleef_footer_input_file "${SLEEF_ORG_FOOTER}")
   list(APPEND SLEEF_HEADER_COMMANDS COMMAND type ${sleef_footer_input_file} >> ${SLEEF_INCLUDE_HEADER})
 else()

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach(SIMD ${SLEEF_HEADER_LIST})
   list(APPEND SLEEF_HEADER_COMMANDS COMMAND $<TARGET_FILE:${TARGET_MKRENAME}> ${HEADER_PARAMS_${SIMD}} >> ${SLEEF_INCLUDE_HEADER})
 endforeach()
 
-if(WIN32)
+if(MSVC OR MINGW AND WIN32)
   string(REPLACE "/" "\\" sleef_footer_input_file "${SLEEF_ORG_FOOTER}")
   list(APPEND SLEEF_HEADER_COMMANDS COMMAND type ${sleef_footer_input_file} >> ${SLEEF_INCLUDE_HEADER})
 else()

--- a/src/quad/CMakeLists.txt
+++ b/src/quad/CMakeLists.txt
@@ -60,7 +60,7 @@ foreach(SIMD ${SLEEFQUAD_SUPPORTED_EXT})
   endif()
 endforeach()
 
-if(MSVC)
+if(WIN32)
   string(REPLACE "/" "\\" sleef_footer_input_file "${SLEEFQUAD_ORG_FOOTER}")
   list(APPEND SLEEF_HEADER_COMMANDS COMMAND type ${sleef_footer_input_file} >> ${SLEEFQUAD_INCLUDE_HEADER})
 else()

--- a/src/quad/CMakeLists.txt
+++ b/src/quad/CMakeLists.txt
@@ -60,7 +60,7 @@ foreach(SIMD ${SLEEFQUAD_SUPPORTED_EXT})
   endif()
 endforeach()
 
-if(WIN32)
+if(MSVC OR MINGW AND WIN32)
   string(REPLACE "/" "\\" sleef_footer_input_file "${SLEEFQUAD_ORG_FOOTER}")
   list(APPEND SLEEF_HEADER_COMMANDS COMMAND type ${sleef_footer_input_file} >> ${SLEEFQUAD_INCLUDE_HEADER})
 else()


### PR DESCRIPTION
The compiler-specific condition for `type` and `cat` is incorrect. Also `<io.h>` is missed for `_get_osfhandle`.