### PR TITLE
Simplify rint

### DIFF
--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -754,9 +754,9 @@ static CONST di_t rempisub(double x) {
   // This function is equivalent to :
   // di_t ret = { x - rint(4 * x) * 0.25, (int32_t)(rint(4 * x) - rint(x) * 4) };
   di_t ret;
-  double c = mulsign(1L << 52, x);
-  double rint4x = fabsk(4*x) > 1L << 52 ? (4*x) : orsign(mla(4, x, c) - c, x);
-  double rintx  = fabsk(  x) > 1L << 52 ?   x   : orsign(x + c - c       , x);
+  double c = mulsign(1LL << 52, x);
+  double rint4x = fabsk(4*x) > 1LL << 52 ? (4*x) : orsign(mla(4, x, c) - c, x);
+  double rintx  = fabsk(  x) > 1LL << 52 ?   x   : orsign(x + c - c       , x);
   ret.d = mla(-0.25, rint4x,      x);
   ret.i = mla(-4   , rintx , rint4x);
   return ret;
@@ -2298,8 +2298,8 @@ EXPORT CONST double xround(double d) {
 }
 
 EXPORT CONST double xrint(double d) {
-  double c = mulsign(1L << 52, d);
-  return fabsk(d) > 1L << 52 ? d : orsign(d + c - c, d);
+  double c = mulsign(1LL << 52, d);
+  return fabsk(d) > 1LL << 52 ? d : orsign(d + c - c, d);
 }
 
 EXPORT CONST double xhypot_u05(double x, double y) {
@@ -2429,8 +2429,8 @@ EXPORT CONST double xfmod(double x, double y) {
 }
 
 static INLINE CONST double rintk2(double d) {
-  double c = mulsign(1L << 52, d);
-  return fabsk(d) > 1L << 52 ? d : orsign(d + c - c, d);
+  double c = mulsign(1LL << 52, d);
+  return fabsk(d) > 1LL << 52 ? d : orsign(d + c - c, d);
 }
 
 EXPORT CONST double xremainder(double x, double y) {

--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -746,17 +746,19 @@ typedef struct {
   int32_t i;
 } ddi_t;
 
+static INLINE CONST double orsign(double x, double y) {
+  return longBitsToDouble(doubleToRawLongBits(x) | (doubleToRawLongBits(y) & (1LL << 63)));
+}
+
 static CONST di_t rempisub(double x) {
   // This function is equivalent to :
-  // di_t ret = { x - round(4 * x) * 0.25, (int32_t)(round(4 * x) - round(x) * 4) };
+  // di_t ret = { x - rint(4 * x) * 0.25, (int32_t)(rint(4 * x) - rint(x) * 4) };
   di_t ret;
-  double fr = x - (double)(1LL << 28) * (int32_t)(x * (1.0 / (1LL << 28)));
-  ret.i = ((7 & ((x > 0 ? 4 : 3) + (int32_t)(fr * 8))) - 3) >> 1;
-  fr = fr - 0.25 * (int32_t)(fr * 4 + mulsign(0.5, x));
-  fr = fabsk(fr) > 0.25 ? (fr - mulsign(0.5, x)) : fr;
-  fr = fabsk(fr) > 1e+10 ? 0 : fr;
-  if (fabsk(x) == 0.12499999999999998612) { fr = x; ret.i = 0; }
-  ret.d = fr;
+  double c = mulsign(1L << 52, x);
+  double rint4x = fabsk(4*x) > 1L << 52 ? (4*x) : orsign(mla(4, x, c) - c, x);
+  double rintx  = fabsk(  x) > 1L << 52 ?   x   : orsign(x + c - c       , x);
+  ret.d = mla(-0.25, rint4x,      x);
+  ret.i = mla(-4   , rintx , rint4x);
   return ret;
 }
 
@@ -2296,13 +2298,8 @@ EXPORT CONST double xround(double d) {
 }
 
 EXPORT CONST double xrint(double d) {
-  double x = d + 0.5;
-  double fr = x - (double)(1LL << 31) * (int32_t)(x * (1.0 / (1LL << 31)));
-  int32_t isodd = (1 & (int32_t)fr) != 0;
-  fr = fr - (int32_t)fr;
-  fr = (fr < 0 || (fr == 0 && isodd)) ? fr+1.0 : fr;
-  x = d == 0.50000000000000011102 ? 0 : x;  // nextafter(0.5, 1)
-  return (xisinf(d) || fabsk(d) >= (double)(1LL << 52)) ? d : copysignk(x - fr, d);
+  double c = mulsign(1L << 52, d);
+  return fabsk(d) > 1L << 52 ? d : orsign(d + c - c, d);
 }
 
 EXPORT CONST double xhypot_u05(double x, double y) {
@@ -2432,12 +2429,8 @@ EXPORT CONST double xfmod(double x, double y) {
 }
 
 static INLINE CONST double rintk2(double d) {
-  double x = d + 0.5;
-  double fr = x - (double)(1LL << 31) * (int32_t)(x * (1.0 / (1LL << 31)));
-  int32_t isodd = (1 & (int32_t)fr) != 0;
-  fr = fr - (int32_t)fr;
-  fr = (fr < 0 || (fr == 0 && isodd)) ? fr+1.0 : fr;
-  return (fabsk(d) >= (double)(1LL << 52)) ? d : copysignk(x - fr, d);
+  double c = mulsign(1L << 52, d);
+  return fabsk(d) > 1L << 52 ? d : orsign(d + c - c, d);
 }
 
 EXPORT CONST double xremainder(double x, double y) {

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -359,11 +359,11 @@ static INLINE CONST di_t rempisub(vdouble x) {
   vint vi = vtruncate_vi_vd(vsub_vd_vd_vd(y, vmul_vd_vd_vd(vrint_vd_vd(x), vcast_vd_d(4))));
   di_t ret = { vsub_vd_vd_vd(x, vmul_vd_vd_vd(y, vcast_vd_d(0.25))), vi };
 #else
-  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(1L << 52), x);
-  vdouble rint4x = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(vmul_vd_vd_vd(vcast_vd_d(4), x)), vcast_vd_d(1L << 52)),
+  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(1LL << 52), x);
+  vdouble rint4x = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(vmul_vd_vd_vd(vcast_vd_d(4), x)), vcast_vd_d(1LL << 52)),
 				    vmul_vd_vd_vd(vcast_vd_d(4), x),
 				    vorsign_vd_vd_vd(vsub_vd_vd_vd(vmla_vd_vd_vd_vd(vcast_vd_d(4), x, c), c), x));
-  vdouble rintx  = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(1L << 52)),
+  vdouble rintx  = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(1LL << 52)),
 				    x, vorsign_vd_vd_vd(vsub_vd_vd_vd(vadd_vd_vd_vd(x, c), c), x));
   di_t ret = {
     vmla_vd_vd_vd_vd(vcast_vd_d(-0.25), rint4x, x),
@@ -3124,8 +3124,8 @@ EXPORT CONST VECTOR_CC vdouble xrint(vdouble d) {
 #ifdef FULL_FP_ROUNDING
   return vrint_vd_vd(d);
 #else
-  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(1L << 52), d);
-  return vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1L << 52)),
+  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(1LL << 52), d);
+  return vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1LL << 52)),
 			  d, vorsign_vd_vd_vd(vsub_vd_vd_vd(vadd_vd_vd_vd(d, c), c), d));
 #endif
 }
@@ -3395,8 +3395,8 @@ static INLINE VECTOR_CC vdouble vrintk2_vd_vd(vdouble d) {
 #ifdef FULL_FP_ROUNDING
   return vrint_vd_vd(d);
 #else
-  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(1L << 52), d);
-  return vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1L << 52)),
+  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(1LL << 52), d);
+  return vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1LL << 52)),
 			  d, vorsign_vd_vd_vd(vsub_vd_vd_vd(vadd_vd_vd_vd(d, c), c), d));
 #endif
 }


### PR DESCRIPTION
This patch simplifies rint algorithm that are used when such an instruction is not available.
This patch also replaces sqrt algorithm with FMA.
These changes do not affect performance with recent vector extensions.