### PR TITLE
Build on OpenBSD

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -35,7 +35,7 @@ EXPORT uint64_t Sleef_currentTimeMicros() {
 #else // #if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
 #include <time.h>
 #include <unistd.h>
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <stdlib.h>
 #else
 #include <malloc.h>


### PR DESCRIPTION
Dear Prof. Shibata, 

First of all thank you for providing this library. I am using it with PyTorch on OpenBSD.

With this simple fix your library builds without errors on OpenBSD and all tests pass except for the ilogb denormal/nonnumber tests where "correct" return INT_MIN for inf arg. This appears to be due to a bug in the OpenBSD amd64 implementation of ilogb as the [documentation](https://man.openbsd.org/ilogb) states that the function should return INT_MAX for inf arg. Tests return INT_MAX.

Best regards,
XG6