### PR TITLE
Better error detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(SLEEF_TEST_ALL_IUT "Perform tests on implementations with all vector exte
 option(SLEEF_SHOW_CONFIG "Show SLEEF configuration status messages." ON)
 option(SLEEF_SHOW_ERROR_LOG "Show cmake error log." OFF)
 
+option(ENFORCE_TESTER "Build fails if tester is not available" OFF)
 option(ENFORCE_TESTER3 "Build fails if tester3 is not built" OFF)
 
 option(ENABLE_ALTDIV  "Enable alternative division method (aarch64 only)" OFF)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
   - if "%DO_TEST%" == "TRUE" cd "c:\\projects\\sleef"
   - mkdir build
   - cd build
-  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE %ENV_BUILD_STATIC%
+  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 -DENFORCE_TESTER=TRUE -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE %ENV_BUILD_STATIC%
 build_script:
   - cmake --build . --target install --config Release
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2017
 configuration: Release
 environment:
   matrix:
-  - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=TRUE
+  - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=TRUE -DENFORCE_TESTER=TRUE
     DO_TEST: TRUE
   - ENV_BUILD_STATIC: -DBUILD_SHARED_LIBS=FALSE
     DO_TEST: FALSE
@@ -20,7 +20,7 @@ install:
   - if "%DO_TEST%" == "TRUE" cd "c:\\projects\\sleef"
   - mkdir build
   - cd build
-  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 -DENFORCE_TESTER=TRUE -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE %ENV_BUILD_STATIC%
+  - cmake -G"Visual Studio 15 2017 Win64" .. -DCMAKE_INSTALL_PREFIX=install -DSLEEF_SHOW_CONFIG=1 -DSLEEF_SHOW_ERROR_LOG=1 -DENFORCE_TESTER3=TRUE -DBUILD_QUAD=TRUE %ENV_BUILD_STATIC%
 build_script:
   - cmake --build . --target install --config Release
 test_script:

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -10,6 +10,10 @@ if(NOT LIB_MPFR)
   find_program(TESTER_COMMAND tester)
 endif(NOT LIB_MPFR)
 
+if (ENFORCE_TESTER AND NOT LIB_MPFR AND NOT TESTER_COMMAND)
+  message(FATAL_ERROR "ENFORCE_TESTER is specified and tester is not available")
+endif(ENFORCE_TESTER AND NOT LIB_MPFR AND NOT TESTER_COMMAND)
+
 find_library(LIBRT rt)
 if (NOT LIBRT)
   set(LIBRT "")

--- a/src/libm-tester/tester.c
+++ b/src/libm-tester/tester.c
@@ -16,6 +16,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <sys/wait.h>
 
 #if defined(POWER64_UNDEF_USE_EXTERN_INLINES)
 // This is a workaround required to cross compile for PPC64 binaries
@@ -5074,6 +5075,13 @@ int main(int argc, char **argv) {
 
 	printf("*** Using SDE\n");
       } else {
+	int status;
+	waitpid(pid, &status, 0);
+	if (WIFSIGNALED(status)) {
+	  fprintf(stderr, "\n\nTester : *** Child process has crashed\n");
+	  return -1;
+	}
+
 	fprintf(stderr, "\n\nTester : *** CPU does not support the necessary feature\n");
 	return 0;
       }

--- a/src/quad-tester/qtester.c
+++ b/src/quad-tester/qtester.c
@@ -16,6 +16,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <sys/wait.h>
 
 #if defined(POWER64_UNDEF_USE_EXTERN_INLINES)
 // This is a workaround required to cross compile for PPC64 binaries
@@ -707,6 +708,13 @@ int main(int argc, char **argv) {
 
 	fprintf(stderr, "*** Using SDE\n");
       } else {
+	int status;
+	waitpid(pid, &status, 0);
+	if (WIFSIGNALED(status)) {
+	  fprintf(stderr, "\n\nTester : *** Child process has crashed\n");
+	  return -1;
+	}
+
 	fprintf(stderr, "\n\nTester : *** CPU does not support the necessary feature\n");
 	return 0;
       }


### PR DESCRIPTION
With this patch, testing will fail if IUT crashes.
This patch also adds ENFORCE_TESTER cmake option which make a build fail if no tester is available.