### PR TITLE
Fix build problem with gcc-10 on ppc64

### DIFF
--- a/src/libm/sleeflibm_header.h.org
+++ b/src/libm/sleeflibm_header.h.org
@@ -123,7 +123,7 @@ typedef struct {
 
 #if !defined(Sleef_quad_DEFINED)
 #define Sleef_quad_DEFINED
-#if defined(__SIZEOF_FLOAT128__) || (defined(__linux__) && defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__)))
+#if defined(__SIZEOF_FLOAT128__) || (defined(__linux__) && defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))) || (defined(__PPC64__) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8)
 typedef __float128 Sleef_quad;
 #else
 typedef struct { uint64_t x, y; } Sleef_quad;

--- a/src/quad-tester/CMakeLists.txt
+++ b/src/quad-tester/CMakeLists.txt
@@ -21,6 +21,24 @@ endif()
 
 #
 
+if(SLEEF_OPENSSL_FOUND)
+  # Build tester3printf
+  add_executable(tester3printf tester3printf.c)
+  add_dependencies(tester3printf sleefquad sleefquad_headers ${TARGET_LIBSLEEF} ${TARGET_HEADERS})
+  target_compile_definitions(tester3printf PRIVATE ${COMMON_TARGET_DEFINITIONS})
+  set_target_properties(tester3printf PROPERTIES C_STANDARD 99)
+  target_link_libraries(tester3printf sleefquad ${TARGET_LIBSLEEF} ${SLEEF_OPENSSL_LIBRARIES})
+  target_include_directories(tester3printf PRIVATE ${SLEEF_OPENSSL_INCLUDE_DIR})
+
+  if(CMAKE_CROSSCOMPILING AND EMULATOR)
+    add_test(NAME tester3printf COMMAND ${EMULATOR} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
+  else()
+    add_test(NAME tester3printf COMMAND tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
+  endif()
+endif()
+
+#
+
 function(add_test_iut IUT)
   if (LIB_MPFR)
     set(QTESTER qtester)
@@ -110,21 +128,3 @@ if(LIB_MPFR AND NOT MINGW)
     endif()
   endif()
 endif(LIB_MPFR AND NOT MINGW)
-
-if(SLEEF_OPENSSL_FOUND)
-  # Build tester3printf
-  add_executable(tester3printf tester3printf.c)
-  add_dependencies(tester3printf sleefquad sleefquad_headers ${TARGET_LIBSLEEF} ${TARGET_HEADERS})
-  target_compile_definitions(tester3printf PRIVATE ${COMMON_TARGET_DEFINITIONS})
-  set_target_properties(tester3printf PROPERTIES C_STANDARD 99)
-  target_link_libraries(tester3printf sleefquad ${TARGET_LIBSLEEF} ${SLEEF_OPENSSL_LIBRARIES})
-  target_include_directories(tester3printf PRIVATE ${SLEEF_OPENSSL_INCLUDE_DIR})
-
-  if (SDE_COMMAND)
-    add_test(NAME tester3printf COMMAND ${SDE_COMMAND} "--" ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
-  elseif(EMULATOR)
-    add_test(NAME tester3printf COMMAND ${EMULATOR} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
-  else()
-    add_test(NAME tester3printf COMMAND tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
-  endif()
-endif()

--- a/src/quad-tester/qtesterutil.c
+++ b/src/quad-tester/qtesterutil.c
@@ -268,7 +268,7 @@ char *sprintfr(mpfr_t fr) {
 
 //
 
-#if MPFR_VERSION_MAJOR >= 4 && defined(ENABLEFLOAT128) && !defined(__APPLE__)
+#if MPFR_VERSION_MAJOR >= 4 && defined(ENABLEFLOAT128) && !defined(__APPLE__) && !defined(__PPC64__)
 void mpfr_set_f128(mpfr_t frx, Sleef_quad q, mpfr_rnd_t rnd) {
   int mpfr_set_float128(mpfr_t rop, __float128 op, mpfr_rnd_t rnd);
   union {


### PR DESCRIPTION
This is caused because __float128 is defined since gcc-8, and even though it does not define `__SIZEOF_FLOAT128__`.