### PR TITLE
PPC64LE: Fix build issue on gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,17 @@ matrix:
       env:
         - LABEL="armhf-gcc"
         - ENABLE_DOCKER="true"
+    - arch: ppc64le
+      dist: bionic
+      env:
+        - LABEL=common
+        - OMP_WAIT_POLICY=passive CTEST_OUTPUT_ON_FAILURE=TRUE
+    - arch: ppc64le
+      compiler: clang
+      dist: bionic
+      env:
+        - LABEL=common
+        - OMP_WAIT_POLICY=passive CTEST_OUTPUT_ON_FAILURE=TRUE
 
 before_install:
      - export PATH=$PATH:/usr/bin

--- a/src/arch/helperpower_128.h
+++ b/src/arch/helperpower_128.h
@@ -6,7 +6,7 @@
 #if CONFIG == 1 || CONFIG == 2
 
 #ifndef __VSX__
-#error Please specify -mvsx.
+#error Please specify -mcpu=power8 or -mcpu=power9
 #endif
 
 #else
@@ -15,11 +15,11 @@
 
 #define ENABLE_DP
 #define LOG2VECTLENDP 1
-#define VECTLENDP (1 << LOG2VECTLENDP)
+#define VECTLENDP 2
 
 #define ENABLE_SP
-#define LOG2VECTLENSP (LOG2VECTLENDP+1)
-#define VECTLENSP (1 << LOG2VECTLENSP)
+#define LOG2VECTLENSP 2
+#define VECTLENSP 4
 
 #if CONFIG == 1
 #define ENABLE_FMA_DP
@@ -31,334 +31,748 @@
 #define FULL_FP_ROUNDING
 
 #include <altivec.h>
+// undef altivec types since CPP and C99 use them as compiler tokens
+// use __vector and __bool instead
+#undef vector
+#undef bool
 
 #include <stdint.h>
 #include "misc.h"
 
-typedef vector unsigned int vmask;
-typedef vector unsigned int vopmask;
-
-typedef vector double vdouble;
-typedef vector int vint;
-
-typedef vector float  vfloat;
-typedef vector int vint2;
-
-//
-
-static INLINE int vavailability_i(int name) { return 3; }
-
 #define ISANAME "VSX"
 #define DFTPRIORITY 25
 
+static INLINE int vavailability_i(int name) { return 3; }
 static INLINE void vprefetch_v_p(const void *ptr) { }
 
-static vint2 vloadu_vi2_p(int32_t *p) { return vec_ld(0, p); }
-static void vstoreu_v_p_vi2(int32_t *p, vint2 v) { vec_st(v, 0, p); }
-static vint vloadu_vi_p(int32_t *p) { return vec_ld(0, p); }
-static void vstoreu_v_p_vi(int32_t *p, vint v) { vec_st(v, 0, p); }
+/**********************************************
+ ** Types
+***********************************************/
+typedef __vector unsigned int vmask;
+// using __bool with typedef may cause ambiguous errors
+#define vopmask __vector __bool int
+typedef __vector signed int vint;
+typedef __vector signed int vint2;
+typedef __vector float  vfloat;
+typedef __vector double vdouble;
 
-static INLINE vdouble vload_vd_p(const double *ptr) { return (vector double)vec_ld(0, (const int *)ptr); }
-static INLINE void vstore_v_p_vd(double *ptr, vdouble v) { vec_st((vector int)v, 0, (int *)ptr); }
-static INLINE vdouble vloadu_vd_p(const double *ptr) { return (vector double) ( ptr[0], ptr[1] ); }
-static INLINE void vstoreu_v_p_vd(double *ptr, vdouble v) { ptr[0] = v[0]; ptr[1] = v[1]; }
+// internal use types
+typedef __vector unsigned int v__u32;
+typedef __vector unsigned char v__u8;
+typedef __vector signed long long  v__i64;
+typedef __vector unsigned long long  v__u64;
+#define v__b64 __vector __bool long long
 
-static INLINE vfloat vload_vf_p(const float *ptr) { return (vector float)vec_ld(0, (const int *)ptr); }
-static INLINE void vstore_v_p_vf(float *ptr, vfloat v) { vec_st((vector int)v, 0, (int *)ptr); }
-static INLINE void vscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat v) {
-  *(ptr+(offset + step * 0)*2 + 0) = v[0];
-  *(ptr+(offset + step * 0)*2 + 1) = v[1];
-  *(ptr+(offset + step * 1)*2 + 0) = v[2];
-  *(ptr+(offset + step * 1)*2 + 1) = v[3];
-}
+/**********************************************
+ ** Utilities
+***********************************************/
+#define vset__vi(v0, v1) ((vint) {v0, v1, v0, v1})
+#define vset__vi2(...) ((vint2) {__VA_ARGS__})
+#define vset__vm(...) ((vmask) {__VA_ARGS__})
+#define vset__vo(...) ((vopmask) {__VA_ARGS__})
+#define vset__vf(...) ((vfloat) {__VA_ARGS__})
+#define vset__vd(...) ((vdouble) {__VA_ARGS__})
+#define vset__u8(...) ((v__u8) {__VA_ARGS__})
+#define vset__u32(...) ((v__u32) {__VA_ARGS__})
+#define vset__s64(...) ((v__i64) {__VA_ARGS__})
+#define vset__u64(...) ((v__u64) {__VA_ARGS__})
 
-static INLINE vfloat vloadu_vf_p(const float *ptr) { return (vfloat) ( ptr[0], ptr[1], ptr[2], ptr[3] ); }
-static INLINE void vstoreu_v_p_vf(float *ptr, vfloat v) { ptr[0] = v[0]; ptr[1] = v[1]; ptr[2] = v[2]; ptr[3] = v[3]; }
+#define vsetall__vi(v)  vset__vi(v, v)
+#define vsetall__vi2(v) vset__vi2(v, v, v, v)
+#define vsetall__vm(v)  vset__vm(v, v, v, v)
+#define vsetall__vo(v)  vset__vo(v, v, v, v)
+#define vsetall__vf(v)  vset__vf(v, v, v, v)
+#define vsetall__vd(v)  vset__vd(v, v)
+#define vsetall__u8(v)  vset__u8(v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v)
+#define vsetall__u32(v) vset__u32(v, v, v, v)
+#define vsetall__s64(v) vset__s64(v, v)
+#define vsetall__u64(v) vset__u64(v, v)
 
-static INLINE void vscatter2_v_p_i_i_vd(double *ptr, int offset, int step, vdouble v) { vstore_v_p_vd((double *)(&ptr[2*offset]), v); }
+#define vzero__vi()  vsetall__vi(0)
+#define vzero__vi2() vsetall__vi2(0)
+#define vzero__vm()  vsetall__vm(0)
+#define vzero__vo()  vsetall__vo(0)
+#define vzero__vf()  vsetall__vf(0)
+#define vzero__vd()  vsetall__vd(0)
+#define vzero__u8()  vsetall__u8(0)
+#define vzero__u32() vsetall__u32(0)
+#define vzero__s64() vsetall__s64(0)
+#define vzero__u64() vsetall__u64(0)
 
