### PR TITLE
Add extern C declaration to sleefdft h

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 build_cloud: lithium
-max_jobs: 4
+max_jobs: 2
 image: Visual Studio 2019
 configuration: Release
 environment:

--- a/include/sleefdft.h
+++ b/include/sleefdft.h
@@ -1,6 +1,11 @@
 #ifndef __SLEEFDFT_H__
 #define __SLEEFDFT_H__
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdlib.h>
 #include <stdint.h>
 
@@ -76,5 +81,9 @@ IMPORT void SleefDFT_setPlanFilePath(const char *path, const char *arch, uint64_
 #define SLEEF_PLAN_REFERTOENVVAR (1 << 30)
 
 #undef IMPORT
+
+#ifdef __cplusplus
+}
 #endif
 
+#endif // #ifndef __SLEEFDFT_H__


### PR DESCRIPTION
This patch adds extern "C" declaration to sleefdft.h, as suggested in issue https://github.com/shibatch/sleef/issues/298.