### PR TITLE
Change suffixes of constants

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -19,7 +19,7 @@ EXPORT void Sleef_free(void *ptr) { _aligned_free(ptr); }
 EXPORT uint64_t Sleef_currentTimeMicros() {
   struct __timeb64 t;
   _ftime64(&t);
-  return t.time * 1000000LL + t.millitm*1000;
+  return t.time * INT64_C(1000000) + t.millitm*1000;
 }
 #elif defined(__APPLE__)
 #include <sys/time.h>
@@ -30,7 +30,7 @@ EXPORT void Sleef_free(void *ptr) { free(ptr); }
 EXPORT uint64_t Sleef_currentTimeMicros() {
   struct timeval time;
   gettimeofday(&time, NULL);
-  return (uint64_t)((time.tv_sec * 1000000LL) + time.tv_usec);
+  return (uint64_t)((time.tv_sec * INT64_C(1000000)) + time.tv_usec);
 }
 #else // #if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
 #include <time.h>
@@ -47,7 +47,7 @@ EXPORT void Sleef_free(void *ptr) { free(ptr); }
 EXPORT uint64_t Sleef_currentTimeMicros() {
   struct timespec tp;
   clock_gettime(CLOCK_MONOTONIC, &tp);
-  return (uint64_t)tp.tv_sec * 1000000LL + ((uint64_t)tp.tv_nsec/1000);
+  return (uint64_t)tp.tv_sec * INT64_C(1000000) + ((uint64_t)tp.tv_nsec/1000);
 }
 #endif // #if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER)
 