-static INLINE vdouble vgather_vd_p_vi(const double *ptr, vint vi) {
-  int a[VECTLENDP];
-  vstoreu_v_p_vi(a, vi);
-  return ((vdouble) { ptr[a[0]], ptr[a[1]] });
-}
-
-static INLINE vfloat vgather_vf_p_vi2(const float *ptr, vint2 vi2) {
-  int a[VECTLENSP];
-  vstoreu_v_p_vi2(a, vi2);
-  return ((vfloat) { ptr[a[0]], ptr[a[1]], ptr[a[2]], ptr[a[3]] });
-}
-
-static INLINE vint vcast_vi_i(int i) { return (vint) { i, i }; }
-static INLINE vint2 vcast_vi2_i(int i) { return (vint2) { i, i, i, i }; }
-static INLINE vfloat vcast_vf_f(float f) { return (vfloat) { f, f, f, f }; }
-static INLINE vdouble vcast_vd_d(double d) { return (vdouble) { d, d }; }
-
-static INLINE vdouble vcast_vd_vi(vint vi) { return vec_doubleh(vi); }
-static INLINE vfloat vcast_vf_vi2(vint2 vi) { return vec_float(vi); }
-static INLINE vint vrint_vi_vd(vdouble vd) {
-  vd = vec_signed(vec_round(vd));
-  return vec_perm(vd, vd, (vector unsigned char)(0, 1, 2, 3, 8, 9, 10, 11, 8, 9, 10, 11, 12, 13, 14, 15));
-}
-static INLINE vint2 vrint_vi2_vf(vfloat vf) { return vec_signed(vec_round(vf)); }
-static INLINE vint vtruncate_vi_vd(vdouble vd) {
-  return vec_perm(vec_signed(vd), vec_signed(vd), (vector unsigned char)(0, 1, 2, 3, 8, 9, 10, 11, 8, 9, 10, 11, 12, 13, 14, 15));
-}
-static INLINE vint2 vtruncate_vi2_vf(vfloat vf) { return vec_signed(vf); }
-static INLINE vdouble vtruncate_vd_vd(vdouble vd) { return vec_trunc(vd); }
-static INLINE vfloat vtruncate_vf_vf(vfloat vf) { return vec_trunc(vf); }
-static INLINE vdouble vrint_vd_vd(vdouble vd) { return vec_round(vd); }
-static INLINE vfloat vrint_vf_vf(vfloat vf) { return vec_round(vf); }
-
-static INLINE vmask vreinterpret_vm_vd(vdouble vd) { return (vmask)vd; }
-static INLINE vdouble vreinterpret_vd_vm(vmask vm) { return (vdouble)vm; }
-static INLINE vint2 vreinterpret_vi2_vd(vdouble vd) { return (vint2)vd; }
-static INLINE vdouble vreinterpret_vd_vi2(vint2 vi) { return (vdouble)vi; }
-
-static INLINE vmask vreinterpret_vm_vf(vfloat vf) { return (vmask)vf; }
-static INLINE vfloat vreinterpret_vf_vm(vmask vm) { return (vfloat)vm; }
-static INLINE vfloat vreinterpret_vf_vi2(vint2 vi) { return (vfloat)vi; }
-static INLINE vint2 vreinterpret_vi2_vf(vfloat vf) { return (vint2)vf; }
-
-static INLINE vdouble vadd_vd_vd_vd(vdouble x, vdouble y) { return vec_add(x, y); }
-static INLINE vdouble vsub_vd_vd_vd(vdouble x, vdouble y) { return vec_sub(x, y); }
-static INLINE vdouble vmul_vd_vd_vd(vdouble x, vdouble y) { return vec_mul(x, y); }
-static INLINE vdouble vdiv_vd_vd_vd(vdouble x, vdouble y) { return vec_div(x, y); }
-static INLINE vdouble vrec_vd_vd(vdouble x) { return vec_div(vcast_vd_d(1.0), x); }
-static INLINE vdouble vneg_vd_vd(vdouble d) { return vec_neg(d); }
-
-static INLINE vfloat vadd_vf_vf_vf(vfloat x, vfloat y) { return vec_add(x, y); }
-static INLINE vfloat vsub_vf_vf_vf(vfloat x, vfloat y) { return vec_sub(x, y); }
-static INLINE vfloat vmul_vf_vf_vf(vfloat x, vfloat y) { return vec_mul(x, y); }
-static INLINE vfloat vdiv_vf_vf_vf(vfloat x, vfloat y) { return vec_div(x, y); }
-static INLINE vfloat vrec_vf_vf(vfloat x) { return vec_div(vcast_vf_f(1.0f), x); }
-static INLINE vfloat vneg_vf_vf(vfloat d) { return vec_neg(d); }
-
-static INLINE vmask vand_vm_vm_vm(vmask x, vmask y) { return vec_and(x, y); }
-static INLINE vmask vandnot_vm_vm_vm(vmask x, vmask y) { return vec_andc(y, x); }
-static INLINE vmask vor_vm_vm_vm(vmask x, vmask y) { return vec_or(x, y); }
-static INLINE vmask vxor_vm_vm_vm(vmask x, vmask y) { return vec_xor(x, y); }
-
-static INLINE vopmask vand_vo_vo_vo(vopmask x, vopmask y) { return vec_and(x, y); }
-static INLINE vopmask vandnot_vo_vo_vo(vopmask x, vopmask y) { return vec_andc(y, x); }
-static INLINE vopmask vor_vo_vo_vo(vopmask x, vopmask y) { return vec_or(x, y); }
-static INLINE vopmask vxor_vo_vo_vo(vopmask x, vopmask y) { return vec_xor(x, y); }
-
-static INLINE vmask vand_vm_vo64_vm(vopmask x, vmask y) { return vec_and((vmask)x, y); }
-static INLINE vmask vandnot_vm_vo64_vm(vopmask x, vmask y) { return vec_andc(y, x); }
-static INLINE vmask vor_vm_vo64_vm(vopmask x, vmask y) { return vec_or((vmask)x, y); }
-static INLINE vmask vxor_vm_vo64_vm(vopmask x, vmask y) { return vec_xor((vmask)x, y); }
-
-static INLINE vmask vand_vm_vo32_vm(vopmask x, vmask y) { return vec_and((vmask)x, y); }
-static INLINE vmask vandnot_vm_vo32_vm(vopmask x, vmask y) { return vec_andc(y, x); }
-static INLINE vmask vor_vm_vo32_vm(vopmask x, vmask y) { return vec_or((vmask)x, y); }
-static INLINE vmask vxor_vm_vo32_vm(vopmask x, vmask y) { return vec_xor((vmask)x, y); }
-
-static INLINE vdouble vsel_vd_vo_vd_vd(vopmask o, vdouble x, vdouble y) { return vec_sel(y, x, (vector unsigned long long)o); }
-static INLINE vfloat vsel_vf_vo_vf_vf(vopmask o, vfloat x, vfloat y) { return vec_sel(y, x, o); }
-static INLINE vint2 vsel_vi2_vo_vi2_vi2(vopmask o, vint2 x, vint2 y) { return vec_sel(y, x, o); }
-
-static INLINE int vtestallones_i_vo64(vopmask g) {
-  return vec_all_ne(vec_and(g, (vector unsigned int)(0, 0, 0xffffffff, 0xffffffff)), (vector unsigned int)(0, 0, 0, 0));
-}
-static INLINE int vtestallones_i_vo32(vopmask g) { return vec_all_ne(g, (vector unsigned int)(0, 0, 0, 0)); }
-
-static INLINE vopmask vcast_vo32_vo64(vopmask m) { return vec_perm(m, m, (vector unsigned char)(4, 5, 6, 7, 12, 13, 14, 15, 8, 9, 10, 11, 12, 13, 14, 15 )); }
-static INLINE vopmask vcast_vo64_vo32(vopmask m) { return vec_perm(m, m, (vector unsigned char)(0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 4, 5, 6, 7)); }
-
-static INLINE vmask vcast_vm_i_i(int h, int l) { return (vmask){ l, h, l, h }; }
-static INLINE vint2 vcastu_vi2_vi(vint vi) { return (vint2){ 0, vi[0], 0, vi[1] }; }
-static INLINE vint vcastu_vi_vi2(vint2 vi2) { return (vint){ vi2[1], vi2[3] }; }
-
-static INLINE vint vreinterpretFirstHalf_vi_vi2(vint2 vi2) { return (vint){ vi2[0], vi2[1] }; }
-static INLINE vint2 vreinterpretFirstHalf_vi2_vi(vint vi) { return (vint2){ vi[0], vi[1], 0, 0 }; }
-
-static INLINE vdouble vrev21_vd_vd(vdouble vd) { return vec_perm(vd, vd, (vector unsigned char)(8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7)); }
-static INLINE vdouble vreva2_vd_vd(vdouble vd) { return vd; }
-static INLINE vfloat vrev21_vf_vf(vfloat vf) { return vec_perm(vf, vf, (vector unsigned char)(4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11)); }
-static INLINE vfloat vreva2_vf_vf(vfloat vf) { return vec_perm(vf, vf, (vector unsigned char)(8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7)); }
-static INLINE vint2 vrev21_vi2_vi2(vint2 i) { return vreinterpret_vi2_vf(vrev21_vf_vf(vreinterpret_vf_vi2(i))); }
-
-static INLINE vopmask veq64_vo_vm_vm(vmask x, vmask y) {
-  vopmask o = vec_cmpeq(x, y);
-  return o & vec_perm(o, o, (vector unsigned char)(4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11));
-}
-
-static INLINE vmask vadd64_vm_vm_vm(vmask x, vmask y) {
-  return (vmask)vec_add((vector long long)x, (vector long long)y);
-}
-
-//
-
-#define PNMASK ((vdouble) { +0.0, -0.0 })
-#define NPMASK ((vdouble) { -0.0, +0.0 })
-#define PNMASKf ((vfloat) { +0.0f, -0.0f, +0.0f, -0.0f })
-#define NPMASKf ((vfloat) { -0.0f, +0.0f, -0.0f, +0.0f })
-
-static INLINE vdouble vposneg_vd_vd(vdouble d) { return vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(d), vreinterpret_vm_vd(PNMASK))); }
-static INLINE vdouble vnegpos_vd_vd(vdouble d) { return vreinterpret_vd_vm(vxor_vm_vm_vm(vreinterpret_vm_vd(d), vreinterpret_vm_vd(NPMASK))); }
-static INLINE vfloat vposneg_vf_vf(vfloat d) { return vreinterpret_vf_vm(vxor_vm_vm_vm(vreinterpret_vm_vf(d), vreinterpret_vm_vf(PNMASKf))); }
-static INLINE vfloat vnegpos_vf_vf(vfloat d) { return vreinterpret_vf_vm(vxor_vm_vm_vm(vreinterpret_vm_vf(d), vreinterpret_vm_vf(NPMASKf))); }
-
-//
-
-static INLINE vdouble vabs_vd_vd(vdouble d) { return vec_abs(d); }
-static INLINE vdouble vmax_vd_vd_vd(vdouble x, vdouble y) { return vec_max(x, y); }
-static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y) { return vec_min(x, y); }
-static INLINE vdouble vsubadd_vd_vd_vd(vdouble x, vdouble y) { return vadd_vd_vd_vd(x, vnegpos_vd_vd(y)); }
-static INLINE vdouble vsqrt_vd_vd(vdouble d) { return vec_sqrt(d); }
-
-#if CONFIG == 1
-static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_madd(x, y, z); }
-static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_msub(x, y, z); }
-static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_nmsub(x, y, z); }
+//// Swap doubleword elements
+#ifdef __clang__
+  static INLINE v__u64 v__swapd_u64(v__u64 v)
+  { return vec_xxpermdi(v, v, 2); }
 #else
