### PR TITLE
Add "extern" to the reference to enableFlushToZero in testerutil.h

### DIFF
--- a/src/libm-tester/testerutil.h
+++ b/src/libm-tester/testerutil.h
@@ -13,7 +13,7 @@
 
 #define M_PIf ((float)M_PI)
 
-int enableFlushToZero;
+extern int enableFlushToZero;
 double flushToZero(double y);
 
 int isnumber(double x);


### PR DESCRIPTION
This patch fixes a small bug in testerutil.h.
This bug makes builds with gcc-10 fail.