--- a/src/common/f128util.h
+++ b/src/common/f128util.h
@@ -77,8 +77,8 @@ static char *toBCq(__float128 d) {
   int s = (int)(m >> 127);
   m = d == 0 ? 0 : ((m & ((((__uint128_t)1) << 112)-1)) | ((__uint128_t)1 << 112));
 
-  uint64_t h = m / 10000000000000000000ULL;
-  uint64_t l = m % 10000000000000000000ULL;
+  uint64_t h = m / UINT64_C(10000000000000000000);
+  uint64_t l = m % UINT64_C(10000000000000000000);
 
   char *ptr = frstr[(frstrcnt++) & 15];
   

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -45,7 +45,7 @@
 #define SLEEF_FP_ILOGBNAN ((int)2147483647)
 #endif
 
-#define SLEEF_SNAN (((union { long long int i; double d; }) { .i = 0x7ff0000000000001LL }).d)
+#define SLEEF_SNAN (((union { long long int i; double d; }) { .i = INT64_C(0x7ff0000000000001) }).d)
 #define SLEEF_SNANf (((union { long int i; float f; }) { .i = 0xff800001 }).f)
 
 

--- a/src/libm-tester/tester.c
+++ b/src/libm-tester/tester.c
@@ -3560,7 +3560,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracyNR_d(mpfr_trunc, child_trunc, d, 0);
     {
-      double start = u2d(d2u((double)(1LL << 52))-20), end = u2d(d2u((double)(1LL << 52))+20);
+      double start = u2d(d2u((double)(INT64_C(1) << 52))-20), end = u2d(d2u((double)(INT64_C(1) << 52))+20);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracyNR_d(mpfr_trunc, child_trunc,  d, 0);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracyNR_d(mpfr_trunc, child_trunc, -d, 0);
     }
@@ -3574,7 +3574,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracyNR_d(mpfr_floor, child_floor, d, 0);
     {
-      double start = u2d(d2u((double)(1LL << 52))-20), end = u2d(d2u((double)(1LL << 52))+20);
+      double start = u2d(d2u((double)(INT64_C(1) << 52))-20), end = u2d(d2u((double)(INT64_C(1) << 52))+20);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracyNR_d(mpfr_floor, child_floor,  d, 0);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracyNR_d(mpfr_floor, child_floor, -d, 0);
     }
@@ -3588,7 +3588,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracyNR_d(mpfr_ceil, child_ceil, d, 0);
     {
-      double start = u2d(d2u((double)(1LL << 52))-20), end = u2d(d2u((double)(1LL << 52))+20);
+      double start = u2d(d2u((double)(INT64_C(1) << 52))-20), end = u2d(d2u((double)(INT64_C(1) << 52))+20);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracyNR_d(mpfr_ceil, child_ceil,  d, 0);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracyNR_d(mpfr_ceil, child_ceil, -d, 0);
     }
@@ -3602,7 +3602,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracyNR_d(mpfr_round, child_round, d, 0);
     {
-      double start = u2d(d2u((double)(1LL << 52))-20), end = u2d(d2u((double)(1LL << 52))+20);
+      double start = u2d(d2u((double)(INT64_C(1) << 52))-20), end = u2d(d2u((double)(INT64_C(1) << 52))+20);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracyNR_d(mpfr_round, child_round,  d, 0);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracyNR_d(mpfr_round, child_round, -d, 0);
     }
@@ -3616,7 +3616,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracy_d(mpfr_rint, child_rint, d, 0);
     {
-      double start = u2d(d2u((double)(1LL << 52))-20), end = u2d(d2u((double)(1LL << 52))+20);
+      double start = u2d(d2u((double)(INT64_C(1) << 52))-20), end = u2d(d2u((double)(INT64_C(1) << 52))+20);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracy_d(mpfr_rint, child_rint,  d, 0);
       for(d = start;d <= end;d = u2d(d2u(d)+1)) checkAccuracy_d(mpfr_rint, child_rint, -d, 0);
     }
@@ -4359,7 +4359,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracyNR_f(mpfr_trunc, child_truncf, d, 0);
     {
-      double start = u2f(f2u((double)(1LL << 23))-20), end = u2f(f2u((double)(1LL << 23))+20);
+      double start = u2f(f2u((double)(INT64_C(1) << 23))-20), end = u2f(f2u((double)(INT64_C(1) << 23))+20);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracyNR_f(mpfr_trunc, child_truncf,  d, 0);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracyNR_f(mpfr_trunc, child_truncf, -d, 0);
     }
@@ -4373,7 +4373,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracyNR_f(mpfr_floor, child_floorf, d, 0);
     {
-      double start = u2f(f2u((double)(1LL << 23))-20), end = u2f(f2u((double)(1LL << 23))+20);
+      double start = u2f(f2u((double)(INT64_C(1) << 23))-20), end = u2f(f2u((double)(INT64_C(1) << 23))+20);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracyNR_f(mpfr_floor, child_floorf,  d, 0);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracyNR_f(mpfr_floor, child_floorf, -d, 0);
     }
@@ -4387,7 +4387,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracyNR_f(mpfr_ceil, child_ceilf, d, 0);
     {
-      double start = u2f(f2u((double)(1LL << 23))-20), end = u2f(f2u((double)(1LL << 23))+20);
+      double start = u2f(f2u((double)(INT64_C(1) << 23))-20), end = u2f(f2u((double)(INT64_C(1) << 23))+20);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracyNR_f(mpfr_ceil, child_ceilf,  d, 0);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracyNR_f(mpfr_ceil, child_ceilf, -d, 0);
     }
@@ -4401,7 +4401,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracyNR_f(mpfr_round, child_roundf, d, 0);
     {
-      double start = u2f(f2u((double)(1LL << 23))-20), end = u2f(f2u((double)(1LL << 23))+20);
+      double start = u2f(f2u((double)(INT64_C(1) << 23))-20), end = u2f(f2u((double)(INT64_C(1) << 23))+20);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracyNR_f(mpfr_round, child_roundf,  d, 0);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracyNR_f(mpfr_round, child_roundf, -d, 0);
     }
@@ -4415,7 +4415,7 @@ void do_test() {
     }
     for(d = -10000;d < 10000 && success;d += 2.5) checkAccuracy_f(mpfr_rint, child_rintf, d, 0);
     {
-      double start = u2f(f2u((double)(1LL << 23))-20), end = u2f(f2u((double)(1LL << 23))+20);
+      double start = u2f(f2u((double)(INT64_C(1) << 23))-20), end = u2f(f2u((double)(INT64_C(1) << 23))+20);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracy_f(mpfr_rint, child_rintf,  d, 0);
       for(d = start;d <= end;d = u2f(f2u(d)+1)) checkAccuracy_f(mpfr_rint, child_rintf, -d, 0);
     }

--- a/src/libm-tester/tester3.c
+++ b/src/libm-tester/tester3.c
@@ -36,7 +36,7 @@ typedef __attribute__((vector_size(16))) float  vector_float;
 
 //
 
-#define XNAN  (((union { int64_t u; double d; })  { .u = 0xffffffffffffffffLL }).d)
+#define XNAN  (((union { int64_t u; double d; })  { .u = INT64_C(0xffffffffffffffff) }).d)
 #define XNANf (((union { int32_t u; float d; })  { .u = 0xffffffff }).d)
 
 static INLINE double unifyValue(double x) { x = !(x == x) ? XNAN  : x; return x; }

--- a/src/libm-tester/testerutil.c
+++ b/src/libm-tester/testerutil.c
@@ -84,7 +84,7 @@ int readln(int fd, char *buf, int cnt) {
 static uint64_t xseed;
 
 uint64_t xrand() {
-  xseed = xseed * 6364136223846793005ULL + 1;
+  xseed = xseed * UINT64_C(6364136223846793005) + 1;
   return xseed;
 }
 

--- a/src/libm-tester/testerutil.h
+++ b/src/libm-tester/testerutil.h
@@ -30,7 +30,7 @@ float signf(float d);
 
 int readln(int fd, char *buf, int cnt);
 
-#define XRAND_MAX (0x100000000LL * (double)0x100000000LL)
+#define XRAND_MAX (INT64_C(0x100000000) * (double)INT64_C(0x100000000))
 
 void xsrand(uint64_t s);
 uint64_t xrand();

--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -53,15 +53,15 @@ static INLINE CONST double longBitsToDouble(int64_t i) {
 }
 
 static INLINE CONST double fabsk(double x) {
-  return longBitsToDouble(0x7fffffffffffffffLL & doubleToRawLongBits(x));
+  return longBitsToDouble(INT64_C(0x7fffffffffffffff) & doubleToRawLongBits(x));
 }
 
 static INLINE CONST double mulsign(double x, double y) {
-  return longBitsToDouble(doubleToRawLongBits(x) ^ (doubleToRawLongBits(y) & (1LL << 63)));
+  return longBitsToDouble(doubleToRawLongBits(x) ^ (doubleToRawLongBits(y) & (INT64_C(1) << 63)));
 }
 
 static INLINE CONST double copysignk(double x, double y) {
-  return longBitsToDouble((doubleToRawLongBits(x) & ~(1LL << 63)) ^ (doubleToRawLongBits(y) & (1LL << 63)));
+  return longBitsToDouble((doubleToRawLongBits(x) & ~(INT64_C(1) << 63)) ^ (doubleToRawLongBits(y) & (INT64_C(1) << 63)));
 }
 
 static INLINE CONST double sign(double d) { return mulsign(1, d); }
@@ -80,13 +80,13 @@ static INLINE CONST int xisnegzero(double x) { return doubleToRawLongBits(x) == 
 static INLINE CONST int xisnumber(double x) { return !xisinf(x) && !xisnan(x); }
 
 static INLINE CONST int xisint(double d) {
-  double x = d - (double)(1LL << 31) * (int)(d * (1.0 / (1LL << 31)));
-  return (x == (int)x) || (fabsk(d) >= (double)(1LL << 53));
+  double x = d - (double)(INT64_C(1) << 31) * (int)(d * (1.0 / (INT64_C(1) << 31)));
+  return (x == (int)x) || (fabsk(d) >= (double)(INT64_C(1) << 53));
 }
 
 static INLINE CONST int xisodd(double d) {
-  double x = d - (double)(1LL << 31) * (int)(d * (1.0 / (1LL << 31)));
-  return (1 & (int)x) != 0 && fabsk(d) < (double)(1LL << 53);
+  double x = d - (double)(INT64_C(1) << 31) * (int)(d * (1.0 / (INT64_C(1) << 31)));
+  return (1 & (int)x) != 0 && fabsk(d) < (double)(INT64_C(1) << 53);
 }
 
 static INLINE CONST double pow2i(int q) {
@@ -163,7 +163,7 @@ static int checkfp(double x) {
 #endif
 
 static INLINE CONST double upper(double d) {
-  return longBitsToDouble(doubleToRawLongBits(d) & 0xfffffffff8000000LL);
+  return longBitsToDouble(doubleToRawLongBits(d) & INT64_C(0xfffffffff8000000));
 }
 
 static INLINE CONST Sleef_double2 dd(double h, double l) {
@@ -655,7 +655,7 @@ static Sleef_double2 atan2k_u1(Sleef_double2 y, Sleef_double2 x) {
 }
 
 EXPORT CONST double xatan2_u1(double y, double x) {
-  if (fabsk(x) < 5.5626846462680083984e-309) { y *= (1ULL << 53); x *= (1ULL << 53); } // nexttoward((1.0 / DBL_MAX), 1)
+  if (fabsk(x) < 5.5626846462680083984e-309) { y *= (UINT64_C(1) << 53); x *= (UINT64_C(1) << 53); } // nexttoward((1.0 / DBL_MAX), 1)
   Sleef_double2 d = atan2k_u1(dd(fabsk(y), 0), dd(x, 0));
   double r = d.x + d.y;
 
@@ -747,16 +747,16 @@ typedef struct {
 } ddi_t;
 
 static INLINE CONST double orsign(double x, double y) {
-  return longBitsToDouble(doubleToRawLongBits(x) | (doubleToRawLongBits(y) & (1LL << 63)));
+  return longBitsToDouble(doubleToRawLongBits(x) | (doubleToRawLongBits(y) & (INT64_C(1) << 63)));
 }
 
 static CONST di_t rempisub(double x) {
   // This function is equivalent to :
   // di_t ret = { x - rint(4 * x) * 0.25, (int32_t)(rint(4 * x) - rint(x) * 4) };
   di_t ret;
-  double c = mulsign(1LL << 52, x);
-  double rint4x = fabsk(4*x) > 1LL << 52 ? (4*x) : orsign(mla(4, x, c) - c, x);
-  double rintx  = fabsk(  x) > 1LL << 52 ?   x   : orsign(x + c - c       , x);
+  double c = mulsign(INT64_C(1) << 52, x);
+  double rint4x = fabsk(4*x) > INT64_C(1) << 52 ? (4*x) : orsign(mla(4, x, c) - c, x);
+  double rintx  = fabsk(  x) > INT64_C(1) << 52 ?   x   : orsign(x + c - c       , x);
   ret.d = mla(-0.25, rint4x,      x);
   ret.i = mla(-4   , rintx , rint4x);
   return ret;
@@ -905,8 +905,8 @@ EXPORT CONST double xcos(double d) {
     d = mla(ql, -PI_A2*0.5, d);
     d = mla(ql, -PI_B2*0.5, d);
   } else if (fabsk(d) < TRIGRANGEMAX) {
-    double dqh = trunck(d * (M_1_PI / (1LL << 23)) - 0.5 * (M_1_PI / (1LL << 23)));
-    ql = 2*rintk(d * M_1_PI - 0.5 - dqh * (double)(1LL << 23))+1;
+    double dqh = trunck(d * (M_1_PI / (INT64_C(1) << 23)) - 0.5 * (M_1_PI / (INT64_C(1) << 23)));
+    ql = 2*rintk(d * M_1_PI - 0.5 - dqh * (double)(INT64_C(1) << 23))+1;
     dqh *= 1 << 24;
 
     d = mla(dqh, -PI_A*0.5, d);
@@ -960,8 +960,8 @@ EXPORT CONST double xcos_u1(double d) {
     s = ddadd2_d2_d_d(d, ql * (-PI_A2*0.5));
     s = ddadd_d2_d2_d(s, ql * (-PI_B2*0.5));
   } else if (d < TRIGRANGEMAX) {
-    double dqh = trunck(d * (M_1_PI / (1LL << 23)) - 0.5 * (M_1_PI / (1LL << 23)));
-    ql = 2*rintk(d * M_1_PI - 0.5 - dqh * (double)(1LL << 23))+1;
+    double dqh = trunck(d * (M_1_PI / (INT64_C(1) << 23)) - 0.5 * (M_1_PI / (INT64_C(1) << 23)));
+    ql = 2*rintk(d * M_1_PI - 0.5 - dqh * (double)(INT64_C(1) << 23))+1;
     dqh *= 1 << 24;
 
     u = mla(dqh, -PI_A*0.5, d);
@@ -1440,7 +1440,7 @@ EXPORT CONST double xlog(double d) {
   int e;
 
   int o = d < DBL_MIN;
-  if (o) d *= (double)(1LL << 32) * (double)(1LL << 32);
+  if (o) d *= (double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32);
   
   e = ilogb2k(d * (1.0/0.75));
   m = ldexp3k(d, -e);
@@ -1533,7 +1533,7 @@ static INLINE CONST Sleef_double2 logk(double d) {
   int e;
 
   int o = d < DBL_MIN;
-  if (o) d *= (double)(1LL << 32) * (double)(1LL << 32);
+  if (o) d *= (double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32);
   
   e = ilogb2k(d * (1.0/0.75));
   m = ldexp3k(d, -e);
@@ -1572,7 +1572,7 @@ EXPORT CONST double xlog_u1(double d) {
   int e;
 
   int o = d < DBL_MIN;
-  if (o) d *= (double)(1LL << 32) * (double)(1LL << 32);
+  if (o) d *= (double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32);
       
   e = ilogb2k(d * (1.0/0.75));
   m = ldexp3k(d, -e);
@@ -2041,7 +2041,7 @@ EXPORT CONST double xlog10(double d) {
   int e;
 
   int o = d < DBL_MIN;
-  if (o) d *= (double)(1LL << 32) * (double)(1LL << 32);
+  if (o) d *= (double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32);
       
   e = ilogb2k(d * (1.0/0.75));
   m = ldexp3k(d, -e);
@@ -2080,7 +2080,7 @@ EXPORT CONST double xlog2(double d) {
   int e;
 
   int o = d < DBL_MIN;
-  if (o) d *= (double)(1LL << 32) * (double)(1LL << 32);
+  if (o) d *= (double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32);
       
   e = ilogb2k(d * (1.0/0.75));
   m = ldexp3k(d, -e);
@@ -2117,7 +2117,7 @@ EXPORT CONST double xlog2_u35(double d) {
   int e;
 
   int o = d < DBL_MIN;
-  if (o) d *= (double)(1LL << 32) * (double)(1LL << 32);
+  if (o) d *= (double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32);
       
   e = ilogb2k(d * (1.0/0.75));
   m = ldexp3k(d, -e);
@@ -2153,7 +2153,7 @@ EXPORT CONST double xlog1p(double d) {
   double dp1 = d + 1;
   
   int o = dp1 < DBL_MIN;
-  if (o) dp1 *= (double)(1LL << 32) * (double)(1LL << 32);
+  if (o) dp1 *= (double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32);
       
   e = ilogb2k(dp1 * (1.0/0.75));
 
@@ -2194,14 +2194,14 @@ EXPORT CONST double xlog1p(double d) {
 EXPORT CONST double xfma(double x, double y, double z) {
   double h2 = x * y + z, q = 1;
   if (fabsk(h2) < 1e-300) {
-    const double c0 = 1ULL << 54, c1 = c0 * c0, c2 = c1 * c1;
+    const double c0 = UINT64_C(1) << 54, c1 = c0 * c0, c2 = c1 * c1;
     x *= c1;
     y *= c1;
     z *= c2;
     q = 1.0 / c2;
   }
   if (fabsk(h2) > 1e+299) {
-    const double c0 = 1ULL << 54, c1 = c0 * c0, c2 = c1 * c1;
+    const double c0 = UINT64_C(1) << 54, c1 = c0 * c0, c2 = c1 * c1;
     x *= 1.0 / c1;
     y *= 1.0 / c1;
     z *= 1. / c2;
@@ -2268,38 +2268,38 @@ EXPORT CONST double xfdim(double x, double y) {
 }
 
 EXPORT CONST double xtrunc(double x) {
-  double fr = x - (double)(1LL << 31) * (int32_t)(x * (1.0 / (1LL << 31)));
+  double fr = x - (double)(INT64_C(1) << 31) * (int32_t)(x * (1.0 / (INT64_C(1) << 31)));
   fr = fr - (int32_t)fr;
-  return (xisinf(x) || fabsk(x) >= (double)(1LL << 52)) ? x : copysignk(x - fr, x);
+  return (xisinf(x) || fabsk(x) >= (double)(INT64_C(1) << 52)) ? x : copysignk(x - fr, x);
 }
 
 EXPORT CONST double xfloor(double x) {
-  double fr = x - (double)(1LL << 31) * (int32_t)(x * (1.0 / (1LL << 31)));
+  double fr = x - (double)(INT64_C(1) << 31) * (int32_t)(x * (1.0 / (INT64_C(1) << 31)));
   fr = fr - (int32_t)fr;
   fr = fr < 0 ? fr+1.0 : fr;
-  return (xisinf(x) || fabsk(x) >= (double)(1LL << 52)) ? x : copysignk(x - fr, x);
+  return (xisinf(x) || fabsk(x) >= (double)(INT64_C(1) << 52)) ? x : copysignk(x - fr, x);
 }
 
 EXPORT CONST double xceil(double x) {
-  double fr = x - (double)(1LL << 31) * (int32_t)(x * (1.0 / (1LL << 31)));
+  double fr = x - (double)(INT64_C(1) << 31) * (int32_t)(x * (1.0 / (INT64_C(1) << 31)));
   fr = fr - (int32_t)fr;
   fr = fr <= 0 ? fr : fr-1.0;
-  return (xisinf(x) || fabsk(x) >= (double)(1LL << 52)) ? x : copysignk(x - fr, x);
+  return (xisinf(x) || fabsk(x) >= (double)(INT64_C(1) << 52)) ? x : copysignk(x - fr, x);
 }
 
 EXPORT CONST double xround(double d) {
   double x = d + 0.5;
-  double fr = x - (double)(1LL << 31) * (int32_t)(x * (1.0 / (1LL << 31)));
+  double fr = x - (double)(INT64_C(1) << 31) * (int32_t)(x * (1.0 / (INT64_C(1) << 31)));
   fr = fr - (int32_t)fr;
   if (fr == 0 && x <= 0) x--;
   fr = fr < 0 ? fr+1.0 : fr;
   x = d == 0.49999999999999994449 ? 0 : x;  // nextafter(0.5, 0)
-  return (xisinf(d) || fabsk(d) >= (double)(1LL << 52)) ? d : copysignk(x - fr, d);
+  return (xisinf(d) || fabsk(d) >= (double)(INT64_C(1) << 52)) ? d : copysignk(x - fr, d);
 }
 
 EXPORT CONST double xrint(double d) {
-  double c = mulsign(1LL << 52, d);
-  return fabsk(d) > 1LL << 52 ? d : orsign(d + c - c, d);
+  double c = mulsign(INT64_C(1) << 52, d);
+  return fabsk(d) > INT64_C(1) << 52 ? d : orsign(d + c - c, d);
 }
 
 EXPORT CONST double xhypot_u05(double x, double y) {
@@ -2308,7 +2308,7 @@ EXPORT CONST double xhypot_u05(double x, double y) {
   double min = fmink(x, y), n = min;
   double max = fmaxk(x, y), d = max;
 
-  if (max < DBL_MIN) { n *= 1ULL << 54; d *= 1ULL << 54; }
+  if (max < DBL_MIN) { n *= UINT64_C(1) << 54; d *= UINT64_C(1) << 54; }
   Sleef_double2 t = dddiv_d2_d2_d2(dd(n, 0), dd(d, 0));
   t = ddmul_d2_d2_d(ddsqrt_d2_d2(ddadd2_d2_d2_d(ddsqu_d2_d2(t), 1)), max);
   double ret = t.x + t.y;
@@ -2342,11 +2342,11 @@ EXPORT CONST double xnextafter(double x, double y) {
   x = x == 0 ? mulsign(0, y) : x;
   cx.f = x;
   int c = (cx.i < 0) == (y < x);
-  if (c) cx.i = -(cx.i ^ (1ULL << 63));
+  if (c) cx.i = -(cx.i ^ (UINT64_C(1) << 63));
 
   if (x != y) cx.i--;
 
-  if (c) cx.i = -(cx.i ^ (1ULL << 63));
+  if (c) cx.i = -(cx.i ^ (UINT64_C(1) << 63));
 
   if (cx.f == 0 && x != 0) cx.f = mulsign(0, x);
   if (x == 0 && y == 0) cx.f = y;
@@ -2361,11 +2361,11 @@ EXPORT CONST double xfrfrexp(double x) {
     uint64_t u;
   } cx;
 
-  if (fabsk(x) < DBL_MIN) x *= (1ULL << 63);
+  if (fabsk(x) < DBL_MIN) x *= (UINT64_C(1) << 63);
   
   cx.f = x;
-  cx.u &= ~0x7ff0000000000000ULL;
-  cx.u |=  0x3fe0000000000000ULL;
+  cx.u &= ~UINT64_C(0x7ff0000000000000);
+  cx.u |=  UINT64_C(0x3fe0000000000000);
 
   if (xisinf(x)) cx.f = mulsign(SLEEF_INFINITY, x);
   if (x == 0) cx.f = x;
@@ -2381,7 +2381,7 @@ EXPORT CONST int xexpfrexp(double x) {
 
   int ret = 0;
   
-  if (fabsk(x) < DBL_MIN) { x *= (1ULL << 63); ret = -63; }
+  if (fabsk(x) < DBL_MIN) { x *= (UINT64_C(1) << 63); ret = -63; }
   
   cx.f = x;
   ret += (int32_t)(((cx.u >> 52) & 0x7ff)) - 0x3fe;
@@ -2396,17 +2396,17 @@ static INLINE CONST double toward0(double d) {
 }
 
 static INLINE CONST double removelsb(double d) {
-  return longBitsToDouble(doubleToRawLongBits(d) & 0xfffffffffffffffeLL);
+  return longBitsToDouble(doubleToRawLongBits(d) & INT64_C(0xfffffffffffffffe));
 }
 
 static INLINE CONST double ptrunc(double x) {
-  double fr = mla(-(double)(1LL << 31), (int32_t)(x * (1.0 / (1LL << 31))), x);
-  return fabsk(x) >= (double)(1LL << 52) ? x : (x - (fr - (int32_t)fr));
+  double fr = mla(-(double)(INT64_C(1) << 31), (int32_t)(x * (1.0 / (INT64_C(1) << 31))), x);
+  return fabsk(x) >= (double)(INT64_C(1) << 52) ? x : (x - (fr - (int32_t)fr));
 }
 
 EXPORT CONST double xfmod(double x, double y) {
   double n = fabsk(x), d = fabsk(y), s = 1, q;
-  if (d < DBL_MIN) { n *= 1ULL << 54; d *= 1ULL << 54; s = 1.0 / (1ULL << 54); }
+  if (d < DBL_MIN) { n *= UINT64_C(1) << 54; d *= UINT64_C(1) << 54; s = 1.0 / (UINT64_C(1) << 54); }
   Sleef_double2 r = dd(n, 0);
   double rd = toward0(1.0 / d);
   
@@ -2429,13 +2429,13 @@ EXPORT CONST double xfmod(double x, double y) {
 }
 
 static INLINE CONST double rintk2(double d) {
-  double c = mulsign(1LL << 52, d);
-  return fabsk(d) > 1LL << 52 ? d : orsign(d + c - c, d);
+  double c = mulsign(INT64_C(1) << 52, d);
+  return fabsk(d) > INT64_C(1) << 52 ? d : orsign(d + c - c, d);
 }
 
 EXPORT CONST double xremainder(double x, double y) {
   double n = fabsk(x), d = fabsk(y), s = 1, q;
-  if (d < DBL_MIN*2) { n *= 1ULL << 54; d *= 1ULL << 54; s = 1.0 / (1ULL << 54); }
+  if (d < DBL_MIN*2) { n *= UINT64_C(1) << 54; d *= UINT64_C(1) << 54; s = 1.0 / (UINT64_C(1) << 54); }
   double rd = 1.0 / d;
   Sleef_double2 r = dd(n, 0);
   int qisodd = 0;
@@ -2459,9 +2459,9 @@ EXPORT CONST double xremainder(double x, double y) {
 }
 
 EXPORT CONST Sleef_double2 xmodf(double x) {
-  double fr = x - (double)(1LL << 31) * (int32_t)(x * (1.0 / (1LL << 31)));
+  double fr = x - (double)(INT64_C(1) << 31) * (int32_t)(x * (1.0 / (INT64_C(1) << 31)));
   fr = fr - (int32_t)fr;
-  fr = fabsk(x) >= (double)(1LL << 52) ? 0 : fr;
+  fr = fabsk(x) >= (double)(INT64_C(1) << 52) ? 0 : fr;
   Sleef_double2 ret = { copysignk(fr, x), copysignk(x - fr, x) };
   return ret;
 }
@@ -2533,9 +2533,9 @@ static CONST dd2 gammak(double a) {
     (oref ? ddadd2_d2_d2_d2(dd(1.1447298858494001639, 1.026595116270782638e-17), ddneg_d2_d2(clc)) : clc); // log(M_PI)
   clln = otiny ? dd(1, 0) : (oref ? clln : clld);
 
-  if (oref) x = ddmul_d2_d2_d2(clld, sinpik(a - (double)(1LL << 28) * (int32_t)(a * (1.0 / (1LL << 28)))));
+  if (oref) x = ddmul_d2_d2_d2(clld, sinpik(a - (double)(INT64_C(1) << 28) * (int32_t)(a * (1.0 / (INT64_C(1) << 28)))));
 
-  clld = otiny ? dd(a*((1LL << 60)*(double)(1LL << 60)), 0) : (oref ? x : y);
+  clld = otiny ? dd(a*((INT64_C(1) << 60)*(double)(INT64_C(1) << 60)), 0) : (oref ? x : y);
 
   dd2 ret = { clc, dddiv_d2_d2_d2(clln, clld) };
 

--- a/src/libm/sleefqp.c
+++ b/src/libm/sleefqp.c
@@ -38,7 +38,7 @@ static INLINE CONST Sleef_quad xfabsq(Sleef_quad x) {
   } cnv;
 
   cnv.q = x;
-  cnv.u[1] &= 0x7fffffffffffffffULL;
+  cnv.u[1] &= UINT64_C(0x7fffffffffffffff);
   return cnv.q;
 }
 
@@ -58,7 +58,7 @@ static INLINE CONST Sleef_quad upperq(Sleef_quad d) {
   } cnv;
 
   cnv.q = d;
-  cnv.u[0] &= ~((1ULL << (112/2+1)) - 1);
+  cnv.u[0] &= ~((UINT64_C(1) << (112/2+1)) - 1);
   return cnv.q;
 }
 

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -319,10 +319,10 @@ static INLINE CONST VECTOR_CC vopmask visint_vo_vd(vdouble d) {
 #ifdef FULL_FP_ROUNDING
   return veq_vo_vd_vd(vtruncate_vd_vd(d), d);
 #else
-  vdouble x = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0 / (1LL << 31))));
-  x = vmla_vd_vd_vd_vd(vcast_vd_d(-(double)(1LL << 31)), x, d);
+  vdouble x = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0 / (INT64_C(1) << 31))));
+  x = vmla_vd_vd_vd_vd(vcast_vd_d(-(double)(INT64_C(1) << 31)), x, d);
   return vor_vo_vo_vo(veq_vo_vd_vd(vtruncate_vd_vd(x), x),
-		      vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1LL << 53)));
+		      vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(INT64_C(1) << 53)));
 #endif
 }
 
@@ -331,11 +331,11 @@ static INLINE CONST VECTOR_CC vopmask visodd_vo_vd(vdouble d) {
   vdouble x = vmul_vd_vd_vd(d, vcast_vd_d(0.5));
   return vneq_vo_vd_vd(vtruncate_vd_vd(x), x);
 #else
-  vdouble x = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0 / (1LL << 31))));
-  x = vmla_vd_vd_vd_vd(vcast_vd_d(-(double)(1LL << 31)), x, d);
+  vdouble x = vtruncate_vd_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0 / (INT64_C(1) << 31))));
+  x = vmla_vd_vd_vd_vd(vcast_vd_d(-(double)(INT64_C(1) << 31)), x, d);
 
   return vand_vo_vo_vo(vcast_vo64_vo32(veq_vo_vi_vi(vand_vi_vi_vi(vtruncate_vi_vd(x), vcast_vi_i(1)), vcast_vi_i(1))),
-		       vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1LL << 53)));
+		       vlt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(INT64_C(1) << 53)));
 #endif
 }
 
@@ -391,11 +391,11 @@ static INLINE CONST di_t rempisub(vdouble x) {
   vint vi = vtruncate_vi_vd(vsub_vd_vd_vd(y, vmul_vd_vd_vd(vrint_vd_vd(x), vcast_vd_d(4))));
   return disetdi_di_vd_vi(vsub_vd_vd_vd(x, vmul_vd_vd_vd(y, vcast_vd_d(0.25))), vi);
 #else
-  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(1LL << 52), x);
-  vdouble rint4x = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(vmul_vd_vd_vd(vcast_vd_d(4), x)), vcast_vd_d(1LL << 52)),
+  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(INT64_C(1) << 52), x);
+  vdouble rint4x = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(vmul_vd_vd_vd(vcast_vd_d(4), x)), vcast_vd_d(INT64_C(1) << 52)),
 				    vmul_vd_vd_vd(vcast_vd_d(4), x),
 				    vorsign_vd_vd_vd(vsub_vd_vd_vd(vmla_vd_vd_vd_vd(vcast_vd_d(4), x, c), c), x));
-  vdouble rintx  = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(1LL << 52)),
+  vdouble rintx  = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(INT64_C(1) << 52)),
 				    x, vorsign_vd_vd_vd(vsub_vd_vd_vd(vadd_vd_vd_vd(x, c), c), x));
   return disetdi_di_vd_vi(vmla_vd_vd_vd_vd(vcast_vd_d(-0.25), rint4x, x),
 			  vtruncate_vi_vd(vmla_vd_vd_vd_vd(vcast_vd_d(-4), rintx, rint4x)));