-static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vadd_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
-static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vsub_vd_vd_vd(vmul_vd_vd_vd(x, y), z); }
+  static INLINE v__u64 v__swapd_u64(v__u64 v)
+  {
+    __asm__ __volatile__("xxswapd %x0,%x1" : "=wa" (v) : "wa" (v));
+    return v;
+  }
 #endif
 
-static INLINE vdouble vmlsubadd_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vmla_vd_vd_vd_vd(x, y, vnegpos_vd_vd(z)); }
-static INLINE vdouble vfma_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_madd(x, y, z); }
-static INLINE vdouble vfmapp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_madd(x, y, z); }
-static INLINE vdouble vfmapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_msub(x, y, z); }
-static INLINE vdouble vfmanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_nmsub(x, y, z); }
-static INLINE vdouble vfmann_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z) { return vec_nmadd(x, y, z); }
+/**********************************************
+ ** Memory
+***********************************************/
 
-static INLINE vfloat vabs_vf_vf(vfloat f) { return vec_abs(f); }
-static INLINE vfloat vmax_vf_vf_vf(vfloat x, vfloat y) { return vec_max(x, y); }
-static INLINE vfloat vmin_vf_vf_vf(vfloat x, vfloat y) { return vec_min(x, y); }
-static INLINE vfloat vsubadd_vf_vf_vf(vfloat x, vfloat y) { return vadd_vf_vf_vf(x, vnegpos_vf_vf(y)); }
-static INLINE vfloat vsqrt_vf_vf(vfloat d) { return vec_sqrt(d); }
-
-#if CONFIG == 1
-static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_madd(x, y, z); }
-static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_nmsub(x, y, z); }
-static INLINE vfloat vmlapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_msub(x, y, z); }
+////////////// Unaligned memory access //////////////
+/**
+ * It's not safe to use vector assignment via (cast & dereference) for unaligned memory access
+ * with almost all clang versions and gcc8 when VSX3 isn't enabled,
+ * these compilers tends to generate instructions 'lvx/stvx' instead of 'lxvd2x/lxvw4x/stxvd2x/stxvw4x'
+ * for more information check https://github.com/seiko2plus/vsx_mem_test
+ *
+ * TODO: check GCC(9, 10)
+*/
+//// load
+#if defined(__POWER9_VECTOR__) || (!defined(__clang__) && defined(__GNUC__) && __GNUC__ < 8)
+static vint vloadu_vi_p(const int32_t *ptr)
+{ return *((vint*)ptr); }
+static INLINE vint2 vloadu_vi2_p(const int32_t *ptr)
+{ return *((vint2*)ptr); }
+static INLINE vfloat vloadu_vf_p(const float *ptr)
+{ return *((vfloat*)ptr); }
+static INLINE vdouble vloadu_vd_p(const double *ptr)
+{ return *((vdouble*)ptr); }
 #else
-static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vadd_vf_vf_vf(vmul_vf_vf_vf(x, y), z); }
-static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vsub_vf_vf_vf(z, vmul_vf_vf_vf(x, y)); }
-static INLINE vfloat vmlapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vsub_vf_vf_vf(vmul_vf_vf_vf(x, y), z); }
+static vint vloadu_vi_p(const int32_t *ptr)
+{ return vec_vsx_ld(0, ptr); }
+static INLINE vint2 vloadu_vi2_p(const int32_t *ptr)
+{ return vec_vsx_ld(0, ptr); }
+static INLINE vfloat vloadu_vf_p(const float *ptr)
+{ return vec_vsx_ld(0, ptr); }
+static INLINE vdouble vloadu_vd_p(const double *ptr)
+{ return vec_vsx_ld(0, ptr); }
 #endif
 
-static INLINE vfloat vmlsubadd_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vmla_vf_vf_vf_vf(x, y, vnegpos_vf_vf(z)); }
-static INLINE vfloat vfma_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_madd(x, y, z); }
-static INLINE vfloat vfmapp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_madd(x, y, z); }
-static INLINE vfloat vfmapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_msub(x, y, z); }
-static INLINE vfloat vfmanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_nmsub(x, y, z); }
-static INLINE vfloat vfmann_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z) { return vec_nmadd(x, y, z); }
+//// store
+#if defined(__POWER9_VECTOR__) || (!defined(__clang__) && defined(__GNUC__) && __GNUC__ < 8)
+static void vstoreu_v_p_vi(int32_t *ptr, vint v)
+{ *((vint*)ptr) = v; }
+static void vstoreu_v_p_vi2(int32_t *ptr, vint2 v)
+{ *((vint2*)ptr) = v; }
+static INLINE void vstoreu_v_p_vf(float *ptr, vfloat v)
+{ *((vfloat*)ptr) = v; }
+static INLINE void vstoreu_v_p_vd(double *ptr, vdouble v)
+{ *((vdouble*)ptr) = v; }
+#else
+static void vstoreu_v_p_vi(int32_t *ptr, vint v)
+{ vec_vsx_st(v, 0, ptr); }
+static void vstoreu_v_p_vi2(int32_t *ptr, vint2 v)
+{ vec_vsx_st(v, 0, ptr); }
+static INLINE void vstoreu_v_p_vf(float *ptr, vfloat v)
+{ vec_vsx_st(v, 0, ptr); }
+static INLINE void vstoreu_v_p_vd(double *ptr, vdouble v)
+{ vec_vsx_st(v, 0, ptr); }
+#endif
 
-//
+////////////// aligned memory access //////////////
+//// load
+static INLINE vfloat vload_vf_p(const float *ptr)
+{ return vec_ld(0, ptr); }
+static INLINE vdouble vload_vd_p(const double *ptr)
+{ return *((vdouble*)ptr); }
 
