### PR TITLE
Make SVE detection fail with gcc-10

### DIFF
--- a/Configure.cmake
+++ b/Configure.cmake
@@ -561,6 +561,9 @@ if(SLEEF_ARCH_AARCH64 AND NOT DISABLE_SVE)
   set (CMAKE_REQUIRED_FLAGS ${FLAGS_ENABLE_SVE})
   CHECK_C_SOURCE_COMPILES("
   #include <arm_sve.h>
+  typedef __sizeless_struct vdouble2 {
+    svfloat64_t x, y;
+  } vdouble2;
   int main() {
     svint32_t r = svdup_n_s32(1); }"
     COMPILER_SUPPORTS_SVE)
@@ -722,6 +725,10 @@ endif()
 
 if (MSVC)
   set(COMPILER_SUPPORTS_OPENMP FALSE)   # At this time, OpenMP is not supported on MSVC
+endif()
+
+if (CMAKE_C_COMPILER MATCHES "clang" AND CMAKE_C_COMPILER_VERSION VERSION_EQUAL 9 AND BUILD_QUAD)
+  message(FATAL_ERROR "Quad library cannot be built with clang-9.")
 endif()
 
 ##

--- a/travis/ppc64el-cc
+++ b/travis/ppc64el-cc
@@ -1,2 +1,0 @@
-#!/bin/sh
-clang-5.0 -target ppc64le-linux-gnu -mvsx -fuse-ld=/usr/powerpc64le-linux-gnu/bin/ld $*


### PR DESCRIPTION
The current SVE helper heavily depends on the sizeless struct, but this seems to be removed from SVE ACLE. We need to use svfloat64x2_t instead of the current double2, but this requires fairly large amount of modification.

Instead of following the latest SVE ACLE, this patch adds a check for availability of __sizeless_struct when detecting compiler support for SVE. Without this patch, gcc-10 fails to build the library for aarch64.

This patch also disable quad support with clang-9. Compilation does not finish with clang-9 if quad support is enabled. This seems to be a bug, and there is no problem with clang-10.