@@ -1426,9 +1426,9 @@ TYPE2_FUNCATR VECTOR_CC vdouble2 XSINCOSPI_U35(vdouble d) {
 }
 
 TYPE6_FUNCATR VECTOR_CC vdouble2 XMODF(vdouble x) {
-  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(1LL << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (1LL << 31)))))));
+  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 31)))))));
   fr = vsub_vd_vd_vd(fr, vcast_vd_vi(vtruncate_vi_vd(fr)));
-  fr = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(1LL << 52)), vcast_vd_d(0), fr);
+  fr = vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(INT64_C(1) << 52)), vcast_vd_d(0), fr);
 
   vdouble2 ret;
 
@@ -1958,8 +1958,8 @@ EXPORT CONST VECTOR_CC vdouble xatan2(vdouble y, vdouble x) {
 
 EXPORT CONST VECTOR_CC vdouble xatan2_u1(vdouble y, vdouble x) {
   vopmask o = vlt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(5.5626846462680083984e-309)); // nexttoward((1.0 / DBL_MAX), 1)
-  x = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(x, vcast_vd_d(1ULL << 53)), x);
-  y = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(y, vcast_vd_d(1ULL << 53)), y);
+  x = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(x, vcast_vd_d(UINT64_C(1) << 53)), x);
+  y = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(y, vcast_vd_d(UINT64_C(1) << 53)), y);
 
   vdouble2 d = atan2k_u1(vcast_vd2_vd_vd(vabs_vd_vd(y), vcast_vd_d(0)), vcast_vd2_vd_vd(x, vcast_vd_d(0)));
   vdouble r = vadd_vd_vd_vd(vd2getx_vd_vd2(d), vd2gety_vd_vd2(d));
@@ -2159,7 +2159,7 @@ EXPORT CONST VECTOR_CC vdouble xlog(vdouble d) {
   
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vd_vd(d, vcast_vd_d(DBL_MIN));
-  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(1LL << 32) * (double)(1LL << 32))), d);
+  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32))), d);
   vint e = vilogb2k_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0/0.75)));
   m = vldexp3_vd_vd_vi(d, vneg_vi_vi(e));
   e = vsel_vi_vo_vi_vi(vcast_vo32_vo64(o), vsub_vi_vi_vi(e, vcast_vi_i(64)), e);
@@ -2283,7 +2283,7 @@ static INLINE CONST VECTOR_CC vdouble2 logk(vdouble d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vd_vd(d, vcast_vd_d(DBL_MIN));
-  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(1LL << 32) * (double)(1LL << 32))), d);
+  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32))), d);
   vint e = vilogb2k_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0/0.75)));
   m = vldexp3_vd_vd_vi(d, vneg_vi_vi(e));
   e = vsel_vi_vo_vi_vi(vcast_vo32_vo64(o), vsub_vi_vi_vi(e, vcast_vi_i(64)), e);
@@ -2330,7 +2330,7 @@ EXPORT CONST VECTOR_CC vdouble xlog_u1(vdouble d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vd_vd(d, vcast_vd_d(DBL_MIN));
-  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(1LL << 32) * (double)(1LL << 32))), d);
+  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32))), d);
   vint e = vilogb2k_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0/0.75)));
   m = vldexp3_vd_vd_vi(d, vneg_vi_vi(e));
   e = vsel_vi_vo_vi_vi(vcast_vo32_vo64(o), vsub_vi_vi_vi(e, vcast_vi_i(64)), e);