-static INLINE CONST vdouble vsel_vd_vo_d_d(vopmask o, double v1, double v0) {
-  return vsel_vd_vo_vd_vd(o, vcast_vd_d(v1), vcast_vd_d(v0));
+//// store
+static INLINE void vstore_v_p_vf(float *ptr, vfloat v)
+{ vec_st(v, 0, ptr); }
+static INLINE void vstore_v_p_vd(double *ptr, vdouble v)
+{ *((vdouble*)ptr) = v; }
+
+////////////// non-temporal memory access //////////////
+//// store
+static INLINE void vstream_v_p_vf(float *ptr, vfloat v)
+{ vstore_v_p_vf(ptr, v); }
+static INLINE void vstream_v_p_vd(double *ptr, vdouble v)
+{ vstore_v_p_vd(ptr, v); }
+
+////////////// LUT //////////////
+//// load
+static INLINE vdouble vgather_vd_p_vi(const double *ptr, vint vi)
+{ return vset__vd(ptr[vec_extract(vi, 0)], ptr[vec_extract(vi, 1)]); }
+
+static INLINE vfloat vgather_vf_p_vi2(const float *ptr, vint2 vi2)
+{
+  return vset__vf(
+    ptr[vec_extract(vi2, 0)], ptr[vec_extract(vi2, 1)],
+    ptr[vec_extract(vi2, 2)], ptr[vec_extract(vi2, 3)]
+  );
 }
 
-static INLINE vdouble vsel_vd_vo_vo_d_d_d(vopmask o0, vopmask o1, double d0, double d1, double d2) {
-  return vsel_vd_vo_vd_vd(o0, vcast_vd_d(d0), vsel_vd_vo_d_d(o1, d1, d2));
+//// store
+static INLINE void vscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat v)
+{
+  const v__u64 vll = (v__u64)v;
+  float *ptr_low = ptr + offset*2;
+  float *ptr_high = ptr + (offset + step)*2;
+  *((uint64_t*)ptr_low) = vec_extract(vll, 0);
+  *((uint64_t*)ptr_high) = vec_extract(vll, 1);
 }
 
-static INLINE vdouble vsel_vd_vo_vo_vo_d_d_d_d(vopmask o0, vopmask o1, vopmask o2, double d0, double d1, double d2, double d3) {
-  return vsel_vd_vo_vd_vd(o0, vcast_vd_d(d0), vsel_vd_vo_vd_vd(o1, vcast_vd_d(d1), vsel_vd_vo_d_d(o2, d2, d3)));
+static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat v)
+{ vscatter2_v_p_i_i_vf(ptr, offset, step, v); }
+
+static INLINE void vscatter2_v_p_i_i_vd(double *ptr, int offset, int step, vdouble v)
+{ vstore_v_p_vd((double *)(&ptr[2*offset]), v); }
+
+static INLINE void vsscatter2_v_p_i_i_vd(double *ptr, int offset, int step, vdouble v)
+{ vscatter2_v_p_i_i_vd(ptr, offset, step, v); }
+
+/**********************************************
+ ** Misc
+ **********************************************/
+
+// vector with a specific value set to all lanes (Vector Splat)
+static INLINE vint vcast_vi_i(int i)
+{ return vsetall__vi(i); }
+static INLINE vint2 vcast_vi2_i(int i)
+{ return vsetall__vi2(i); }
+static INLINE vfloat vcast_vf_f(float f)
+{ return vsetall__vf(f); }
+static INLINE vdouble vcast_vd_d(double d)
+{ return vsetall__vd(d); }
+// cast
+static INLINE vint2 vcast_vi2_vm(vmask vm)
+{ return (vint2)vm; }
+static INLINE vmask vcast_vm_vi2(vint2 vi)
+{ return (vmask)vi; }
+// get the first element
+static INLINE float vcast_f_vf(vfloat v)
+{ return vec_extract(v, 0); }
+static INLINE double vcast_d_vd(vdouble v)
+{ return vec_extract(v, 0); }
+
+static INLINE vmask vreinterpret_vm_vd(vdouble vd)
+{ return (vmask)vd; }
+static INLINE vdouble vreinterpret_vd_vm(vmask vm)
+{ return (vdouble)vm; }
+static INLINE vint2 vreinterpret_vi2_vd(vdouble vd)
+{ return (vint2)vd; }
+static INLINE vdouble vreinterpret_vd_vi2(vint2 vi)
+{ return (vdouble)vi; }
+
+static INLINE vmask vreinterpret_vm_vf(vfloat vf)
+{ return (vmask)vf; }
+static INLINE vfloat vreinterpret_vf_vm(vmask vm)
+{ return (vfloat)vm; }
+static INLINE vfloat vreinterpret_vf_vi2(vint2 vi)
+{ return (vfloat)vi; }
+static INLINE vint2 vreinterpret_vi2_vf(vfloat vf)
+{ return (vint2)vf; }
+
+// per element select via mask (blend)
+static INLINE vdouble vsel_vd_vo_vd_vd(vopmask o, vdouble x, vdouble y)
+{ return vec_sel(y, x, (v__b64)o); }
+static INLINE vfloat vsel_vf_vo_vf_vf(vopmask o, vfloat x, vfloat y)
+{ return vec_sel(y, x, o); }
+
+static INLINE vint vsel_vi_vo_vi_vi(vopmask o, vint x, vint y)
+{ return vec_sel(y, x, o); }
+
+static INLINE vint2 vsel_vi2_vo_vi2_vi2(vopmask o, vint2 x, vint2 y)
+{ return vec_sel(y, x, o); }
+
+static INLINE vfloat vsel_vf_vo_f_f(vopmask o, float v1, float v0)
+{
+  return vsel_vf_vo_vf_vf(o, vsetall__vf(v1), vsetall__vf(v0));
+}
+static INLINE vfloat vsel_vf_vo_vo_f_f_f(vopmask o0, vopmask o1, float d0, float d1, float d2)
+{
+  return vsel_vf_vo_vf_vf(o0, vsetall__vf(d0), vsel_vf_vo_f_f(o1, d1, d2));
+}
+static INLINE vfloat vsel_vf_vo_vo_vo_f_f_f_f(vopmask o0, vopmask o1, vopmask o2, float d0, float d1, float d2, float d3)
+{
+  return vsel_vf_vo_vf_vf(o0, vsetall__vf(d0), vsel_vf_vo_vf_vf(o1, vsetall__vf(d1), vsel_vf_vo_f_f(o2, d2, d3)));
 }
 
-//
-
-static INLINE vopmask vnot_vo_vo(vopmask o) { return vec_nand(o, o); }
-
-static INLINE vopmask veq_vo_vd_vd(vdouble x, vdouble y) { return (vopmask)vec_cmpeq(x, y); }
-static INLINE vopmask vneq_vo_vd_vd(vdouble x, vdouble y) { return (vopmask)vnot_vo_vo(vec_cmpeq(x, y)); }
-static INLINE vopmask vlt_vo_vd_vd(vdouble x, vdouble y) { return (vopmask)vec_cmplt(x, y); }
-static INLINE vopmask vle_vo_vd_vd(vdouble x, vdouble y) { return (vopmask)vec_cmple(x, y); }
-static INLINE vopmask vgt_vo_vd_vd(vdouble x, vdouble y) { return (vopmask)vec_cmpgt(x, y); }
-static INLINE vopmask vge_vo_vd_vd(vdouble x, vdouble y) { return (vopmask)vec_cmpge(x, y); }
-
-static INLINE vint vadd_vi_vi_vi(vint x, vint y) { return vec_add(x, y); }
-static INLINE vint vsub_vi_vi_vi(vint x, vint y) { return vec_sub(x, y); }
-static INLINE vint vneg_vi_vi(vint e) { return vec_neg(e); }
-
-static INLINE vint vand_vi_vi_vi(vint x, vint y) { return vec_and(x, y); }
-static INLINE vint vandnot_vi_vi_vi(vint x, vint y) { return vec_andc(y, x); }
-static INLINE vint vor_vi_vi_vi(vint x, vint y) { return vec_or(x, y); }
-static INLINE vint vxor_vi_vi_vi(vint x, vint y) { return vec_xor(x, y); }
-
-static INLINE vint vand_vi_vo_vi(vopmask x, vint y) { return vreinterpretFirstHalf_vi_vi2((vint2)x) & y; }
-static INLINE vint vandnot_vi_vo_vi(vopmask x, vint y) { return vec_andc(y, vreinterpretFirstHalf_vi_vi2((vint2)x)); }
-
-static INLINE vint vsll_vi_vi_i(vint x, int c) { return vec_sl (x, (vector unsigned int)(c, c, c, c)); }
-static INLINE vint vsrl_vi_vi_i(vint x, int c) { return vec_sr (x, (vector unsigned int)(c, c, c, c)); }
-static INLINE vint vsra_vi_vi_i(vint x, int c) { return vec_sra(x, (vector unsigned int)(c, c, c, c)); }
-
-static INLINE vint veq_vi_vi_vi(vint x, vint y) { return vec_cmpeq(x, y); }
-static INLINE vint vgt_vi_vi_vi(vint x, vint y) { return vec_cmpgt(x, y); }
-
-static INLINE vopmask veq_vo_vi_vi(vint x, vint y) { return (vopmask)vreinterpretFirstHalf_vi2_vi(vec_cmpeq(x, y)); }
-static INLINE vopmask vgt_vo_vi_vi(vint x, vint y) { return (vopmask)vreinterpretFirstHalf_vi2_vi(vec_cmpgt(x, y));}
-
-static INLINE vint vsel_vi_vo_vi_vi(vopmask m, vint x, vint y) {
-  return vor_vi_vi_vi(vand_vi_vi_vi(vreinterpretFirstHalf_vi_vi2((vint2)m), x),
-		      vandnot_vi_vi_vi(vreinterpretFirstHalf_vi_vi2((vint2)m), y));
+static INLINE vdouble vsel_vd_vo_d_d(vopmask o, double v1, double v0)
+{
+  return vsel_vd_vo_vd_vd(o, vsetall__vd(v1), vsetall__vd(v0));
+}
+static INLINE vdouble vsel_vd_vo_vo_d_d_d(vopmask o0, vopmask o1, double d0, double d1, double d2)
+{
+  return vsel_vd_vo_vd_vd(o0, vsetall__vd(d0), vsel_vd_vo_d_d(o1, d1, d2));
+}
+static INLINE vdouble vsel_vd_vo_vo_vo_d_d_d_d(vopmask o0, vopmask o1, vopmask o2, double d0, double d1, double d2, double d3)
+{
+  return vsel_vd_vo_vd_vd(o0, vsetall__vd(d0), vsel_vd_vo_vd_vd(o1, vsetall__vd(d1), vsel_vd_vo_d_d(o2, d2, d3)));
 }
 
-static INLINE vopmask visinf_vo_vd(vdouble d) { return (vopmask)(vec_cmpeq(vabs_vd_vd(d), vcast_vd_d(SLEEF_INFINITY))); }
-static INLINE vopmask vispinf_vo_vd(vdouble d) { return (vopmask)(vec_cmpeq(d, vcast_vd_d(SLEEF_INFINITY))); }
-static INLINE vopmask visminf_vo_vd(vdouble d) { return (vopmask)(vec_cmpeq(d, vcast_vd_d(-SLEEF_INFINITY))); }
-static INLINE vopmask visnan_vo_vd(vdouble d) { return (vopmask)(vnot_vo_vo(vec_cmpeq(d, d))); }
+static INLINE int vtestallones_i_vo32(vopmask g)
+{ return vec_all_ne((vint2)g, vzero__vi2()); }
+static INLINE int vtestallones_i_vo64(vopmask g)
+{ return vec_all_ne((v__i64)g, vzero__s64()); }
 
-static INLINE double vcast_d_vd(vdouble v) { return v[0]; }
-static INLINE float vcast_f_vf(vfloat v) { return v[0]; }
+/**********************************************
+ ** Conversions
+ **********************************************/
 
-static INLINE void vstream_v_p_vd(double *ptr, vdouble v) { vstore_v_p_vd(ptr, v); }
-static INLINE void vsscatter2_v_p_i_i_vd(double *ptr, int offset, int step, vdouble v) { vscatter2_v_p_i_i_vd(ptr, offset, step, v); }
+////////////// Numeric //////////////
+// pack 64-bit mask to 32-bit
+static INLINE vopmask vcast_vo32_vo64(vopmask m)
+{ return (vopmask)vec_pack((v__u64)m, (v__u64)m); }
+// clip 64-bit lanes to lower 32-bit
+static INLINE vint vcastu_vi_vi2(vint2 vi2)
+{ return vec_mergeo(vi2, vec_splat(vi2, 3)); }
 
-//
+// expand lower 32-bit mask
+static INLINE vopmask vcast_vo64_vo32(vopmask m)
+{ return vec_mergeh(m, m); }
+// unsigned expand lower 32-bit integer
+static INLINE vint2 vcastu_vi2_vi(vint vi)
+{ return vec_mergeh(vzero__vi(), vi); }
 
-static INLINE CONST vfloat vsel_vf_vo_f_f(vopmask o, float v1, float v0) {
-  return vsel_vf_vo_vf_vf(o, vcast_vf_f(v1), vcast_vf_f(v0));
+// signed int to single-precision
+static INLINE vfloat vcast_vf_vi2(vint2 vi)
+{
+  vfloat ret;
+#ifdef __clang__
+  ret = __builtin_convertvector(vi, vfloat);
+#else
+  __asm__ __volatile__("xvcvsxwsp %x0,%x1" : "=wa" (ret) : "wa" (vi));
+#endif
+  return ret;
 }
 
-static INLINE vfloat vsel_vf_vo_vo_f_f_f(vopmask o0, vopmask o1, float d0, float d1, float d2) {
-  return vsel_vf_vo_vf_vf(o0, vcast_vf_f(d0), vsel_vf_vo_f_f(o1, d1, d2));
+// lower signed int to double-precision
+static INLINE vdouble vcast_vd_vi(vint vi)
+{
+  vdouble ret;
+  vint swap = vec_mergeh(vi, vi);
+#ifdef __clang__
+  ret = __builtin_vsx_xvcvsxwdp(swap);
+#else
+  __asm__ __volatile__("xvcvsxwdp %x0,%x1" : "=wa" (ret) : "wa" (swap));
+#endif
+  return ret;
 }
 
-static INLINE vfloat vsel_vf_vo_vo_vo_f_f_f_f(vopmask o0, vopmask o1, vopmask o2, float d0, float d1, float d2, float d3) {
-  return vsel_vf_vo_vf_vf(o0, vcast_vf_f(d0), vsel_vf_vo_vf_vf(o1, vcast_vf_f(d1), vsel_vf_vo_f_f(o2, d2, d3)));
+// zip two scalars
+static INLINE vmask vcast_vm_i_i(int l, int h)
+{ return (vmask)vec_mergeh(vsetall__vi2(h), vsetall__vi2(l)); }
+
+////////////// Truncation //////////////
+
+static INLINE vint2 vtruncate_vi2_vf(vfloat vf)
+{
+  vint2 ret;
+#ifdef __clang__
+  ret = __builtin_convertvector(vf, vint2);
+#else
+  __asm__ __volatile__("xvcvspsxws %x0,%x1" : "=wa" (ret) : "wa" (vf));
+#endif
+  return ret;
 }
 
-static INLINE vint2 vcast_vi2_vm(vmask vm) { return (vint2)vm; }
-static INLINE vmask vcast_vm_vi2(vint2 vi) { return (vmask)vi; }
+static INLINE vint vtruncate_vi_vd(vdouble vd)
+{
+  vint ret;
+#ifdef __clang__
+  ret = __builtin_vsx_xvcvdpsxws(vd);
+#else
+  __asm__ __volatile__("xvcvdpsxws %x0,%x1" : "=wa" (ret) : "wa" (vd));
+#endif
+  return vec_mergeo(ret, vec_splat(ret, 3));
+}
 
-static INLINE vopmask veq_vo_vf_vf(vfloat x, vfloat y) { return (vopmask)vec_cmpeq(x, y); }
-static INLINE vopmask vneq_vo_vf_vf(vfloat x, vfloat y) { return (vopmask)vnot_vo_vo(vec_cmpeq(x, y)); }
-static INLINE vopmask vlt_vo_vf_vf(vfloat x, vfloat y) { return (vopmask)vec_cmplt(x, y); }
-static INLINE vopmask vle_vo_vf_vf(vfloat x, vfloat y) { return (vopmask)vec_cmple(x, y); }
-static INLINE vopmask vgt_vo_vf_vf(vfloat x, vfloat y) { return (vopmask)vec_cmpgt(x, y); }
-static INLINE vopmask vge_vo_vf_vf(vfloat x, vfloat y) { return (vopmask)vec_cmpge(x, y); }
+static INLINE vdouble vtruncate_vd_vd(vdouble vd)
+{ return vec_trunc(vd); }
+static INLINE vfloat vtruncate_vf_vf(vfloat vf)
+{ return vec_trunc(vf); }
 
-static INLINE vint2 vadd_vi2_vi2_vi2(vint2 x, vint2 y) { return vec_add(x, y); }
-static INLINE vint2 vsub_vi2_vi2_vi2(vint2 x, vint2 y) { return vec_sub(x, y); }
-static INLINE vint2 vneg_vi2_vi2(vint2 e) { return vec_neg(e); }
+////////////// Rounding //////////////
 
-static INLINE vint2 vand_vi2_vi2_vi2(vint2 x, vint2 y) { return vec_and(x, y); }
-static INLINE vint2 vandnot_vi2_vi2_vi2(vint2 x, vint2 y) { return vec_andc(y, x); }
-static INLINE vint2 vor_vi2_vi2_vi2(vint2 x, vint2 y) { return vec_or(x, y); }
-static INLINE vint2 vxor_vi2_vi2_vi2(vint2 x, vint2 y) { return vec_xor(x, y); }
+// towards the nearest even
+static INLINE vint vrint_vi_vd(vdouble vd)
+{ return vtruncate_vi_vd(vec_rint(vd)); }
+static INLINE vint2 vrint_vi2_vf(vfloat vf)
+{ return vtruncate_vi2_vf(vec_rint(vf)); }
+static INLINE vdouble vrint_vd_vd(vdouble vd)
+{ return vec_rint(vd); }
+static INLINE vfloat vrint_vf_vf(vfloat vf)
+{ return vec_rint(vf); }
 
-static INLINE vint2 vand_vi2_vo_vi2(vopmask x, vint2 y) { return (vint2)vec_and((vint2)x, y); }
-static INLINE vint2 vandnot_vi2_vo_vi2(vopmask x, vint2 y) { return vec_andc(y, (vint2)x); }
+/**********************************************
+ ** Logical
+ **********************************************/
 
-static INLINE vint2 vsll_vi2_vi2_i(vint2 x, int c) { return vec_sl (x, (vector unsigned int)(c, c, c, c)); }
-static INLINE vint2 vsrl_vi2_vi2_i(vint2 x, int c) { return vec_sr (x, (vector unsigned int)(c, c, c, c)); }
-static INLINE vint2 vsra_vi2_vi2_i(vint2 x, int c) { return vec_sra(x, (vector unsigned int)(c, c, c, c)); }
+////////////// And //////////////
+static INLINE vint vand_vi_vi_vi(vint x, vint y)
+{ return vec_and(x, y); }
+static INLINE vint vand_vi_vo_vi(vopmask x, vint y)
+{ return vec_and((vint)x, y); }
+static INLINE vint2 vand_vi2_vi2_vi2(vint2 x, vint2 y)
+{ return vec_and(x, y); }
+static INLINE vint2 vand_vi2_vo_vi2(vopmask x, vint2 y)
+{ return (vint2)vec_and((vint2)x, y); }
 
-static INLINE vopmask veq_vo_vi2_vi2(vint2 x, vint2 y) { return (vopmask)vec_cmpeq(x, y); }
-static INLINE vopmask vgt_vo_vi2_vi2(vint2 x, vint2 y) { return (vopmask)vec_cmpgt(x, y); }
-static INLINE vint2 veq_vi2_vi2_vi2(vint2 x, vint2 y) { return vec_cmpeq(x, y); }
-static INLINE vint2 vgt_vi2_vi2_vi2(vint2 x, vint2 y) { return vec_cmpgt(x, y); }
+static INLINE vmask vand_vm_vm_vm(vmask x, vmask y)
+{ return vec_and(x, y); }
+static INLINE vmask vand_vm_vo32_vm(vopmask x, vmask y)
+{ return vec_and((vmask)x, y); }
+static INLINE vmask vand_vm_vo64_vm(vopmask x, vmask y)
+{ return vec_and((vmask)x, y); }
+static INLINE vopmask vand_vo_vo_vo(vopmask x, vopmask y)
+{ return vec_and(x, y); }
 
-static INLINE vopmask visinf_vo_vf(vfloat d) { return (vopmask)vec_cmpeq(vabs_vf_vf(d), vcast_vf_f(SLEEF_INFINITYf)); }
-static INLINE vopmask vispinf_vo_vf(vfloat d) { return (vopmask)vec_cmpeq(d, vcast_vf_f(SLEEF_INFINITYf)); }
-static INLINE vopmask visminf_vo_vf(vfloat d) { return (vopmask)vec_cmpeq(d, vcast_vf_f(-SLEEF_INFINITYf)); }
-static INLINE vopmask visnan_vo_vf(vfloat d) { return (vopmask)vnot_vo_vo(vec_cmpeq(d, d)); }
+////////////// Or //////////////
+static INLINE vint vor_vi_vi_vi(vint x, vint y)
+{ return vec_or(x, y); }
+static INLINE vint2 vor_vi2_vi2_vi2(vint2 x, vint2 y)
+{ return vec_or(x, y); }
 
-static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloat v) { vscatter2_v_p_i_i_vf(ptr, offset, step, v); }
-static INLINE void vstream_v_p_vf(float *ptr, vfloat v) { vstore_v_p_vf(ptr, v); }
+static INLINE vmask vor_vm_vm_vm(vmask x, vmask y)
+{ return vec_or(x, y); }
+static INLINE vmask vor_vm_vo32_vm(vopmask x, vmask y)
+{ return vec_or((vmask)x, y); }
+static INLINE vmask vor_vm_vo64_vm(vopmask x, vmask y)
+{ return vec_or((vmask)x, y); }
+static INLINE vopmask vor_vo_vo_vo(vopmask x, vopmask y)
+{ return vec_or(x, y); }
+
+////////////// Xor //////////////
+static INLINE vint vxor_vi_vi_vi(vint x, vint y)
+{ return vec_xor(x, y); }
+static INLINE vint2 vxor_vi2_vi2_vi2(vint2 x, vint2 y)
+{ return vec_xor(x, y); }
+
+static INLINE vmask vxor_vm_vm_vm(vmask x, vmask y)
+{ return vec_xor(x, y); }
+static INLINE vmask vxor_vm_vo32_vm(vopmask x, vmask y)
+{ return vec_xor((vmask)x, y); }
+static INLINE vmask vxor_vm_vo64_vm(vopmask x, vmask y)
+{ return vec_xor((vmask)x, y); }
+static INLINE vopmask vxor_vo_vo_vo(vopmask x, vopmask y)
+{ return vec_xor(x, y); }
+
+////////////// Not //////////////
+static INLINE vopmask vnot_vo_vo(vopmask o)
+{ return vec_nor(o, o); }
+
+////////////// And Not ((~x) & y) //////////////
+static INLINE vint vandnot_vi_vi_vi(vint x, vint y)
+{ return vec_andc(y, x); }
+static INLINE vint vandnot_vi_vo_vi(vopmask x, vint y)
+{ return vec_andc(y, (vint)x); }
+static INLINE vint2 vandnot_vi2_vi2_vi2(vint2 x, vint2 y)
+{ return vec_andc(y, x); }
+static INLINE vmask vandnot_vm_vm_vm(vmask x, vmask y)
+{ return vec_andc(y, x); }
+static INLINE vmask vandnot_vm_vo64_vm(vopmask x, vmask y)
+{ return vec_andc(y, x); }
+static INLINE vmask vandnot_vm_vo32_vm(vopmask x, vmask y)
+{ return vec_andc(y, x); }
+static INLINE vopmask vandnot_vo_vo_vo(vopmask x, vopmask y)
+{ return vec_andc(y, x); }
+static INLINE vint2 vandnot_vi2_vo_vi2(vopmask x, vint2 y)
+{ return vec_andc(y, (vint2)x); }
+
+/**********************************************
+ ** Comparison
+ **********************************************/
+
+////////////// Equal //////////////
+static INLINE vint veq_vi_vi_vi(vint x, vint y)
+{ return (vint)vec_cmpeq(x, y); }
+static INLINE vopmask veq_vo_vi_vi(vint x, vint y)
+{ return vec_cmpeq(x, y); }
+
+static INLINE vopmask veq_vo_vi2_vi2(vint2 x, vint2 y)
+{ return vec_cmpeq(x, y); }
+static INLINE vint2 veq_vi2_vi2_vi2(vint2 x, vint2 y)
+{ return (vint2)vec_cmpeq(x, y); }
+
+static INLINE vopmask veq64_vo_vm_vm(vmask x, vmask y)
+{ return (vopmask)vec_cmpeq((v__u64)x, (v__u64)y); }
+
+static INLINE vopmask veq_vo_vf_vf(vfloat x, vfloat y)
+{ return vec_cmpeq(x, y); }
+static INLINE vopmask veq_vo_vd_vd(vdouble x, vdouble y)
+{ return (vopmask)vec_cmpeq(x, y); }
+
+////////////// Not Equal //////////////
+static INLINE vopmask vneq_vo_vf_vf(vfloat x, vfloat y)
+{ return vnot_vo_vo(vec_cmpeq(x, y)); }
+static INLINE vopmask vneq_vo_vd_vd(vdouble x, vdouble y)
+{ return vnot_vo_vo((vopmask)vec_cmpeq(x, y)); }
+
+////////////// Less Than //////////////
+static INLINE vopmask vlt_vo_vf_vf(vfloat x, vfloat y)
+{ return vec_cmplt(x, y); }
+static INLINE vopmask vlt_vo_vd_vd(vdouble x, vdouble y)
+{ return (vopmask)vec_cmplt(x, y); }
+
+////////////// Greater Than //////////////
+static INLINE vint vgt_vi_vi_vi(vint x, vint y)
+{ return (vint)vec_cmpgt(x, y); }
+static INLINE vopmask vgt_vo_vi_vi(vint x, vint y)
+{ return vec_cmpgt(x, y);}
+
+static INLINE vint2 vgt_vi2_vi2_vi2(vint2 x, vint2 y)
+{ return (vint2)vec_cmpgt(x, y); }
+static INLINE vopmask vgt_vo_vi2_vi2(vint2 x, vint2 y)
+{ return vec_cmpgt(x, y); }
+
+static INLINE vopmask vgt_vo_vf_vf(vfloat x, vfloat y)
+{ return vec_cmpgt(x, y); }
+static INLINE vopmask vgt_vo_vd_vd(vdouble x, vdouble y)
+{ return (vopmask)vec_cmpgt(x, y); }
+
+////////////// Less Than Or Equal //////////////
+static INLINE vopmask vle_vo_vf_vf(vfloat x, vfloat y)
+{ return vec_cmple(x, y); }
+static INLINE vopmask vle_vo_vd_vd(vdouble x, vdouble y)
+{ return (vopmask)vec_cmple(x, y); }
+
+////////////// Greater Than Or Equal //////////////
+static INLINE vopmask vge_vo_vf_vf(vfloat x, vfloat y)
+{ return vec_cmpge(x, y); }
+static INLINE vopmask vge_vo_vd_vd(vdouble x, vdouble y)
+{ return (vopmask)vec_cmpge(x, y); }
+
+////////////// Special Cases //////////////
+static INLINE vopmask visinf_vo_vf(vfloat d)
+{ return vec_cmpeq(vec_abs(d), vsetall__vf(SLEEF_INFINITYf)); }
+static INLINE vopmask visinf_vo_vd(vdouble d)
+{ return (vopmask)vec_cmpeq(vec_abs(d), vsetall__vd(SLEEF_INFINITY)); }
+
+static INLINE vopmask vispinf_vo_vf(vfloat d)
+{ return vec_cmpeq(d, vsetall__vf(SLEEF_INFINITYf)); }
+static INLINE vopmask vispinf_vo_vd(vdouble d)
+{ return (vopmask)vec_cmpeq(d, vsetall__vd(SLEEF_INFINITY)); }
+
+static INLINE vopmask visminf_vo_vf(vfloat d)
+{ return vec_cmpeq(d, vsetall__vf(-SLEEF_INFINITYf)); }
+static INLINE vopmask visminf_vo_vd(vdouble d)
+{ return (vopmask)vec_cmpeq(d, vsetall__vd(-SLEEF_INFINITY)); }
+
+static INLINE vopmask visnan_vo_vf(vfloat d)
+{ return vnot_vo_vo(vec_cmpeq(d, d)); }
+static INLINE vopmask visnan_vo_vd(vdouble d)
+{ return vnot_vo_vo((vopmask)vec_cmpeq(d, d)); }
+
+/**********************************************
+ ** Shift
+ **********************************************/
+////////////// Left //////////////
+static INLINE vint vsll_vi_vi_i(vint x, int c)
+{ return vec_sl (x, vsetall__u32(c)); }
+static INLINE vint2 vsll_vi2_vi2_i(vint2 x, int c)
+{ return vec_sl(x, vsetall__u32(c)); }
+
+////////////// Right //////////////
+static INLINE vint vsrl_vi_vi_i(vint x, int c)
+{ return vec_sr(x, vsetall__u32(c)); }
+static INLINE vint2 vsrl_vi2_vi2_i(vint2 x, int c)
+{ return vec_sr(x, vsetall__u32(c)); }
+
+////////////// Algebraic Right //////////////
+static INLINE vint vsra_vi_vi_i(vint x, int c)
+{ return vec_sra(x, vsetall__u32(c)); }
+static INLINE vint2 vsra_vi2_vi2_i(vint2 x, int c)
+{ return vec_sra(x, vsetall__u32(c)); }
+
+/**********************************************
+ ** Reorder
+ **********************************************/
+
+////////////// Reverse //////////////
+// Reverse elements order inside the lower and higher parts
+static INLINE vint2 vrev21_vi2_vi2(vint2 vi)
+{ return vec_mergee(vec_mergeo(vi, vi), vi); }
+static INLINE vfloat vrev21_vf_vf(vfloat vf)
+{ return (vfloat)vrev21_vi2_vi2((vint2)vf); }
+
+// Swap the lower and higher parts
+static INLINE vfloat vreva2_vf_vf(vfloat vf)
+{ return (vfloat)v__swapd_u64((v__u64)vf); }
+static INLINE vdouble vrev21_vd_vd(vdouble vd)
+{ return (vdouble)v__swapd_u64((v__u64)vd); }
+static INLINE vdouble vreva2_vd_vd(vdouble vd)
+{ return vd; }
+
+/**********************************************
+ ** Arithmetic
+ **********************************************/
+
+////////////// Negation //////////////
+static INLINE vint vneg_vi_vi(vint e) {
+#ifdef __clang__
+  return vec_neg(e);
+#else
+  return vec_sub(vzero__vi(), e);
+#endif
+}
+static INLINE vint2 vneg_vi2_vi2(vint2 e)
+{ return vneg_vi_vi(e); }
+
+static INLINE vfloat vneg_vf_vf(vfloat d)
+{
+  vfloat ret;
+#ifdef __clang__
+  ret = vec_neg(d);
+#else
+  __asm__ __volatile__("xvnegsp %x0,%x1" : "=wa" (ret) : "wa" (d));
+#endif
+  return ret;
+}
+
+static INLINE vdouble vneg_vd_vd(vdouble d)
+{
+  vdouble ret;
+#ifdef __clang__
+  ret = vec_neg(d);
+#else
+  __asm__ __volatile__("xvnegdp %x0,%x1" : "=wa" (ret) : "wa" (d));
+#endif
+  return ret;
+}
+
+static INLINE vfloat vposneg_vf_vf(vfloat d)
+{ return vec_xor(d, vset__vf(+0.0f, -0.0f, +0.0f, -0.0f)); }
+static INLINE vdouble vposneg_vd_vd(vdouble d)
+{ return vec_xor(d, vset__vd(+0.0, -0.0)); }
+
+static INLINE vfloat vnegpos_vf_vf(vfloat d)
+{ return vec_xor(d, vset__vf(-0.0f, +0.0f, -0.0f, +0.0f)); }
+static INLINE vdouble vnegpos_vd_vd(vdouble d)
+{ return vec_xor(d, vset__vd(-0.0, +0.0)); }
+
+////////////// Addition //////////////
+static INLINE vint vadd_vi_vi_vi(vint x, vint y)
+{ return vec_add(x, y); }
+static INLINE vint2 vadd_vi2_vi2_vi2(vint2 x, vint2 y)
+{ return vec_add(x, y); }
+
+static INLINE vfloat vadd_vf_vf_vf(vfloat x, vfloat y)
+{ return vec_add(x, y); }
+static INLINE vdouble vadd_vd_vd_vd(vdouble x, vdouble y)
+{ return vec_add(x, y); }
+
+static INLINE vmask vadd64_vm_vm_vm(vmask x, vmask y)
+{ return (vmask)vec_add((v__i64)x, (v__i64)y); }
+
+////////////// Subtraction //////////////
+static INLINE vint vsub_vi_vi_vi(vint x, vint y)
+{ return vec_sub(x, y); }
+static INLINE vint2 vsub_vi2_vi2_vi2(vint2 x, vint2 y)
+{ return vec_sub(x, y); }
+
+static INLINE vfloat vsub_vf_vf_vf(vfloat x, vfloat y)
+{ return vec_sub(x, y); }
+static INLINE vdouble vsub_vd_vd_vd(vdouble x, vdouble y)
+{ return vec_sub(x, y); }
+
+static INLINE vdouble vsubadd_vd_vd_vd(vdouble x, vdouble y)
+{ return vec_add(x, vnegpos_vd_vd(y)); }
+static INLINE vfloat vsubadd_vf_vf_vf(vfloat x, vfloat y)
+{ return vec_add(x, vnegpos_vf_vf(y)); }
+
+////////////// Multiplication //////////////
+static INLINE vfloat vmul_vf_vf_vf(vfloat x, vfloat y)
+{ return vec_mul(x, y); }
+static INLINE vdouble vmul_vd_vd_vd(vdouble x, vdouble y)
+{ return vec_mul(x, y); }
+
+static INLINE vfloat vdiv_vf_vf_vf(vfloat x, vfloat y)
+{ return vec_div(x, y); }
+static INLINE vdouble vdiv_vd_vd_vd(vdouble x, vdouble y)
+{ return vec_div(x, y); }
+
+static INLINE vfloat vrec_vf_vf(vfloat x)
+{ return vec_div(vsetall__vf(1.0f), x); }
+static INLINE vdouble vrec_vd_vd(vdouble x)
+{ return vec_div(vsetall__vd(1.0), x); }
+
+/**********************************************
+ ** Math
+ **********************************************/
+
+static INLINE vfloat vmax_vf_vf_vf(vfloat x, vfloat y)
+{ return vec_max(x, y); }
+static INLINE vdouble vmax_vd_vd_vd(vdouble x, vdouble y)
+{ return vec_max(x, y); }
+
+static INLINE vfloat vmin_vf_vf_vf(vfloat x, vfloat y)
+{ return vec_min(x, y); }
+static INLINE vdouble vmin_vd_vd_vd(vdouble x, vdouble y)
+{ return vec_min(x, y); }
+
+static INLINE vfloat vabs_vf_vf(vfloat f)
+{ return vec_abs(f); }
+static INLINE vdouble vabs_vd_vd(vdouble d)
+{ return vec_abs(d); }
+
+static INLINE vfloat vsqrt_vf_vf(vfloat f)
+{ return vec_sqrt(f); }
+static INLINE vdouble vsqrt_vd_vd(vdouble d)
+{ return vec_sqrt(d); }
+
+
+/**********************************************
+ ** FMA3
+ **********************************************/
+#if CONFIG == 1
+
+static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_madd(x, y, z); }
+static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_madd(x, y, z); }
+
+static INLINE vfloat vmlapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_msub(x, y, z); }
+static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_msub(x, y, z); }
+
+static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_nmsub(x, y, z); }
+static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_nmsub(x, y, z); }
+
+#else
+
+static INLINE vfloat vmla_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_add(vec_mul(x, y), z); }
+static INLINE vdouble vmla_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_add(vec_mul(x, y), z); }
+
+static INLINE vfloat vmlapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_sub(vec_mul(x, y), z); }
+static INLINE vdouble vmlapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_sub(vec_mul(x, y), z); }
+
+static INLINE vfloat vmlanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_sub(z, vec_mul(x, y)); }
+static INLINE vdouble vmlanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_sub(z, vec_mul(x, y)); }
+
+#endif
+
+static INLINE vfloat vfma_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_madd(x, y, z); }
+static INLINE vdouble vfma_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_madd(x, y, z); }
+static INLINE vfloat vfmapp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_madd(x, y, z); }
+static INLINE vdouble vfmapp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_madd(x, y, z); }
+
+static INLINE vfloat vfmapn_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_msub(x, y, z); }
+static INLINE vdouble vfmapn_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_msub(x, y, z); }
+
+static INLINE vfloat vfmanp_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_nmsub(x, y, z); }
+static INLINE vdouble vfmanp_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_nmsub(x, y, z); }
+
+static INLINE vfloat vfmann_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vec_nmadd(x, y, z); }
+static INLINE vdouble vfmann_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vec_nmadd(x, y, z); }
+
+static INLINE vfloat vmlsubadd_vf_vf_vf_vf(vfloat x, vfloat y, vfloat z)
+{ return vmla_vf_vf_vf_vf(x, y, vnegpos_vf_vf(z)); }
+static INLINE vdouble vmlsubadd_vd_vd_vd_vd(vdouble x, vdouble y, vdouble z)
+{ return vmla_vd_vd_vd_vd(x, y, vnegpos_vd_vd(z)); }

