### PR TITLE
Removes disabling of OpenMP on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,8 +155,3 @@ if(SLEEF_SHOW_CONFIG)
     message(STATUS "Building SLEEF with AArch64 Vector PCS support")
   endif()
 endif(SLEEF_SHOW_CONFIG)
-
-if (MSVC)
-  message("")
-  message("*** Note: Parallel build is not supported on Microsoft Visual Studio")
-endif()

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -705,10 +705,6 @@ if (${RUNNING_ON_TRAVIS} AND CMAKE_C_COMPILER_ID MATCHES "Clang")
   set(COMPILER_SUPPORTS_FLOAT128 FALSE) # Compilation on unroll_0_vecextqp.c does not finish on Travis
 endif()
 
-if (MSVC)
-  set(COMPILER_SUPPORTS_OPENMP FALSE)   # At this time, OpenMP is not supported on MSVC
-endif()
-
 ##
 
 # Set common definitions


### PR DESCRIPTION
OpenMP is supported (2.0 specification) in MSVC from [2015](https://docs.microsoft.com/en-us/cpp/parallel/openmp/openmp-in-visual-cpp?view=vs-2015).

This therefore removes disabling of OpenMP on MSVC. Code compiles without issues, tested on VS2017, VS2019 in both, 32-bit and 64-bit.