### PR TITLE
[Quad] Add quad cast functions

### DIFF
--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -287,10 +287,6 @@ typedef union {
 
 #elif defined(_MSC_VER) // #if (defined (__GNUC__) || defined (__clang__) || defined(__INTEL_COMPILER)) && !defined(_MSC_VER)
 
-#pragma warning(disable:4116) // warning C4116: unnamed type definition in parentheses
-#pragma warning(disable:4244) // warning C4244: 'function': conversion from 'vopmask' to '__mmask8', possible loss of data
-#pragma warning(disable:4305) // warning C4305: 'function': truncation from 'double' to 'float'
-
 #if defined(SLEEF_GENHEADER)
 
 #define INLINE SLEEF_ALWAYS_INLINE
@@ -361,4 +357,23 @@ typedef union {
 #define VECTOR_CC __attribute__((aarch64_vector_pcs))
 #else
 #define VECTOR_CC
+#endif
+
+//
+
+#if defined (__GNUC__) && !defined(__INTEL_COMPILER)
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#if !defined (__clang__)
+#pragma GCC diagnostic ignored "-Wattribute-alias"
+#pragma GCC diagnostic ignored "-Wlto-type-mismatch"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning(disable:4101) // warning C4101: 'v': unreferenced local variable
+#pragma warning(disable:4116) // warning C4116: unnamed type definition in parentheses
+#pragma warning(disable:4244) // warning C4244: 'function': conversion from 'vopmask' to '__mmask8', possible loss of data
+#pragma warning(disable:4267) // warning C4267: 'initializing': conversion from 'size_t' to 'const int', possible loss of data
+#pragma warning(disable:4305) // warning C4305: 'function': truncation from 'double' to 'float'
 #endif

--- a/src/common/misc.h
+++ b/src/common/misc.h
@@ -362,6 +362,7 @@ typedef union {
 //
 
 #if defined (__GNUC__) && !defined(__INTEL_COMPILER)
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #if !defined (__clang__)
 #pragma GCC diagnostic ignored "-Wattribute-alias"

--- a/src/libm/sleeflibm_header.h.org
+++ b/src/libm/sleeflibm_header.h.org
@@ -123,7 +123,7 @@ typedef struct {
 
 #if !defined(Sleef_quad_DEFINED)
 #define Sleef_quad_DEFINED
-#if defined(__SIZEOF_FLOAT128__) || (defined(__linux__) && defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))) || (defined(__PPC64__) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 8)
+#if defined(__SIZEOF_FLOAT128__) || (defined(__linux__) && defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__)))
 typedef __float128 Sleef_quad;
 #else
 typedef struct { uint64_t x, y; } Sleef_quad;

--- a/src/libm/sleeflibm_header.h.org
+++ b/src/libm/sleeflibm_header.h.org
@@ -63,9 +63,10 @@
 
 #if defined(__VSX__) && defined(__PPC64__) && defined(__LITTLE_ENDIAN__)
 #include <altivec.h>
-typedef __vector double SLEEF_VECTOR_DOUBLE;
-typedef __vector float  SLEEF_VECTOR_FLOAT;
-typedef __vector int    SLEEF_VECTOR_INT;
+typedef __vector double       SLEEF_VECTOR_DOUBLE;
+typedef __vector float        SLEEF_VECTOR_FLOAT;
+typedef __vector int          SLEEF_VECTOR_INT;
+typedef __vector unsigned int SLEEF_VECTOR_UINT;
 #endif
 
 #if defined(__VX__) && defined(__VEC__)
@@ -73,9 +74,11 @@ typedef __vector int    SLEEF_VECTOR_INT;
 #include <vecintrin.h>
 #define SLEEF_VECINTRIN_H_INCLUDED
 #endif
-typedef __vector double SLEEF_VECTOR_DOUBLE;
-typedef __vector float  SLEEF_VECTOR_FLOAT;
-typedef __vector int    SLEEF_VECTOR_INT;
+typedef __vector double       SLEEF_VECTOR_DOUBLE;
+typedef __vector float        SLEEF_VECTOR_FLOAT;
+typedef __vector int          SLEEF_VECTOR_INT;
+typedef __vector unsigned int SLEEF_VECTOR_UINT;
+typedef __vector unsigned long long SLEEF_VECTOR_ULONGLONG;
 #endif
 
 //

--- a/src/quad-tester/CMakeLists.txt
+++ b/src/quad-tester/CMakeLists.txt
@@ -21,24 +21,6 @@ endif()
 
 #
 
-if(SLEEF_OPENSSL_FOUND)
-  # Build tester3printf
-  add_executable(tester3printf tester3printf.c)
-  add_dependencies(tester3printf sleefquad sleefquad_headers ${TARGET_LIBSLEEF} ${TARGET_HEADERS})
-  target_compile_definitions(tester3printf PRIVATE ${COMMON_TARGET_DEFINITIONS})
-  set_target_properties(tester3printf PROPERTIES C_STANDARD 99)
-  target_link_libraries(tester3printf sleefquad ${TARGET_LIBSLEEF} ${SLEEF_OPENSSL_LIBRARIES})
-  target_include_directories(tester3printf PRIVATE ${SLEEF_OPENSSL_INCLUDE_DIR})
-
-  if(CMAKE_CROSSCOMPILING AND EMULATOR)
-    add_test(NAME tester3printf COMMAND ${EMULATOR} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
-  else()
-    add_test(NAME tester3printf COMMAND tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
-  endif()
-endif()
-
-#
-
 function(add_test_iut IUT)
   if (LIB_MPFR)
     set(QTESTER qtester)
@@ -128,3 +110,21 @@ if(LIB_MPFR AND NOT MINGW)
     endif()
   endif()
 endif(LIB_MPFR AND NOT MINGW)
+
+if(SLEEF_OPENSSL_FOUND)
+  # Build tester3printf
+  add_executable(tester3printf tester3printf.c)
+  add_dependencies(tester3printf sleefquad sleefquad_headers ${TARGET_LIBSLEEF} ${TARGET_HEADERS})
+  target_compile_definitions(tester3printf PRIVATE ${COMMON_TARGET_DEFINITIONS})
+  set_target_properties(tester3printf PROPERTIES C_STANDARD 99)
+  target_link_libraries(tester3printf sleefquad ${TARGET_LIBSLEEF} ${SLEEF_OPENSSL_LIBRARIES})
+  target_include_directories(tester3printf PRIVATE ${SLEEF_OPENSSL_INCLUDE_DIR})
+
+  if (SDE_COMMAND)
+    add_test(NAME tester3printf COMMAND ${SDE_COMMAND} "--" ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
+  elseif(EMULATOR)
+    add_test(NAME tester3printf COMMAND ${EMULATOR} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
+  else()
+    add_test(NAME tester3printf COMMAND tester3printf ${sleef_SOURCE_DIR}/src/quad-tester/hash_printf.txt)
+  endif()
+endif()

--- a/src/quad-tester/qiutsimd.c
+++ b/src/quad-tester/qiutsimd.c
@@ -252,6 +252,41 @@ typedef union {
     }							\
   }
 
+#define func_m_q(funcStr, funcName) {					\
+    while (startsWith(buf, funcStr " ")) {				\
+      sentinel = 0;							\
+      int lane = xrand() % VECTLENDP;					\
+      cnv128 c0;							\
+      sscanf(buf, funcStr " %" PRIx64 ":%" PRIx64, &c0.h, &c0.l);	\
+      VARGQUAD a0;							\
+      memrand(&a0, SIZEOF_VARGQUAD);					\
+      a0 = xsetq(a0, lane, c0.q);					\
+      double d[VECTLENDP];						\
+      vstoreu_v_p_vd(d, vreinterpret_vd_vm(funcName(a0)));		\
+      printf("%" PRIx64 "\n", d2u(d[lane]));				\
+      fflush(stdout);							\
+      if (fgets(buf, BUFSIZE-1, stdin) == NULL) break;			\
+    }									\
+  }
+
+#define func_q_m(funcStr, funcName) {			\
+    while (startsWith(buf, funcStr " ")) {		\
+      sentinel = 0;					\
+      int lane = xrand() % VECTLENDP;			\
+      uint64_t u;					\
+      sscanf(buf, funcStr " %" PRIx64, &u);		\
+      double s[VECTLENDP];				\
+      memrand(s, sizeof(s));				\
+      s[lane] = u2d(u);					\
+      VARGQUAD a0 = funcName(vreinterpret_vm_vd(vloadu_vd_p(s)));	\
+      cnv128 c0;					\
+      c0.q = xgetq(a0, lane);				\
+      printf("%" PRIx64 ":%" PRIx64 "\n", c0.h, c0.l);	\
+      fflush(stdout);					\
+      if (fgets(buf, BUFSIZE-1, stdin) == NULL) break;	\
+    }							\
+  }
+
 #define func_strtoq(funcStr) {						\
     while (startsWith(buf, funcStr " ")) {				\
       sentinel = 0;							\
@@ -369,6 +404,10 @@ int do_test(int argc, char **argv) {
     func_q_q("negq", xnegq);
     func_q_d("cast_from_doubleq", xcast_from_doubleq);
     func_d_q("cast_to_doubleq", xcast_to_doubleq);
+    func_q_m("cast_from_int64q", xcast_from_int64q);
+    func_m_q("cast_to_int64q", xcast_to_int64q);
+    func_q_m("cast_from_uint64q", xcast_from_uint64q);
+    func_m_q("cast_to_uint64q", xcast_to_uint64q);
     func_i_q_q("cmpltq", xcmpltq);
     func_i_q_q("cmpgtq", xcmpgtq);
     func_i_q_q("cmpleq", xcmpleq);

--- a/src/quad-tester/qtesterutil.c
+++ b/src/quad-tester/qtesterutil.c
@@ -268,7 +268,7 @@ char *sprintfr(mpfr_t fr) {
 
 //
 
-#if MPFR_VERSION_MAJOR >= 4 && defined(ENABLEFLOAT128) && !defined(__APPLE__) && !defined(__PPC64__)
+#if MPFR_VERSION_MAJOR >= 4 && defined(ENABLEFLOAT128) && !defined(__APPLE__)
 void mpfr_set_f128(mpfr_t frx, Sleef_quad q, mpfr_rnd_t rnd) {
   int mpfr_set_float128(mpfr_t rop, __float128 op, mpfr_rnd_t rnd);
   union {

--- a/src/quad-tester/tester2simdqp.c
+++ b/src/quad-tester/tester2simdqp.c
@@ -160,6 +160,25 @@ double vgetd(vdouble v, int idx) {
   return a[idx];
 }
 
+vmask vsetm(vmask v, int idx, uint64_t d) {
+  uint64_t a[VECTLENDP];
+  vstoreu_v_p_vd((double *)a, vreinterpret_vd_vm(v));
+  a[idx] = d;
+  return vreinterpret_vm_vd(vloadu_vd_p((double *)a));
+}
+
+uint64_t vgetm(vmask v, int idx) {
+  uint64_t a[VECTLENDP];
+  vstoreu_v_p_vd((double *)a, vreinterpret_vd_vm(v));
+  return a[idx];
+}
+
+int64_t vgetm_signed(vmask v, int idx) {
+  int64_t a[VECTLENDP];
+  vstoreu_v_p_vd((double *)a, vreinterpret_vd_vm(v));
+  return a[idx];
+}
+
 static int vgeti(vint v, int idx) {
   int a[VECTLENDP*2];
   vstoreu_v_p_vi(a, v);
@@ -196,6 +215,11 @@ int main(int argc,char **argv)
   mpfr_t frw, frx, fry, frz;
   mpfr_inits(frw, frx, fry, frz, NULL);
 
+  memset(&a0, 0, sizeof(a0));
+  memset(&a1, 0, sizeof(a1));
+  memset(&a2, 0, sizeof(a2));
+  memset(&a3, 0, sizeof(a3));
+
   for(cnt = 0;ecnt < 1000;cnt++) {
     int e = cnt % VECTLENDP;
 
@@ -231,45 +255,54 @@ int main(int argc,char **argv)
     case 122:
       q0 = rndf128x();
       q1 = rndf128x();
-      q1 += 1;
+      q0 += q1;
       break;
     case 121:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q0 -= q1;
+      break;
+    case 120:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q1 += 1;
+      break;
+    case 119:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q0 += 1;
+      break;
+    case 118:
       q0 = rndf128x();
       q1 = rndf128x();
       q0 += 1;
       q1 -= 1;
       break;
-    case 120:
-      q0 = rndf128x();
-      q1 = rndf128x();
-      q1 += copysign(1, q1) * SLEEF_QUAD_MIN;
-      break;
-    case 119:
-      q0 = rndf128x();
-      q1 = rndf128x();
-      q1 = copysign(1, q1) * SLEEF_QUAD_MIN;
-      break;
-    case 118:
-      q0 = rndf128x();
-      q1 = rndf128x();
-      q0 += copysign(1, q0);
-      q1  = copysign(1, q1) * SLEEF_QUAD_MIN;
-      break;
     case 117:
       q0 = rndf128x();
       q1 = rndf128x();
-      q1 = copysign(1, q1) * SLEEF_QUAD_MIN;
+      q0 -= 1;
+      q1 += 1;
       break;
     case 116:
       q0 = rndf128x();
       q1 = rndf128x();
-      q0 += copysign(1, q0);
-      q1  = copysign(1, q1) * SLEEF_QUAD_MIN;
+      q1 += copysign(1, q1) * SLEEF_QUAD_MIN;
       break;
     case 115:
       q0 = rndf128x();
       q1 = rndf128x();
-      q1 += copysign(1, q1) * SLEEF_QUAD_MAX;
+      q0 += copysign(1, q0) * SLEEF_QUAD_MIN;
+      break;
+    case 114:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q1 -= copysign(1, q1) * SLEEF_QUAD_MIN;
+      break;
+    case 113:
+      q0 = rndf128x();
+      q1 = rndf128x();
+      q0 -= copysign(1, q0) * SLEEF_QUAD_MIN;
       break;
 #endif
     default:
@@ -389,6 +422,60 @@ int main(int argc,char **argv)
 	printf(ISANAME " cast_to_double arg=%s\n", sprintf128(q0));
 	printf("test = %.20g\n", td);
 	printf("corr = %.20g\n", cd);
+	fflush(stdout); ecnt++;
+      }
+    }
+
+    {
+      int64_t i64 = mpfr_get_sj(frx, GMP_RNDN);
+      vd0 = vreinterpret_vd_vm(vsetm(vreinterpret_vm_vd(vd0), e, i64));
+      t = vget(xcast_from_int64q(vreinterpret_vm_vd(vd0)), e);
+      mpfr_set_sj(frz, i64, GMP_RNDN);
+      Sleef_quad q2 = mpfr_get_f128(frz, GMP_RNDN);
+
+      if (memcmp(&t, &q2, sizeof(Sleef_quad)) != 0) {
+	printf(ISANAME " cast_from_int64q arg=%lld\n", (long long)i64);
+	printf("test = %s\n", sprintf128(t));
+	printf("corr = %s\n\n", sprintf128(q2));
+	fflush(stdout); ecnt++;
+      }
+    }
+
+    {
+      int64_t td = vgetm_signed(xcast_to_int64q(a0), e);
+      int64_t cd = mpfr_get_sj(frx, GMP_RNDZ);
+
+      if (cd != td && !isnan(mpfr_get_d(frx, GMP_RNDN))) {
+	printf(ISANAME " cast_to_int64q arg=%s\n", sprintf128(q0));
+	printf("test = %lld\n", (long long)td);
+	printf("corr = %lld\n", (long long)cd);
+	fflush(stdout); ecnt++;
+      }
+    }
+
+    {
+      uint64_t u64 = mpfr_get_uj(frx, GMP_RNDN);
+      vd0 = vreinterpret_vd_vm(vsetm(vreinterpret_vm_vd(vd0), e, u64));
+      t = vget(xcast_from_uint64q(vreinterpret_vm_vd(vd0)), e);
+      mpfr_set_uj(frz, u64, GMP_RNDN);
+      Sleef_quad q2 = mpfr_get_f128(frz, GMP_RNDN);
+
+      if (memcmp(&t, &q2, sizeof(Sleef_quad)) != 0) {
+	printf(ISANAME " cast_from_uint64q arg=%llu\n", (unsigned long long)u64);
+	printf("test = %s\n", sprintf128(t));
+	printf("corr = %s\n\n", sprintf128(q2));
+	fflush(stdout); ecnt++;
+      }
+    }
+
+    {
+      uint64_t td = vgetm_signed(xcast_to_uint64q(a0), e);
+      uint64_t cd = mpfr_get_uj(frx, GMP_RNDZ);
+
+      if (cd != td && !isnan(mpfr_get_d(frx, GMP_RNDN))) {
+	printf(ISANAME " cast_to_uint64q arg=%s\n", sprintf128(q0));
+	printf("test = %llu\n", (unsigned long long)td);
+	printf("corr = %llu\n", (unsigned long long)cd);
 	fflush(stdout); ecnt++;
       }
     }

--- a/src/quad-tester/tester2simdqp.c
+++ b/src/quad-tester/tester2simdqp.c
@@ -215,10 +215,12 @@ int main(int argc,char **argv)
   mpfr_t frw, frx, fry, frz;
   mpfr_inits(frw, frx, fry, frz, NULL);
 
+#ifndef ENABLE_SVE
   memset(&a0, 0, sizeof(a0));
   memset(&a1, 0, sizeof(a1));
   memset(&a2, 0, sizeof(a2));
   memset(&a3, 0, sizeof(a3));
+#endif
 
   for(cnt = 0;ecnt < 1000;cnt++) {
     int e = cnt % VECTLENDP;

--- a/src/quad-tester/tester3printf.c
+++ b/src/quad-tester/tester3printf.c
@@ -107,6 +107,8 @@ static void testem(MD5_CTX *ctx, Sleef_quad val, char *types) {
 
 int main(int argc, char **argv) {
 #if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 13)
+#pragma GCC diagnostic ignored "-Wformat"
+#pragma GCC diagnostic ignored "-Wformat-extra-args"
   Sleef_registerPrintfHook();
   static char buf[110];
   Sleef_quad q = Sleef_strtoq("3.1415926535897932384626433832795028842", NULL);

--- a/src/quad/CMakeLists.txt
+++ b/src/quad/CMakeLists.txt
@@ -28,8 +28,8 @@ set(QUAD_HEADER_PARAMS_AVX2            4 Sleef_quadx4 Sleef_quadx4_2 __m256d    
 set(QUAD_HEADER_PARAMS_AVX512F         8 Sleef_quadx8 Sleef_quadx8_2 __m512d     __m512      __m512i    __m256i   __AVX512F__       avx512f)
 set(QUAD_HEADER_PARAMS_ADVSIMD         2 Sleef_quadx2 Sleef_quadx2_2 float64x2_t float32x4_t uint32x4_t int32x2_t __ARM_NEON        advsimd)
 set(QUAD_HEADER_PARAMS_SVE             x Sleef_svquad Sleef_svquad_2 svfloat64_t svfloat32_t svint32_t  svint32_t __ARM_FEATURE_SVE sve)
-set(QUAD_HEADER_PARAMS_VSX             2 Sleef_quadx2 Sleef_quadx2_2 "SLEEF_VECTOR_DOUBLE" "SLEEF_VECTOR_FLOAT" "SLEEF_VECTOR_INT" "SLEEF_VECTOR_INT" __VSX__ vsx)
-set(QUAD_HEADER_PARAMS_ZVECTOR2        2 Sleef_quadx2 Sleef_quadx2_2 "SLEEF_VECTOR_DOUBLE" "SLEEF_VECTOR_FLOAT" "SLEEF_VECTOR_INT" "SLEEF_VECTOR_INT" __VEC__ zvector2)
+set(QUAD_HEADER_PARAMS_VSX             2 Sleef_quadx2 Sleef_quadx2_2 "SLEEF_VECTOR_DOUBLE" "SLEEF_VECTOR_FLOAT" "SLEEF_VECTOR_UINT" "SLEEF_VECTOR_INT" __VSX__ vsx)
+set(QUAD_HEADER_PARAMS_ZVECTOR2        2 Sleef_quadx2 Sleef_quadx2_2 "SLEEF_VECTOR_DOUBLE" "SLEEF_VECTOR_FLOAT" "SLEEF_VECTOR_ULONGLONG" "SLEEF_VECTOR_INT" __VEC__ zvector2)
 
 set(QUAD_RENAME_PARAMS_PUREC_SCALAR    1 purec)
 set(QUAD_RENAME_PARAMS_PURECFMA_SCALAR 1 purecfma)

--- a/src/quad/qfuncproto.h
+++ b/src/quad/qfuncproto.h
@@ -58,6 +58,10 @@ funcSpec funcList[] = {
 
   { "cast_to_double", -1, 0, 10, 0 },
   { "cast_from_double", -1, 0, 11, 0 },
+  { "cast_to_int64", -1, 0, 12, 0 },
+  { "cast_from_int64", -1, 0, 13, 0 },
+  { "cast_to_uint64", -1, 0, 12, 0 },
+  { "cast_from_uint64", -1, 0, 13, 0 },
   { "load", -1, 0, 14, 0 },
   { "store", -1, 0, 15, 0 },
   { "get", -1, 0, 16, 0 },


### PR DESCRIPTION
This patch adds functions for casting between 64-bit integer and quad.
It also fixes a bug in quad-precision log1p function.