--- a/src/libm-tester/iutsimd.c
+++ b/src/libm-tester/iutsimd.c
@@ -179,16 +179,16 @@ typedef Sleef___m256_2 vfloat2;
 #define CONFIG 1
 #include "helperpower_128.h"
 #include "renamevsx.h"
-typedef Sleef_vector_double_2 vdouble2;
-typedef Sleef_vector_float_2 vfloat2;
+typedef Sleef___vector_double_2 vdouble2;
+typedef Sleef___vector_float_2 vfloat2;
 #endif
 
 #ifdef ENABLE_VSXNOFMA
 #define CONFIG 2
 #include "helperpower_128.h"
 #include "renamevsxnofma.h"
-typedef Sleef_vector_double_2 vdouble2;
-typedef Sleef_vector_float_2 vfloat2;
+typedef Sleef___vector_double_2 vdouble2;
+typedef Sleef___vector_float_2 vfloat2;
 #endif
 
 #ifdef ENABLE_PUREC_SCALAR

--- a/src/libm-tester/tester2simddp.c
+++ b/src/libm-tester/tester2simddp.c
@@ -142,16 +142,16 @@ typedef Sleef_svfloat32_t_2 vfloat2;
 #define CONFIG 1
 #include "helperpower_128.h"
 #include "renamevsx.h"