@@ -2885,7 +2885,7 @@ EXPORT CONST VECTOR_CC vdouble xlog10(vdouble d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vd_vd(d, vcast_vd_d(DBL_MIN));
-  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(1LL << 32) * (double)(1LL << 32))), d);
+  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32))), d);
   vint e = vilogb2k_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0/0.75)));
   m = vldexp3_vd_vd_vi(d, vneg_vi_vi(e));
   e = vsel_vi_vo_vi_vi(vcast_vo32_vo64(o), vsub_vi_vi_vi(e, vcast_vi_i(64)), e);
@@ -2936,7 +2936,7 @@ EXPORT CONST VECTOR_CC vdouble xlog2(vdouble d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vd_vd(d, vcast_vd_d(DBL_MIN));
-  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(1LL << 32) * (double)(1LL << 32))), d);
+  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32))), d);
   vint e = vilogb2k_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0/0.75)));
   m = vldexp3_vd_vd_vi(d, vneg_vi_vi(e));
   e = vsel_vi_vo_vi_vi(vcast_vo32_vo64(o), vsub_vi_vi_vi(e, vcast_vi_i(64)), e);
@@ -2987,7 +2987,7 @@ EXPORT CONST VECTOR_CC vdouble xlog2_u35(vdouble d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vd_vd(d, vcast_vd_d(DBL_MIN));
-  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(1LL << 32) * (double)(1LL << 32))), d);
+  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d((double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32))), d);
   vint e = vilogb2k_vi_vd(vmul_vd_vd_vd(d, vcast_vd_d(1.0/0.75)));
   m = vldexp3_vd_vd_vi(d, vneg_vi_vi(e));
   e = vsel_vi_vo_vi_vi(vcast_vo32_vo64(o), vsub_vi_vi_vi(e, vcast_vi_i(64)), e);
@@ -3037,7 +3037,7 @@ EXPORT CONST VECTOR_CC vdouble xlog1p(vdouble d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vd_vd(dp1, vcast_vd_d(DBL_MIN));
-  dp1 = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(dp1, vcast_vd_d((double)(1LL << 32) * (double)(1LL << 32))), dp1);
+  dp1 = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(dp1, vcast_vd_d((double)(INT64_C(1) << 32) * (double)(INT64_C(1) << 32))), dp1);
   vint e = vilogb2k_vi_vd(vmul_vd_vd_vd(dp1, vcast_vd_d(1.0/0.75)));
   t = vldexp3_vd_vd_vi(vcast_vd_d(1), vneg_vi_vi(e));
   m = vmla_vd_vd_vd_vd(d, t, vsub_vd_vd_vd(t, vcast_vd_d(1)));
@@ -3111,42 +3111,42 @@ EXPORT CONST VECTOR_CC vdouble xtrunc(vdouble x) {
 #ifdef FULL_FP_ROUNDING
   return vtruncate_vd_vd(x);
 #else
-  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(1LL << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (1LL << 31)))))));
+  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 31)))))));
   fr = vsub_vd_vd_vd(fr, vcast_vd_vi(vtruncate_vi_vd(fr)));
-  return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(x), vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(1LL << 52))), x, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), x));
+  return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(x), vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(INT64_C(1) << 52))), x, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), x));
 #endif
 }
 
 EXPORT CONST VECTOR_CC vdouble xfloor(vdouble x) {
-  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(1LL << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (1LL << 31)))))));
+  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 31)))))));
   fr = vsub_vd_vd_vd(fr, vcast_vd_vi(vtruncate_vi_vd(fr)));
   fr = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(fr, vcast_vd_d(0)), vadd_vd_vd_vd(fr, vcast_vd_d(1.0)), fr);
-  return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(x), vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(1LL << 52))), x, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), x));
+  return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(x), vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(INT64_C(1) << 52))), x, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), x));
 }
 
 EXPORT CONST VECTOR_CC vdouble xceil(vdouble x) {
-  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(1LL << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (1LL << 31)))))));
+  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 31)))))));
   fr = vsub_vd_vd_vd(fr, vcast_vd_vi(vtruncate_vi_vd(fr)));
   fr = vsel_vd_vo_vd_vd(vle_vo_vd_vd(fr, vcast_vd_d(0)), fr, vsub_vd_vd_vd(fr, vcast_vd_d(1.0)));
-  return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(x), vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(1LL << 52))), x, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), x));
+  return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(x), vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(INT64_C(1) << 52))), x, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), x));
 }
 
 EXPORT CONST VECTOR_CC vdouble xround(vdouble d) {
   vdouble x = vadd_vd_vd_vd(d, vcast_vd_d(0.5));
-  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(1LL << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (1LL << 31)))))));
+  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 31)))))));
   fr = vsub_vd_vd_vd(fr, vcast_vd_vi(vtruncate_vi_vd(fr)));
   x = vsel_vd_vo_vd_vd(vand_vo_vo_vo(vle_vo_vd_vd(x, vcast_vd_d(0)), veq_vo_vd_vd(fr, vcast_vd_d(0))), vsub_vd_vd_vd(x, vcast_vd_d(1.0)), x);
   fr = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(fr, vcast_vd_d(0)), vadd_vd_vd_vd(fr, vcast_vd_d(1.0)), fr);
   x = vsel_vd_vo_vd_vd(veq_vo_vd_vd(d, vcast_vd_d(0.49999999999999994449)), vcast_vd_d(0), x);
-  return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(d), vge_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1LL << 52))), d, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), d));
+  return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(d), vge_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(INT64_C(1) << 52))), d, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), d));
 }
 
 EXPORT CONST VECTOR_CC vdouble xrint(vdouble d) {
 #ifdef FULL_FP_ROUNDING
   return vrint_vd_vd(d);
 #else
-  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(1LL << 52), d);
-  return vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1LL << 52)),
+  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(INT64_C(1) << 52), d);
+  return vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(INT64_C(1) << 52)),
 			  d, vorsign_vd_vd_vd(vsub_vd_vd_vd(vadd_vd_vd_vd(d, c), c), d));
 #endif
 }
@@ -3183,7 +3183,7 @@ EXPORT CONST VECTOR_CC vdouble xnextafter(vdouble x, vdouble y) {
 }
 
 EXPORT CONST VECTOR_CC vdouble xfrfrexp(vdouble x) {
-  x = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(DBL_MIN)), vmul_vd_vd_vd(x, vcast_vd_d(1ULL << 63)), x);
+  x = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(DBL_MIN)), vmul_vd_vd_vd(x, vcast_vd_d(UINT64_C(1) << 63)), x);
 
   vmask xm = vreinterpret_vm_vd(x);
   xm = vand_vm_vm_vm(xm, vcast_vm_i_i(~0x7ff00000, ~0));
@@ -3198,7 +3198,7 @@ EXPORT CONST VECTOR_CC vdouble xfrfrexp(vdouble x) {
 }
 
 EXPORT CONST VECTOR_CC vint xexpfrexp(vdouble x) {
-  x = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(DBL_MIN)), vmul_vd_vd_vd(x, vcast_vd_d(1ULL << 63)), x);
+  x = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(DBL_MIN)), vmul_vd_vd_vd(x, vcast_vd_d(UINT64_C(1) << 63)), x);
 
   vint ret = vcastu_vi_vi2(vreinterpret_vi2_vd(x));
   ret = vsub_vi_vi_vi(vand_vi_vi_vi(vsrl_vi_vi_i(ret, 20), vcast_vi_i(0x7ff)), vcast_vi_i(0x3fe));
@@ -3215,7 +3215,7 @@ EXPORT CONST VECTOR_CC vdouble xfma(vdouble x, vdouble y, vdouble z) {
   vdouble h2 = vadd_vd_vd_vd(vmul_vd_vd_vd(x, y), z), q = vcast_vd_d(1);
   vopmask o = vlt_vo_vd_vd(vabs_vd_vd(h2), vcast_vd_d(1e-300));
   {
-    const double c0 = 1ULL << 54, c1 = c0 * c0, c2 = c1 * c1;
+    const double c0 = UINT64_C(1) << 54, c1 = c0 * c0, c2 = c1 * c1;
     x = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(x, vcast_vd_d(c1)), x);
     y = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(y, vcast_vd_d(c1)), y);
     z = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(z, vcast_vd_d(c2)), z);
@@ -3223,7 +3223,7 @@ EXPORT CONST VECTOR_CC vdouble xfma(vdouble x, vdouble y, vdouble z) {
   }
   o = vgt_vo_vd_vd(vabs_vd_vd(h2), vcast_vd_d(1e+300));
   {
-    const double c0 = 1ULL << 54, c1 = c0 * c0, c2 = c1 * c1;
+    const double c0 = UINT64_C(1) << 54, c1 = c0 * c0, c2 = c1 * c1;
     x = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(x, vcast_vd_d(1.0 / c1)), x);
     y = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(y, vcast_vd_d(1.0 / c1)), y);
     z = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(z, vcast_vd_d(1.0 / c2)), z);
@@ -3332,8 +3332,8 @@ EXPORT CONST VECTOR_CC vdouble xhypot_u05(vdouble x, vdouble y) {
   vdouble max = vmax_vd_vd_vd(x, y), d = max;
 
   vopmask o = vlt_vo_vd_vd(max, vcast_vd_d(DBL_MIN));
-  n = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(n, vcast_vd_d(1ULL << 54)), n);
-  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d(1ULL << 54)), d);
+  n = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(n, vcast_vd_d(UINT64_C(1) << 54)), n);
+  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d(UINT64_C(1) << 54)), d);
 
   vdouble2 t = dddiv_vd2_vd2_vd2(vcast_vd2_vd_vd(n, vcast_vd_d(0)), vcast_vd2_vd_vd(d, vcast_vd_d(0)));
   t = ddmul_vd2_vd2_vd(ddsqrt_vd2_vd2(ddadd2_vd2_vd2_vd(ddsqu_vd2_vd2(t), vcast_vd_d(1))), max);
@@ -3370,9 +3370,9 @@ static INLINE CONST VECTOR_CC vdouble vptrunc(vdouble x) { // round to integer t
 #ifdef FULL_FP_ROUNDING
   return vtruncate_vd_vd(x);
 #else
-  vdouble fr = vmla_vd_vd_vd_vd(vcast_vd_d(-(double)(1LL << 31)), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (1LL << 31))))), x);
+  vdouble fr = vmla_vd_vd_vd_vd(vcast_vd_d(-(double)(INT64_C(1) << 31)), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 31))))), x);
   fr = vsub_vd_vd_vd(fr, vcast_vd_vi(vtruncate_vi_vd(fr)));
-  return vsel_vd_vo_vd_vd(vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(1LL << 52)), x, vsub_vd_vd_vd(x, fr));
+  return vsel_vd_vo_vd_vd(vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(INT64_C(1) << 52)), x, vsub_vd_vd_vd(x, fr));
 #endif
 }
 
@@ -3380,9 +3380,9 @@ static INLINE CONST VECTOR_CC vdouble vptrunc(vdouble x) { // round to integer t
 EXPORT CONST VECTOR_CC vdouble xfmod(vdouble x, vdouble y) {
   vdouble n = vabs_vd_vd(x), d = vabs_vd_vd(y), s = vcast_vd_d(1), q;
   vopmask o = vlt_vo_vd_vd(d, vcast_vd_d(DBL_MIN));
-  n = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(n, vcast_vd_d(1ULL << 54)), n);
-  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d(1ULL << 54)), d);
-  s  = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(s , vcast_vd_d(1.0 / (1ULL << 54))), s);
+  n = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(n, vcast_vd_d(UINT64_C(1) << 54)), n);
+  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d(UINT64_C(1) << 54)), d);
+  s  = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(s , vcast_vd_d(1.0 / (UINT64_C(1) << 54))), s);
   vdouble2 r = vcast_vd2_vd_vd(n, vcast_vd_d(0));
   vdouble rd = vtoward0(vrec_vd_vd(d));
 
@@ -3416,8 +3416,8 @@ static INLINE VECTOR_CC vdouble vrintk2_vd_vd(vdouble d) {
 #ifdef FULL_FP_ROUNDING
   return vrint_vd_vd(d);
 #else
-  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(1LL << 52), d);
-  return vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(1LL << 52)),
+  vdouble c = vmulsign_vd_vd_vd(vcast_vd_d(INT64_C(1) << 52), d);
+  return vsel_vd_vo_vd_vd(vgt_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(INT64_C(1) << 52)),
 			  d, vorsign_vd_vd_vd(vsub_vd_vd_vd(vadd_vd_vd_vd(d, c), c), d));
 #endif
 }
@@ -3425,9 +3425,9 @@ static INLINE VECTOR_CC vdouble vrintk2_vd_vd(vdouble d) {
 EXPORT CONST VECTOR_CC vdouble xremainder(vdouble x, vdouble y) {
   vdouble n = vabs_vd_vd(x), d = vabs_vd_vd(y), s = vcast_vd_d(1), q;
   vopmask o = vlt_vo_vd_vd(d, vcast_vd_d(DBL_MIN*2));
-  n = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(n, vcast_vd_d(1ULL << 54)), n);
-  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d(1ULL << 54)), d);
-  s  = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(s , vcast_vd_d(1.0 / (1ULL << 54))), s);
+  n = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(n, vcast_vd_d(UINT64_C(1) << 54)), n);
+  d = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(d, vcast_vd_d(UINT64_C(1) << 54)), d);
+  s  = vsel_vd_vo_vd_vd(o, vmul_vd_vd_vd(s , vcast_vd_d(1.0 / (UINT64_C(1) << 54))), s);
   vdouble rd = vrec_vd_vd(d);
   vdouble2 r = vcast_vd2_vd_vd(n, vcast_vd_d(0));
   vopmask qisodd = vneq_vo_vd_vd(vcast_vd_d(0), vcast_vd_d(0));
@@ -3538,11 +3538,11 @@ static CONST dd2 gammak(vdouble a) {
   clln = vsel_vd2_vo_vd2_vd2(otiny, vcast_vd2_d_d(1, 0), vsel_vd2_vo_vd2_vd2(oref, clln, clld));
 
   if (!vtestallones_i_vo64(vnot_vo64_vo64(oref))) {
-    t = vsub_vd_vd_vd(a, vmul_vd_vd_vd(vcast_vd_d(1LL << 28), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(a, vcast_vd_d(1.0 / (1LL << 28)))))));
+    t = vsub_vd_vd_vd(a, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 28), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(a, vcast_vd_d(1.0 / (INT64_C(1) << 28)))))));
     x = ddmul_vd2_vd2_vd2(clld, sinpik(t));
   }
   
-  clld = vsel_vd2_vo_vd2_vd2(otiny, vcast_vd2_vd_vd(vmul_vd_vd_vd(a, vcast_vd_d((1LL << 60)*(double)(1LL << 60))), vcast_vd_d(0)),
+  clld = vsel_vd2_vo_vd2_vd2(otiny, vcast_vd2_vd_vd(vmul_vd_vd_vd(a, vcast_vd_d((INT64_C(1) << 60)*(double)(INT64_C(1) << 60))), vcast_vd_d(0)),
 			     vsel_vd2_vo_vd2_vd2(oref, x, y));
 
   return dd2setab_dd2_vd2_vd2(clc, dddiv_vd2_vd2_vd2(clln, clld));

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -1468,7 +1468,7 @@ TYPE2_FUNCATR VECTOR_CC vfloat2 XSINCOSPIF_U35(vfloat d) {
 
 TYPE6_FUNCATR VECTOR_CC vfloat2 XMODFF(vfloat x) {
   vfloat fr = vsub_vf_vf_vf(x, vcast_vf_vi2(vtruncate_vi2_vf(x)));
-  fr = vsel_vf_vo_vf_vf(vgt_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(1LL << 23)), vcast_vf_f(0), fr);
+  fr = vsel_vf_vo_vf_vf(vgt_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(INT64_C(1) << 23)), vcast_vf_f(0), fr);
 
   vfloat2 ret;
 
@@ -1864,7 +1864,7 @@ EXPORT CONST VECTOR_CC vfloat xlogf(vfloat d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vf_vf(d, vcast_vf_f(FLT_MIN));
-  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(1LL << 32) * (float)(1LL << 32))), d);
+  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32))), d);
   vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(d, vcast_vf_f(1.0f/0.75f)));
   m = vldexp3_vf_vf_vi2(d, vneg_vi2_vi2(e));
   e = vsel_vi2_vo_vi2_vi2(o, vsub_vi2_vi2_vi2(e, vcast_vi2_i(64)), e);
@@ -2079,7 +2079,7 @@ static INLINE CONST VECTOR_CC vfloat2 logkf(vfloat d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vf_vf(d, vcast_vf_f(FLT_MIN));
-  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(1LL << 32) * (float)(1LL << 32))), d);
+  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32))), d);
   vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(d, vcast_vf_f(1.0f/0.75f)));
   m = vldexp3_vf_vf_vi2(d, vneg_vi2_vi2(e));
   e = vsel_vi2_vo_vi2_vi2(o, vsub_vi2_vi2_vi2(e, vcast_vi2_i(64)), e);
@@ -2114,7 +2114,7 @@ static INLINE CONST VECTOR_CC vfloat logk3f(vfloat d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vf_vf(d, vcast_vf_f(FLT_MIN));
-  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(1LL << 32) * (float)(1LL << 32))), d);
+  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32))), d);
   vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(d, vcast_vf_f(1.0f/0.75f)));
   m = vldexp3_vf_vf_vi2(d, vneg_vi2_vi2(e));
   e = vsel_vi2_vo_vi2_vi2(o, vsub_vi2_vi2_vi2(e, vcast_vi2_i(64)), e);
@@ -2149,7 +2149,7 @@ EXPORT CONST VECTOR_CC vfloat xlogf_u1(vfloat d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vf_vf(d, vcast_vf_f(FLT_MIN));
-  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(1LL << 32) * (float)(1LL << 32))), d);
+  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32))), d);
   vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(d, vcast_vf_f(1.0f/0.75f)));
   m = vldexp3_vf_vf_vi2(d, vneg_vi2_vi2(e));
   e = vsel_vi2_vo_vi2_vi2(o, vsub_vi2_vi2_vi2(e, vcast_vi2_i(64)), e);
@@ -2594,7 +2594,7 @@ EXPORT CONST VECTOR_CC vfloat xlog10f(vfloat d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vf_vf(d, vcast_vf_f(FLT_MIN));
-  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(1LL << 32) * (float)(1LL << 32))), d);
+  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32))), d);
   vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(d, vcast_vf_f(1.0/0.75)));
   m = vldexp3_vf_vf_vi2(d, vneg_vi2_vi2(e));
   e = vsel_vi2_vo_vi2_vi2(o, vsub_vi2_vi2_vi2(e, vcast_vi2_i(64)), e);
@@ -2639,7 +2639,7 @@ EXPORT CONST VECTOR_CC vfloat xlog2f(vfloat d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vf_vf(d, vcast_vf_f(FLT_MIN));
-  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(1LL << 32) * (float)(1LL << 32))), d);
+  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32))), d);
   vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(d, vcast_vf_f(1.0/0.75)));
   m = vldexp3_vf_vf_vi2(d, vneg_vi2_vi2(e));
   e = vsel_vi2_vo_vi2_vi2(o, vsub_vi2_vi2_vi2(e, vcast_vi2_i(64)), e);
@@ -2684,7 +2684,7 @@ EXPORT CONST VECTOR_CC vfloat xlog2f_u35(vfloat d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vf_vf(d, vcast_vf_f(FLT_MIN));
-  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(1LL << 32) * (float)(1LL << 32))), d);
+  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f((float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32))), d);
   vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(d, vcast_vf_f(1.0/0.75)));
   m = vldexp3_vf_vf_vi2(d, vneg_vi2_vi2(e));
   e = vsel_vi2_vo_vi2_vi2(o, vsub_vi2_vi2_vi2(e, vcast_vi2_i(64)), e);
@@ -2726,7 +2726,7 @@ EXPORT CONST VECTOR_CC vfloat xlog1pf(vfloat d) {
 
 #if !defined(ENABLE_AVX512F) && !defined(ENABLE_AVX512FNOFMA)
   vopmask o = vlt_vo_vf_vf(dp1, vcast_vf_f(FLT_MIN));
-  dp1 = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(dp1, vcast_vf_f((float)(1LL << 32) * (float)(1LL << 32))), dp1);
+  dp1 = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(dp1, vcast_vf_f((float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32))), dp1);
   vint2 e = vilogb2k_vi2_vf(vmul_vf_vf_vf(dp1, vcast_vf_f(1.0f/0.75f)));
   t = vldexp3_vf_vf_vi2(vcast_vf_f(1), vneg_vi2_vi2(e));
   m = vmla_vf_vf_vf_vf(d, t, vsub_vf_vf_vf(t, vcast_vf_f(1)));
@@ -2795,20 +2795,20 @@ EXPORT CONST VECTOR_CC vfloat xtruncf(vfloat x) {
   return vtruncate_vf_vf(x);
 #else
   vfloat fr = vsub_vf_vf_vf(x, vcast_vf_vi2(vtruncate_vi2_vf(x)));
-  return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(x), vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(1LL << 23))), x, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), x));
+  return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(x), vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(INT64_C(1) << 23))), x, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), x));
 #endif
 }
 
 EXPORT CONST VECTOR_CC vfloat xfloorf(vfloat x) {
   vfloat fr = vsub_vf_vf_vf(x, vcast_vf_vi2(vtruncate_vi2_vf(x)));
   fr = vsel_vf_vo_vf_vf(vlt_vo_vf_vf(fr, vcast_vf_f(0)), vadd_vf_vf_vf(fr, vcast_vf_f(1.0f)), fr);
-  return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(x), vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(1LL << 23))), x, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), x));
+  return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(x), vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(INT64_C(1) << 23))), x, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), x));
 }
 
 EXPORT CONST VECTOR_CC vfloat xceilf(vfloat x) {
   vfloat fr = vsub_vf_vf_vf(x, vcast_vf_vi2(vtruncate_vi2_vf(x)));
   fr = vsel_vf_vo_vf_vf(vle_vo_vf_vf(fr, vcast_vf_f(0)), fr, vsub_vf_vf_vf(fr, vcast_vf_f(1.0f)));
-  return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(x), vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(1LL << 23))), x, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), x));
+  return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(x), vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(INT64_C(1) << 23))), x, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), x));
 }
 
 EXPORT CONST VECTOR_CC vfloat xroundf(vfloat d) {
@@ -2817,7 +2817,7 @@ EXPORT CONST VECTOR_CC vfloat xroundf(vfloat d) {
   x = vsel_vf_vo_vf_vf(vand_vo_vo_vo(vle_vo_vf_vf(x, vcast_vf_f(0)), veq_vo_vf_vf(fr, vcast_vf_f(0))), vsub_vf_vf_vf(x, vcast_vf_f(1.0f)), x);
   fr = vsel_vf_vo_vf_vf(vlt_vo_vf_vf(fr, vcast_vf_f(0)), vadd_vf_vf_vf(fr, vcast_vf_f(1.0f)), fr);
   x = vsel_vf_vo_vf_vf(veq_vo_vf_vf(d, vcast_vf_f(0.4999999701976776123f)), vcast_vf_f(0), x);
-  return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(d), vge_vo_vf_vf(vabs_vf_vf(d), vcast_vf_f(1LL << 23))), d, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), d));
+  return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(d), vge_vo_vf_vf(vabs_vf_vf(d), vcast_vf_f(INT64_C(1) << 23))), d, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), d));
 }
 
 EXPORT CONST VECTOR_CC vfloat xrintf(vfloat d) {
@@ -2837,7 +2837,7 @@ EXPORT CONST VECTOR_CC vfloat xfmaf(vfloat x, vfloat y, vfloat z) {
   vfloat h2 = vadd_vf_vf_vf(vmul_vf_vf_vf(x, y), z), q = vcast_vf_f(1);
   vopmask o = vlt_vo_vf_vf(vabs_vf_vf(h2), vcast_vf_f(1e-38f));
   {
-    const float c0 = 1ULL << 25, c1 = c0 * c0, c2 = c1 * c1;
+    const float c0 = UINT64_C(1) << 25, c1 = c0 * c0, c2 = c1 * c1;
     x = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(x, vcast_vf_f(c1)), x);
     y = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(y, vcast_vf_f(c1)), y);
     z = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(z, vcast_vf_f(c2)), z);
@@ -2845,7 +2845,7 @@ EXPORT CONST VECTOR_CC vfloat xfmaf(vfloat x, vfloat y, vfloat z) {
   }
   o = vgt_vo_vf_vf(vabs_vf_vf(h2), vcast_vf_f(1e+38f));
   {
-    const float c0 = 1ULL << 25, c1 = c0 * c0, c2 = c1 * c1;
+    const float c0 = UINT64_C(1) << 25, c1 = c0 * c0, c2 = c1 * c1;
     x = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(x, vcast_vf_f(1.0f / c1)), x);
     y = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(y, vcast_vf_f(1.0f / c1)), y);
     z = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(z, vcast_vf_f(1.0f / c2)), z);