-typedef Sleef_vector_double_2 vdouble2;
-typedef Sleef_vector_float_2 vfloat2;
+typedef Sleef___vector_double_2 vdouble2;
+typedef Sleef___vector_float_2 vfloat2;
 #endif
 
 #ifdef ENABLE_VSXNOFMA
 #define CONFIG 2
 #include "helperpower_128.h"
 #include "renamevsxnofma.h"
-typedef Sleef_vector_double_2 vdouble2;
-typedef Sleef_vector_float_2 vfloat2;
+typedef Sleef___vector_double_2 vdouble2;
+typedef Sleef___vector_float_2 vfloat2;
 #endif
 
 #ifdef ENABLE_PUREC_SCALAR

--- a/src/libm-tester/tester2simdsp.c
+++ b/src/libm-tester/tester2simdsp.c
@@ -143,16 +143,16 @@ typedef Sleef_svfloat32_t_2 vfloat2;
 #define CONFIG 1
 #include "helperpower_128.h"
 #include "renamevsx.h"
-typedef Sleef_vector_double_2 vdouble2;
-typedef Sleef_vector_float_2 vfloat2;
+typedef Sleef___vector_double_2 vdouble2;
+typedef Sleef___vector_float_2 vfloat2;
 #endif
 
 #ifdef ENABLE_VSXNOFMA
 #define CONFIG 2
 #include "helperpower_128.h"
 #include "renamevsxnofma.h"