@@ -2956,8 +2956,8 @@ EXPORT CONST VECTOR_CC vfloat xhypotf_u05(vfloat x, vfloat y) {
   vfloat max = vmax_vf_vf_vf(x, y), d = max;
 
   vopmask o = vlt_vo_vf_vf(max, vcast_vf_f(FLT_MIN));
-  n = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(n, vcast_vf_f(1ULL << 24)), n);
-  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f(1ULL << 24)), d);
+  n = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(n, vcast_vf_f(UINT64_C(1) << 24)), n);
+  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f(UINT64_C(1) << 24)), d);
 
   vfloat2 t = dfdiv_vf2_vf2_vf2(vcast_vf2_vf_vf(n, vcast_vf_f(0)), vcast_vf2_vf_vf(d, vcast_vf_f(0)));
   t = dfmul_vf2_vf2_vf(dfsqrt_vf2_vf2(dfadd2_vf2_vf2_vf(dfsqu_vf2_vf2(t), vcast_vf_f(1))), max);
@@ -3009,7 +3009,7 @@ EXPORT CONST VECTOR_CC vfloat xnextafterf(vfloat x, vfloat y) {
 }
 
 EXPORT CONST VECTOR_CC vfloat xfrfrexpf(vfloat x) {
-  x = vsel_vf_vo_vf_vf(vlt_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(FLT_MIN)), vmul_vf_vf_vf(x, vcast_vf_f(1ULL << 30)), x);
+  x = vsel_vf_vo_vf_vf(vlt_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(FLT_MIN)), vmul_vf_vf_vf(x, vcast_vf_f(UINT64_C(1) << 30)), x);
 
   vmask xm = vreinterpret_vm_vf(x);
   xm = vand_vm_vm_vm(xm, vcast_vm_i_i(~0x7f800000U, ~0x7f800000U));
@@ -3026,7 +3026,7 @@ EXPORT CONST VECTOR_CC vfloat xfrfrexpf(vfloat x) {
 
 EXPORT CONST VECTOR_CC vint2 xexpfrexpf(vfloat x) {
   /*
-  x = vsel_vf_vo_vf_vf(vlt_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(FLT_MIN)), vmul_vf_vf_vf(x, vcast_vf_f(1ULL << 63)), x);
+  x = vsel_vf_vo_vf_vf(vlt_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(FLT_MIN)), vmul_vf_vf_vf(x, vcast_vf_f(UINT64_C(1) << 63)), x);
 
   vint ret = vcastu_vi_vi2(vreinterpret_vi2_vf(x));
   ret = vsub_vi_vi_vi(vand_vi_vi_vi(vsrl_vi_vi_i(ret, 20), vcast_vi_i(0x7ff)), vcast_vi_i(0x3fe));
@@ -3048,7 +3048,7 @@ static INLINE CONST VECTOR_CC vfloat vptruncf(vfloat x) {
   return vtruncate_vf_vf(x);
 #else
   vfloat fr = vsub_vf_vf_vf(x, vcast_vf_vi2(vtruncate_vi2_vf(x)));
-  return vsel_vf_vo_vf_vf(vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(1LL << 23)), x, vsub_vf_vf_vf(x, fr));
+  return vsel_vf_vo_vf_vf(vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(INT64_C(1) << 23)), x, vsub_vf_vf_vf(x, fr));
 #endif
 }
 
@@ -3056,9 +3056,9 @@ static INLINE CONST VECTOR_CC vfloat vptruncf(vfloat x) {
 EXPORT CONST VECTOR_CC vfloat xfmodf(vfloat x, vfloat y) {
   vfloat nu = vabs_vf_vf(x), de = vabs_vf_vf(y), s = vcast_vf_f(1), q;
   vopmask o = vlt_vo_vf_vf(de, vcast_vf_f(FLT_MIN));
-  nu = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(nu, vcast_vf_f(1ULL << 25)), nu);
-  de = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(de, vcast_vf_f(1ULL << 25)), de);
-  s  = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(s , vcast_vf_f(1.0f / (1ULL << 25))), s);
+  nu = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(nu, vcast_vf_f(UINT64_C(1) << 25)), nu);
+  de = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(de, vcast_vf_f(UINT64_C(1) << 25)), de);
+  s  = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(s , vcast_vf_f(1.0f / (UINT64_C(1) << 25))), s);
   vfloat rde = vtoward0f(vrec_vf_vf(de));
 #if defined(ENABLE_NEON32) || defined(ENABLE_NEON32VFPV4)
   rde = vtoward0f(rde);
@@ -3101,9 +3101,9 @@ static INLINE CONST VECTOR_CC vfloat vrintfk2_vf_vf(vfloat d) {
 EXPORT CONST VECTOR_CC vfloat xremainderf(vfloat x, vfloat y) {
   vfloat n = vabs_vf_vf(x), d = vabs_vf_vf(y), s = vcast_vf_f(1), q;
   vopmask o = vlt_vo_vf_vf(d, vcast_vf_f(FLT_MIN*2));
-  n = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(n, vcast_vf_f(1ULL << 25)), n);
-  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f(1ULL << 25)), d);
-  s  = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(s , vcast_vf_f(1.0f / (1ULL << 25))), s);
+  n = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(n, vcast_vf_f(UINT64_C(1) << 25)), n);
+  d = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(d, vcast_vf_f(UINT64_C(1) << 25)), d);
+  s  = vsel_vf_vo_vf_vf(o, vmul_vf_vf_vf(s , vcast_vf_f(1.0f / (UINT64_C(1) << 25))), s);
   vfloat2 r = vcast_vf2_vf_vf(n, vcast_vf_f(0));
   vfloat rd = vrec_vf_vf(d);
   vopmask qisodd = vneq_vo_vf_vf(vcast_vf_f(0), vcast_vf_f(0));
@@ -3297,11 +3297,11 @@ static CONST df2 gammafk(vfloat a) {
   clln = vsel_vf2_vo_vf2_vf2(otiny, vcast_vf2_f_f(1, 0), vsel_vf2_vo_vf2_vf2(oref, clln, clld));
 
   if (!vtestallones_i_vo32(vnot_vo32_vo32(oref))) {
-    t = vsub_vf_vf_vf(a, vmul_vf_vf_vf(vcast_vf_f(1LL << 12), vcast_vf_vi2(vtruncate_vi2_vf(vmul_vf_vf_vf(a, vcast_vf_f(1.0 / (1LL << 12)))))));
+    t = vsub_vf_vf_vf(a, vmul_vf_vf_vf(vcast_vf_f(INT64_C(1) << 12), vcast_vf_vi2(vtruncate_vi2_vf(vmul_vf_vf_vf(a, vcast_vf_f(1.0 / (INT64_C(1) << 12)))))));
     x = dfmul_vf2_vf2_vf2(clld, sinpifk(t));
   }
   
-  clld = vsel_vf2_vo_vf2_vf2(otiny, vcast_vf2_vf_vf(vmul_vf_vf_vf(a, vcast_vf_f((1LL << 30)*(float)(1LL << 30))), vcast_vf_f(0)),
+  clld = vsel_vf2_vo_vf2_vf2(otiny, vcast_vf2_vf_vf(vmul_vf_vf_vf(a, vcast_vf_f((INT64_C(1) << 30)*(float)(INT64_C(1) << 30))), vcast_vf_f(0)),
 			     vsel_vf2_vo_vf2_vf2(oref, x, y));
 
   return df2setab_df2_vf2_vf2(clc, dfdiv_vf2_vf2_vf2(clln, clld));

--- a/src/libm/sleefsp.c
+++ b/src/libm/sleefsp.c
@@ -428,7 +428,7 @@ typedef struct {
 
 static CONST fi_t rempisubf(float x) {
   fi_t ret;
-  float fr = x - (float)(1LL << 10) * (int32_t)(x * (1.0f / (1LL << 10)));
+  float fr = x - (float)(INT64_C(1) << 10) * (int32_t)(x * (1.0f / (INT64_C(1) << 10)));
   ret.i = ((7 & ((x > 0 ? 4 : 3) + (int32_t)(fr * 8))) - 3) >> 1;
   fr = fr - 0.25f * (int32_t)(fr * 4 + mulsignf(0.5f, x));
   fr = fabsfk(fr) > 0.125f ? (fr - mulsignf(0.5f, x)) : fr;
@@ -1066,7 +1066,7 @@ static Sleef_float2 atan2kf_u1(Sleef_float2 y, Sleef_float2 x) {
 }
 
 EXPORT CONST float xatan2f_u1(float y, float x) {
-  if (fabsfk(x) < 2.9387372783541830947e-39f) { y *= (1ULL << 24); x *= (1ULL << 24); } // nexttowardf((1.0 / FLT_MAX), 1)
+  if (fabsfk(x) < 2.9387372783541830947e-39f) { y *= (UINT64_C(1) << 24); x *= (UINT64_C(1) << 24); } // nexttowardf((1.0 / FLT_MAX), 1)
   Sleef_float2 d = atan2kf_u1(df(fabsfk(y), 0), df(x, 0));
   float r = d.x + d.y;
 
@@ -1133,7 +1133,7 @@ EXPORT CONST float xlogf(float d) {
   int e;
 
   int o = d < FLT_MIN;
-  if (o) d *= (float)(1LL << 32) * (float)(1LL << 32);
+  if (o) d *= (float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32);
       
   e = ilogb2kf(d * (1.0f/0.75f));
   m = ldexp3kf(d, -e);
@@ -1237,7 +1237,7 @@ static INLINE CONST Sleef_float2 logkf(float d) {
   int e;
 
   int o = d < FLT_MIN;
-  if (o) d *= (float)(1LL << 32) * (float)(1LL << 32);
+  if (o) d *= (float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32);
       
   e = ilogb2kf(d * (1.0f/0.75f));
   m = ldexp3kf(d, -e);
@@ -1265,7 +1265,7 @@ EXPORT CONST float xlogf_u1(float d) {
   int e;
 
   int o = d < FLT_MIN;
-  if (o) d *= (float)(1LL << 32) * (float)(1LL << 32);
+  if (o) d *= (float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32);
       
   e = ilogb2kf(d * (1.0f/0.75f));
   m = ldexp3kf(d, -e);
@@ -1318,8 +1318,8 @@ static INLINE CONST Sleef_float2 expk2f(Sleef_float2 d) {
 }
 
 EXPORT CONST float xpowf(float x, float y) {
-  int yisint = (y == (int)y) || (fabsfk(y) >= (float)(1LL << 24));
-  int yisodd = (1 & (int)y) != 0 && yisint && fabsfk(y) < (float)(1LL << 24);
+  int yisint = (y == (int)y) || (fabsfk(y) >= (float)(INT64_C(1) << 24));
+  int yisodd = (1 & (int)y) != 0 && yisint && fabsfk(y) < (float)(INT64_C(1) << 24);
 
   float result = expkf(dfmul_f2_f2_f(logkf(fabsfk(x)), y));
 
@@ -1340,7 +1340,7 @@ static INLINE CONST float logk3f(float d) {
   int e;
 
   int o = d < FLT_MIN;
-  if (o) d *= (float)(1LL << 32) * (float)(1LL << 32);
+  if (o) d *= (float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32);
       
   e = ilogb2kf(d * (1.0f/0.75f));
   m = ldexp3kf(d, -e);
@@ -1386,8 +1386,8 @@ static INLINE CONST float expk3f(float d) {
 EXPORT CONST float xfastpowf_u3500(float x, float y) {
   float result = expk3f(logk3f(fabsfk(x)) * y);
 
-  int yisint = (y == (int)y) || (fabsfk(y) >= (float)(1LL << 24));
-  int yisodd = (1 & (int)y) != 0 && yisint && fabsfk(y) < (float)(1LL << 24);
+  int yisint = (y == (int)y) || (fabsfk(y) >= (float)(INT64_C(1) << 24));
+  int yisodd = (1 & (int)y) != 0 && yisint && fabsfk(y) < (float)(INT64_C(1) << 24);
 
   result *= (x < 0 && yisodd) ? -1 : 1;
   if (x == 0) result = 0;
@@ -1645,7 +1645,7 @@ EXPORT CONST float xlog10f(float d) {
   int e;
 
   int o = d < FLT_MIN;
-  if (o) d *= (float)(1LL << 32) * (float)(1LL << 32);
+  if (o) d *= (float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32);
       
   e = ilogb2kf(d * (1.0f/0.75f));
   m = ldexp3kf(d, -e);
@@ -1678,7 +1678,7 @@ EXPORT CONST float xlog2f(float d) {
   int e;
 
   int o = d < FLT_MIN;
-  if (o) d *= (float)(1LL << 32) * (float)(1LL << 32);
+  if (o) d *= (float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32);
       
   e = ilogb2kf(d * (1.0f/0.75f));
   m = ldexp3kf(d, -e);
@@ -1709,7 +1709,7 @@ EXPORT CONST float xlog2f_u35(float d) {
   int e;
 
   int o = d < FLT_MIN;
-  if (o) d *= (float)(1LL << 32) * (float)(1LL << 32);
+  if (o) d *= (float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32);
       
   e = ilogb2kf(d * (1.0f/0.75f));
   m = ldexp3kf(d, -e);
@@ -1740,7 +1740,7 @@ EXPORT CONST float xlog1pf(float d) {
   float dp1 = d + 1;
   
   int o = dp1 < FLT_MIN;
-  if (o) dp1 *= (float)(1LL << 32) * (float)(1LL << 32);
+  if (o) dp1 *= (float)(INT64_C(1) << 32) * (float)(INT64_C(1) << 32);
       
   e = ilogb2kf(dp1 * (1.0f/0.75f));
 
@@ -1862,19 +1862,19 @@ EXPORT CONST float xfdimf(float x, float y) {
 
 EXPORT CONST float xtruncf(float x) {
   float fr = x - (int32_t)x;
-  return (xisinff(x) || fabsfk(x) >= (float)(1LL << 23)) ? x : copysignfk(x - fr, x);
+  return (xisinff(x) || fabsfk(x) >= (float)(INT64_C(1) << 23)) ? x : copysignfk(x - fr, x);
 }
 
 EXPORT CONST float xfloorf(float x) {
   float fr = x - (int32_t)x;
   fr = fr < 0 ? fr+1.0f : fr;
-  return (xisinff(x) || fabsfk(x) >= (float)(1LL << 23)) ? x : copysignfk(x - fr, x);
+  return (xisinff(x) || fabsfk(x) >= (float)(INT64_C(1) << 23)) ? x : copysignfk(x - fr, x);
 }
 
 EXPORT CONST float xceilf(float x) {
   float fr = x - (int32_t)x;
   fr = fr <= 0 ? fr : fr-1.0f;
-  return (xisinff(x) || fabsfk(x) >= (float)(1LL << 23)) ? x : copysignfk(x - fr, x);
+  return (xisinff(x) || fabsfk(x) >= (float)(INT64_C(1) << 23)) ? x : copysignfk(x - fr, x);
 }
 
 EXPORT CONST float xroundf(float d) {
@@ -1883,7 +1883,7 @@ EXPORT CONST float xroundf(float d) {
   if (fr == 0 && x <= 0) x--;
   fr = fr < 0 ? fr+1.0f : fr;
   x = d == 0.4999999701976776123f ? 0 : x;  // nextafterf(0.5, 0)
-  return (xisinff(d) || fabsfk(d) >= (float)(1LL << 23)) ? d : copysignfk(x - fr, d);
+  return (xisinff(d) || fabsfk(d) >= (float)(INT64_C(1) << 23)) ? d : copysignfk(x - fr, d);
 }
 
 EXPORT CONST float xrintf(float d) {
@@ -1892,12 +1892,12 @@ EXPORT CONST float xrintf(float d) {
   float fr = x - (int32_t)x;
   fr = (fr < 0 || (fr == 0 && isodd)) ? fr+1.0f : fr;
   x = d == 0.50000005960464477539f ? 0 : x;  // nextafterf(0.5, 1)
-  return (xisinff(d) || fabsfk(d) >= (float)(1LL << 23)) ? d : copysignfk(x - fr, d);
+  return (xisinff(d) || fabsfk(d) >= (float)(INT64_C(1) << 23)) ? d : copysignfk(x - fr, d);
 }
 
 EXPORT CONST Sleef_float2 xmodff(float x) {
   float fr = x - (int32_t)x;
-  fr = fabsfk(x) > (float)(1LL << 23) ? 0 : fr;
+  fr = fabsfk(x) > (float)(INT64_C(1) << 23) ? 0 : fr;
   Sleef_float2 ret = { copysignfk(fr, x), copysignfk(x - fr, x) };
   return ret;
 }
@@ -1980,7 +1980,7 @@ EXPORT CONST float xhypotf_u05(float x, float y) {
   float min = fminfk(x, y), n = min;
   float max = fmaxfk(x, y), d = max;
 
-  if (max < FLT_MIN) { n *= 1ULL << 24; d *= 1ULL << 24; }
+  if (max < FLT_MIN) { n *= UINT64_C(1) << 24; d *= UINT64_C(1) << 24; }
   Sleef_float2 t = dfdiv_f2_f2_f2(df(n, 0), df(d, 0));
   t = dfmul_f2_f2_f(dfsqrt_f2_f2(dfadd2_f2_f2_f(dfsqu_f2_f2(t), 1)), max);
   float ret = t.x + t.y;
@@ -2010,12 +2010,12 @@ static INLINE CONST float toward0f(float d) {
 }
 
 static INLINE CONST float ptruncf(float x) {
-  return fabsfk(x) >= (float)(1LL << 23) ? x : (x - (x - (int32_t)x));
+  return fabsfk(x) >= (float)(INT64_C(1) << 23) ? x : (x - (x - (int32_t)x));
 }
 
 EXPORT CONST float xfmodf(float x, float y) {
   float nu = fabsfk(x), de = fabsfk(y), s = 1, q;
-  if (de < FLT_MIN) { nu *= 1ULL << 25; de *= 1ULL << 25; s = 1.0f / (1ULL << 25); }
+  if (de < FLT_MIN) { nu *= UINT64_C(1) << 25; de *= UINT64_C(1) << 25; s = 1.0f / (UINT64_C(1) << 25); }
   Sleef_float2 r = df(nu, 0);
   float rde = toward0f(1.0f / de);
 
@@ -2041,12 +2041,12 @@ static INLINE CONST float rintfk2(float d) {
   int32_t isodd = (1 & (int32_t)x) != 0;
   float fr = x - (int32_t)x;
   fr = (fr < 0 || (fr == 0 && isodd)) ? fr+1.0f : fr;
-  return (fabsfk(d) >= (float)(1LL << 23)) ? d : copysignfk(x - fr, d);
+  return (fabsfk(d) >= (float)(INT64_C(1) << 23)) ? d : copysignfk(x - fr, d);
 }
 
 EXPORT CONST float xremainderf(float x, float y) {
   float n = fabsfk(x), d = fabsfk(y), s = 1, q;
-  if (d < FLT_MIN*2) { n *= 1ULL << 25; d *= 1ULL << 25; s = 1.0f / (1ULL << 25); }
+  if (d < FLT_MIN*2) { n *= UINT64_C(1) << 25; d *= UINT64_C(1) << 25; s = 1.0f / (UINT64_C(1) << 25); }
   float rd = 1.0f / d;
   Sleef_float2 r = df(n, 0);
   int qisodd = 0;
@@ -2057,7 +2057,7 @@ EXPORT CONST float xremainderf(float x, float y) {
     if (fabsfk(r.x) < 0.5f * d || (fabsfk(r.x) == 0.5f * d && !qisodd)) q = 0;
     if (q == 0) break;
     if (xisinff(q * -d)) q = q + mulsignf(-1, r.x);
-    qisodd ^= (1 & (int)q) != 0 && fabsfk(q) < (float)(1LL << 24);
+    qisodd ^= (1 & (int)q) != 0 && fabsfk(q) < (float)(INT64_C(1) << 24);
     r = dfnormalize_f2_f2(dfadd2_f2_f2_f2(r, dfmul_f2_f_f(q, -d)));
   }
   
@@ -2292,9 +2292,9 @@ static CONST df2 gammafk(float a) {
     (oref ? dfadd2_f2_f2_f2(dfx(1.1447298858494001639), dfneg_f2_f2(clc)) : clc); // log(M_PI)
   clln = otiny ? df(1, 0) : (oref ? clln : clld);
 
-  if (oref) x = dfmul_f2_f2_f2(clld, sinpifk(a - (float)(1LL << 12) * (int32_t)(a * (1.0 / (1LL << 12)))));
+  if (oref) x = dfmul_f2_f2_f2(clld, sinpifk(a - (float)(INT64_C(1) << 12) * (int32_t)(a * (1.0 / (INT64_C(1) << 12)))));
 
-  clld = otiny ? df(a*((1LL << 30)*(float)(1LL << 30)), 0) : (oref ? x : y);
+  clld = otiny ? df(a*((INT64_C(1) << 30)*(float)(INT64_C(1) << 30)), 0) : (oref ? x : y);
 
   df2 ret = { clc, dfdiv_f2_f2_f2(clln, clld) };
 

--- a/src/quad-tester/qtesterutil.c
+++ b/src/quad-tester/qtesterutil.c
@@ -105,7 +105,7 @@ typedef union {
 
 int iszerof128(Sleef_quad a) {
   cnv_t c128 = { .q = a };
-  return (((c128.h & 0x7fffffffffffffffULL) == 0) && c128.l == 0);
+  return (((c128.h & UINT64_C(0x7fffffffffffffff)) == 0) && c128.l == 0);
 }
 
 int isnegf128(Sleef_quad a) {
@@ -115,12 +115,12 @@ int isnegf128(Sleef_quad a) {
 
 int isinff128(Sleef_quad a) {
   cnv_t c128 = { .q = a };
-  return (((c128.h & 0x7fffffffffffffffULL) == 0x7fff000000000000ULL) && c128.l == 0);
+  return (((c128.h & UINT64_C(0x7fffffffffffffff)) == UINT64_C(0x7fff000000000000)) && c128.l == 0);
 }
 
 int isnonnumberf128(Sleef_quad a) {
   cnv_t c128 = { .q = a };
-  return (c128.h & 0x7fff000000000000ULL) == 0x7fff000000000000ULL;
+  return (c128.h & UINT64_C(0x7fff000000000000)) == UINT64_C(0x7fff000000000000);
 }
 
 int isnanf128(Sleef_quad a) {
@@ -133,9 +133,9 @@ static uint64_t xseed;
 
 uint64_t xrand() {
   uint64_t u = xseed;
-  xseed = xseed * 6364136223846793005ULL + 1;
-  u = (u & ((~0ULL) << 32)) | (xseed >> 32);
-  xseed = xseed * 6364136223846793005ULL + 1;
+  xseed = xseed * UINT64_C(6364136223846793005) + 1;
+  u = (u & ((~UINT64_C(0)) << 32)) | (xseed >> 32);
+  xseed = xseed * UINT64_C(6364136223846793005) + 1;
   return u;
 }
 
@@ -156,13 +156,13 @@ void memrand(void *p, int size) {
 
 Sleef_quad rndf128(Sleef_quad min, Sleef_quad max) {
   cnv_t cmin = { .q = min }, cmax = { .q = max }, c;
-  uint64_t enablesign = cmin.h & cmax.h & 0x8000000000000000ULL, sign = 0;
-  cmin.h &= 0x7fffffffffffffffULL;
-  cmax.h &= 0x7fffffffffffffffULL;
+  uint64_t enablesign = cmin.h & cmax.h & UINT64_C(0x8000000000000000), sign = 0;
+  cmin.h &= UINT64_C(0x7fffffffffffffff);
+  cmax.h &= UINT64_C(0x7fffffffffffffff);
   do {
     memrand(&c.q, sizeof(Sleef_quad));
     sign = c.h;
-    c.h &= 0x7fffffffffffffffULL;
+    c.h &= UINT64_C(0x7fffffffffffffff);
   } while(isnonnumberf128(c.q) || lt128(c.x, cmin.x) || lt128(cmax.x, c.x));
   c.h |= sign & enablesign;
   return c.q;
@@ -302,18 +302,18 @@ void mpfr_set_f128(mpfr_t frx, Sleef_quad a, mpfr_rnd_t rnd) {
   } else if (isinff128(a)) {
     mpfr_set_inf(frx, sign ? -1 : 1);
   } else if (exp == 0) {
-    c128.h &= 0xffffffffffffULL;
+    c128.h &= UINT64_C(0xffffffffffff);
     mpfr_set_d(frx, ldexp((double)c128.h, 64), GMP_RNDN);
-    mpfr_add_d(frx, frx, (double)(c128.l & 0xffffffff00000000ULL), GMP_RNDN);
-    mpfr_add_d(frx, frx, (double)(c128.l & 0xffffffffULL), GMP_RNDN);
+    mpfr_add_d(frx, frx, (double)(c128.l & UINT64_C(0xffffffff00000000)), GMP_RNDN);
+    mpfr_add_d(frx, frx, (double)(c128.l & UINT64_C(0xffffffff)), GMP_RNDN);
     mpfr_set_exp(frx, mpfr_get_exp(frx) - 16382 - 112);
     mpfr_setsign(frx, frx, sign, GMP_RNDN);
   } else {
-    c128.h &= 0xffffffffffffULL;
+    c128.h &= UINT64_C(0xffffffffffff);
     mpfr_set_d(frx, ldexp(1, 112), GMP_RNDN);
     mpfr_add_d(frx, frx, ldexp((double)c128.h, 64), GMP_RNDN);
-    mpfr_add_d(frx, frx, (double)(c128.l & 0xffffffff00000000ULL), GMP_RNDN);
-    mpfr_add_d(frx, frx, (double)(c128.l & 0xffffffffULL), GMP_RNDN);
+    mpfr_add_d(frx, frx, (double)(c128.l & UINT64_C(0xffffffff00000000)), GMP_RNDN);
+    mpfr_add_d(frx, frx, (double)(c128.l & UINT64_C(0xffffffff)), GMP_RNDN);
     mpfr_set_exp(frx, exp - 16382);
     mpfr_setsign(frx, frx, sign, GMP_RNDN);
   }
@@ -385,15 +385,15 @@ static TDX_t mpfr_get_tdx(mpfr_t fr, mpfr_rnd_t rnd) {
 #define LOGXSCALE 1
 #define XSCALE (1 << LOGXSCALE)
 #define SX 61
-#define HBY (1.0 / (1ULL << 53))
+#define HBY (1.0 / (UINT64_C(1) << 53))
 #define LOGYSCALE 4
 #define YSCALE (1 << LOGYSCALE)
 #define SY 11
-#define HBZ (1.0 / ((1ULL << 53) * (double)(1ULL << 53)))
+#define HBZ (1.0 / ((UINT64_C(1) << 53) * (double)(UINT64_C(1) << 53)))
 #define LOGZSCALE 10
 #define ZSCALE (1 << LOGZSCALE)
 #define SZ 36
-#define HBR (1.0 / (1ULL << 60))
+#define HBR (1.0 / (UINT64_C(1) << 60))
 
 static int64_t doubleToRawLongBits(double d) {
   union {
@@ -414,7 +414,7 @@ static double longBitsToDouble(int64_t i) {
 }
 
 static int xisnonnumber(double x) {
-  return (doubleToRawLongBits(x) & 0x7ff0000000000000ULL) == 0x7ff0000000000000ULL;
+  return (doubleToRawLongBits(x) & UINT64_C(0x7ff0000000000000)) == UINT64_C(0x7ff0000000000000);
 }
 
 static double xordu(double x, uint64_t y) {
@@ -446,7 +446,7 @@ Sleef_quad mpfr_get_f128(mpfr_t a, mpfr_rnd_t rnd) {
   } c64;
 
   c64.d = f.dd.x;
-  uint64_t signbit = c64.u & 0x8000000000000000ULL;
+  uint64_t signbit = c64.u & UINT64_C(0x8000000000000000);
   int isZero = (f.dd.x == 0.0), denorm = 0;
 
   f.dd.x = xordu(f.dd.x, signbit);
@@ -472,19 +472,19 @@ Sleef_quad mpfr_get_f128(mpfr_t a, mpfr_rnd_t rnd) {
   f.dd.z *= t;
 
   c64.d = f.dd.y + HBY * YSCALE;
-  c64.u &= 0xffffffffffffffffULL << LOGYSCALE;
+  c64.u &= UINT64_C(0xffffffffffffffff) << LOGYSCALE;
   f.dd.z += f.dd.y - (c64.d - (HBZ * ZSCALE + HBY * YSCALE));
   f.dd.y = c64.d;
 
   double c = denorm ? (HBX * XSCALE + HBX) : (HBX * XSCALE);
   c64.d = f.dd.x + c;
-  c64.u &= 0xffffffffffffffffULL << LOGXSCALE;
+  c64.u &= UINT64_C(0xffffffffffffffff) << LOGXSCALE;
   t = f.dd.y + (f.dd.x - (c64.d - c));
   f.dd.z += f.dd.y - t + (f.dd.x - (c64.d - c));
   f.dd.x = c64.d;
 
   c64.d = t;
-  c64.u &= 0xffffffffffffffffULL << LOGYSCALE;
+  c64.u &= UINT64_C(0xffffffffffffffff) << LOGYSCALE;
   f.dd.z += t - c64.d;
   f.dd.y = c64.d;
 
@@ -501,26 +501,26 @@ Sleef_quad mpfr_get_f128(mpfr_t a, mpfr_rnd_t rnd) {
   //
 
   c64.d = f.dd.x;
-  c64.u &= 0xfffffffffffffULL;
+  c64.u &= UINT64_C(0xfffffffffffff);
   c128.x = sll128(c64.u, SX);
 
   c64.d = f.dd.z;
-  c64.u &= 0xfffffffffffffULL;
+  c64.u &= UINT64_C(0xfffffffffffff);
   c128.l |= c64.u >> SZ;
 
   c64.d = f.dd.y;
-  c64.u &= 0xfffffffffffffULL;
+  c64.u &= UINT64_C(0xfffffffffffff);
   c128.x = add128(c128.x, sll128(c64.u, SY));
 
-  c128.h &= denorm ? 0xffffffffffffULL : 0x3ffffffffffffULL;
+  c128.h &= denorm ? UINT64_C(0xffffffffffff) : UINT64_C(0x3ffffffffffff);
   c128.h += ((f.e-1) & ~((uint64_t)-1UL << 15)) << 48;
 
   if (isZero) { c128.l = c128.h = 0; }
   if (f.e >= 32767 || f.dd.x == INFINITY) {
-    c128.h = 0x7fff000000000000ULL;
+    c128.h = UINT64_C(0x7fff000000000000);
     c128.l = 0;
   }
-  if (xisnonnumber(f.dd.x) && f.dd.x != INFINITY) c128.h = c128.l = 0xffffffffffffffffULL;
+  if (xisnonnumber(f.dd.x) && f.dd.x != INFINITY) c128.h = c128.l = UINT64_C(0xffffffffffffffff);
 
   c128.h |= signbit;
 

--- a/src/quad/sleefsimdqp.c
+++ b/src/quad/sleefsimdqp.c
@@ -1182,7 +1182,7 @@ static INLINE CONST di_t rempisub(vdouble x) {
   vint vi = vtruncate_vi_vd(vsub_vd_vd_vd(y, vmul_vd_vd_vd(vrint_vd_vd(x), vcast_vd_d(4))));
   return disetdi_di_vd_vi(vsub_vd_vd_vd(x, vmul_vd_vd_vd(y, vcast_vd_d(0.25))), vi);
 #else
-  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(1LL << 28), vtruncate_vd_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (1LL << 28))))));
+  vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 28), vtruncate_vd_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 28))))));
   vint vi = vadd_vi_vi_vi(vsel_vi_vo_vi_vi(vcast_vo32_vo64(vgt_vo_vd_vd(x, vcast_vd_d(0))), vcast_vi_i(4), vcast_vi_i(3)), vtruncate_vi_vd(vmul_vd_vd_vd(fr, vcast_vd_d(8))));
   vi = vsra_vi_vi_i(vsub_vi_vi_vi(vand_vi_vi_vi(vcast_vi_i(7), vi), vcast_vi_i(3)), 1);
   fr = vsub_vd_vd_vd(fr, vmul_vd_vd_vd(vcast_vd_d(0.25), vtruncate_vd_vd(vmla_vd_vd_vd_vd(fr, vcast_vd_d(4), vmulsign_vd_vd_vd(vcast_vd_d(0.5), x)))));
@@ -2040,8 +2040,8 @@ static tdx vcast_tdx_vf128(vmask2 f) {
   mz = vor_vm_vm_vm(mz, vcast_vm_i_i(0x39700000, 0));
 
   mx = vandnot_vm_vo64_vm(iszero, mx);
-  my = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(my), vcast_vd_d(1.0 / (1ULL << 52))));
-  mz = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(mz), vcast_vd_d(1.0 / ((1ULL << 52) * (double)(1ULL << 52)))));
+  my = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(my), vcast_vd_d(1.0 / (UINT64_C(1) << 52))));
+  mz = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(mz), vcast_vd_d(1.0 / ((UINT64_C(1) << 52) * (double)(UINT64_C(1) << 52)))));
 
   tdx r = tdxsetexyz_tdx_vm_vd_vd_vd(re, 
 				     vreinterpret_vd_vm(vor_vm_vm_vm(mx, signbit)), 
@@ -2088,8 +2088,8 @@ static INLINE CONST tdx vcast_tdx_vf128_fast(vmask2 f) {
   mz = vor_vm_vm_vm(mz, vcast_vm_i_i(0x39700000, 0));
 
   mx = vandnot_vm_vo64_vm(iszero, mx);
-  my = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(my), vcast_vd_d(1.0 / (1ULL << 52))));
-  mz = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(mz), vcast_vd_d(1.0 / ((1ULL << 52) * (double)(1ULL << 52)))));
+  my = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(my), vcast_vd_d(1.0 / (UINT64_C(1) << 52))));
+  mz = vreinterpret_vm_vd(vsub_vd_vd_vd(vreinterpret_vd_vm(mz), vcast_vd_d(1.0 / ((UINT64_C(1) << 52) * (double)(UINT64_C(1) << 52)))));
 
   return tdxsetexyz_tdx_vm_vd_vd_vd(re, 
 				    vreinterpret_vd_vm(vor_vm_vm_vm(mx, signbit)), 
@@ -2101,15 +2101,15 @@ static INLINE CONST tdx vcast_tdx_vf128_fast(vmask2 f) {
 #define LOGXSCALE 1
 #define XSCALE (1 << LOGXSCALE)
 #define SX 61
-#define HBY (1.0 / (1ULL << 53))
+#define HBY (1.0 / (UINT64_C(1) << 53))
 #define LOGYSCALE 4
 #define YSCALE (1 << LOGYSCALE)
 #define SY 11
-#define HBZ (1.0 / ((1ULL << 53) * (double)(1ULL << 53)))
+#define HBZ (1.0 / ((UINT64_C(1) << 53) * (double)(UINT64_C(1) << 53)))
 #define LOGZSCALE 10
 #define ZSCALE (1 << LOGZSCALE)
 #define SZ 36
-#define HBR (1.0 / (1ULL << 60))
+#define HBR (1.0 / (UINT64_C(1) << 60))
 
 static vmask2 vcast_vf128_tdx_slow(tdx f) {
   vmask signbit = vand_vm_vm_vm(vreinterpret_vm_vd(tdxgetd3x_vd_tdx(f)), vcast_vm_i_i(0x80000000, 0));
@@ -2126,7 +2126,7 @@ static vmask2 vcast_vf128_tdx_slow(tdx f) {
   t = vsel_vd_vo_vd_vd(denorm, t, vcast_vd_d(1));
   f = tdxsete_tdx_tdx_vm(f, vsel_vm_vo64_vm_vm(denorm, vcast_vm_i_i(0, 1), tdxgete_vm_tdx(f)));
 
-  vopmask o = vlt_vo_vd_vd(tdxgetd3y_vd_tdx(f), vcast_vd_d(-1.0/(1ULL << 57)/(1ULL << 57)));
+  vopmask o = vlt_vo_vd_vd(tdxgetd3y_vd_tdx(f), vcast_vd_d(-1.0/(UINT64_C(1) << 57)/(UINT64_C(1) << 57)));
   o = vand_vo_vo_vo(o, veq_vo_vd_vd(tdxgetd3x_vd_tdx(f), vcast_vd_d(1)));
   o = vandnot_vo_vo_vo(veq64_vo_vm_vm(tdxgete_vm_tdx(f), vcast_vm_i_i(0, 1)), o);
   t = vsel_vd_vo_vd_vd(o, vcast_vd_d(2), t);
@@ -2774,9 +2774,9 @@ EXPORT void Sleef_qtostr(char *s, int n, vargquad a, int base) {
 
   if (visnanq_vo_vm2(c128.q)) { sprintf(p, "nan"); return; }
 
-  if ((c128.h & 0x8000000000000000ULL) != 0) {
+  if ((c128.h & UINT64_C(0x8000000000000000)) != 0) {
     *p++ = '-';
-    c128.h ^= 0x8000000000000000ULL;
+    c128.h ^= UINT64_C(0x8000000000000000);
   } else {
     *p++ = '+';
   }


### PR DESCRIPTION
This patch changes suffixes of constants to a more portable form.
For example, 1LL is changed to INT64_C(1).