-typedef Sleef_vector_double_2 vdouble2;
-typedef Sleef_vector_float_2 vfloat2;
+typedef Sleef___vector_double_2 vdouble2;
+typedef Sleef___vector_float_2 vfloat2;
 #endif
 
 #ifdef ENABLE_PUREC_SCALAR

--- a/src/libm-tester/tester3.c
+++ b/src/libm-tester/tester3.c
@@ -18,8 +18,11 @@
 #include "testerutil.h"
 
 #ifdef __VSX__
-typedef vector double vector_double;
-typedef vector float  vector_float;
+#include <altivec.h>
+#undef vector
+#undef bool
+typedef __vector double __vector_double;
+typedef __vector float  __vector_float;
 #endif
 
 //
@@ -71,10 +74,10 @@ static INLINE float getsvfloat32_t(svfloat32_t v, int r)  { float  a[svcntw()]; 
 #endif
 
 #ifdef __VSX__
-static INLINE vector_double setvector_double(double d, int r) { double a[2]; memrand(a, sizeof(a)); a[r & 1] = d; return (vector double) ( a[0], a[1] ); }
-static INLINE double getvector_double(vector double v, int r) { double a[2]; return unifyValue(v[r & 1]); }
-static INLINE vector_float setvector_float(float d, int r) { float a[4]; memrand(a, sizeof(a)); a[r & 3] = d; return (vector float) ( a[0], a[1], a[2], a[3] ); }
-static INLINE float getvector_float(vector float v, int r) { float a[4]; return unifyValuef(v[r & 3]); }
+static INLINE __vector double set__vector_double(double d, int r) { double a[2]; memrand(a, sizeof(a)); a[r & 1] = d; return vec_vsx_ld(0, a); }
+static INLINE double get__vector_double(__vector double v, int r) { double a[2]; vec_vsx_st(v, 0, a); return unifyValue(a[r & 1]); }
+static INLINE __vector float set__vector_float(float d, int r) { float a[4]; memrand(a, sizeof(a)); a[r & 3] = d; return vec_vsx_ld(0, a); }
+static INLINE float get__vector_float(__vector float v, int r) { float a[4]; vec_vsx_st(v, 0, a); return unifyValuef(a[r & 3]); }
 #endif
 
 //
@@ -282,7 +285,7 @@ int do_test(int argc, char **argv)
   test_d_d(exp10, u35, -1000, 1000, 200001);
   test_d_d(expm1, u10, -1000, 1000, 200001);
   test_d_d_d(pow, u10, -100, 100, 451, -100, 100, 451);
-  
+
   testu_d_d(cbrt, u10, 1e-14, 1e+14, 100001);
   testu_d_d(cbrt, u10, -1e-14, -1e+14, 100001);
   testu_d_d(cbrt, u35, 1e-14, 1e+14, 100001);
@@ -307,7 +310,7 @@ int do_test(int argc, char **argv)
   test_d_d(asinh, u10, -700, 700, 200001);
   test_d_d(acosh, u10, 1, 700, 200001);
   test_d_d(atanh, u10, -700, 700, 200001);
-  
+
   test_d_d(lgamma, u10, -5000, 5000, 200001);
   test_d_d(tgamma, u10, -10, 10, 200001);
   test_d_d(erf, u10, -100, 100, 200001);
@@ -355,7 +358,7 @@ int do_test(int argc, char **argv)
   test_f_f(exp10, u35, -1000, 1000, 200001);
   test_f_f(expm1, u10, -1000, 1000, 200001);
   test_f_f_f(pow, u10, -100, 100, 451, -100, 100, 451);
-  
+
   testu_f_f(cbrt, u10, 1e-14, 1e+14, 100001);
   testu_f_f(cbrt, u10, -1e-14, -1e+14, 100001);
   testu_f_f(cbrt, u35, 1e-14, 1e+14, 100001);
@@ -380,7 +383,7 @@ int do_test(int argc, char **argv)
   test_f_f(asinh, u10, -88, 88, 200001);
   test_f_f(acosh, u10, 1, 88, 200001);
   test_f_f(atanh, u10, -88, 88, 200001);
-  
+
   test_f_f(lgamma, u10, -5000, 5000, 200001);
   test_f_f(tgamma, u10, -10, 10, 200001);
   test_f_f(erf, u10, -100, 100, 200001);

--- a/travis/before_install.common.sh
+++ b/travis/before_install.common.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ev
+uname -a
+sudo apt-get -qq update
+sudo apt-get install -y libmpfr-dev libssl-dev

--- a/travis/before_script.common.sh
+++ b/travis/before_script.common.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ev
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../install \
+      -DSLEEF_SHOW_CONFIG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE ..

--- a/travis/script.common.sh
+++ b/travis/script.common.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ev
+cd build
+make -j `nproc` all
+ctest -j `nproc`
+make install


### PR DESCRIPTION
#### Several improvements for VSX
  - fix the build on gcc
  - fix accuracy tests
  - fix the build with C++ when 'vector' compiler token is combined,
    NOTE: the generated header is using '__vector' instead of 'vector'
  - fix unaligned memory load
  - set rounding to the nearest even, make it equivalent to X86
  - improve the performance of conversions
  - improve the performance of shuffles and reverses
  - cleanup the whole VSX implementation

#### TODO
- [x]  activate Travis on ppc64le
- [x] fix overflow
- [x] fix  test failures on Clang
- [x] finalize and testing Sleef on a wide range of compilers versions