### PR TITLE
Add s390x and ppc64le support to the benchmarking utility

### DIFF
--- a/src/libm-benchmarks/Makefile
+++ b/src/libm-benchmarks/Makefile
@@ -55,6 +55,22 @@ benchsleef : benchsleef.c benchsleef128.o bench.h
 benchsleef128.o : benchsleef128.c bench.h
 	$(CC) benchsleef128.c -Wall -march=native -O0 -g -I$(BUILDDIR)/include -L$(BUILDDIR)/lib -Wno-attributes -c
 
+else ifeq ($(ARCH),s390x)
+
+benchsleef : benchsleef.c benchsleef128.o bench.h
+	$(CC) benchsleef.c benchsleef128.o -Wall -march=native -O0 -g -I$(BUILDDIR)/include -L$(BUILDDIR)/lib -Wno-attributes -lsleef -lm -o benchsleef
+
+benchsleef128.o : benchsleef128.c bench.h
+	$(CC) benchsleef128.c -Wall -mzvector -march=native -O0 -g -I$(BUILDDIR)/include -L$(BUILDDIR)/lib -Wno-attributes -c
+
+else ifeq ($(ARCH),ppc64le)
+
+benchsleef : benchsleef.c benchsleef128.o bench.h
+	$(CC) benchsleef.c benchsleef128.o -Wall -mcpu=native -O0 -g -I$(BUILDDIR)/include -L$(BUILDDIR)/lib -Wno-attributes -lsleef -lm -o benchsleef
+
+benchsleef128.o : benchsleef128.c bench.h
+	$(CC) benchsleef128.c -Wall -mcpu=native -O0 -g -I$(BUILDDIR)/include -L$(BUILDDIR)/lib -Wno-attributes -c
+
 else
 
 benchsleef : benchsleef.c benchsleef128.o benchsleef256.o benchsleef512.o bench.h

--- a/src/libm-benchmarks/benchsleef.c
+++ b/src/libm-benchmarks/benchsleef.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
   int do128bit = 1;
   int do256bit = cpuSupportsAVX();
   int do512bit = cpuSupportsAVX512F();
-#elif defined(__ARM_NEON)
+#elif defined(__ARM_NEON) || defined(__VSX__) || defined(__VX__)
   int do128bit = 1;
 #else
 #error Unsupported architecture

--- a/src/libm-benchmarks/benchsleef128.c
+++ b/src/libm-benchmarks/benchsleef128.c
@@ -36,6 +36,16 @@ typedef __m128 vfloat;
 typedef float64x2_t vdouble;
 typedef float32x4_t vfloat;
 #define ENABLED
+#elif defined(__VSX__)
+#include <altivec.h>
+typedef __vector double vdouble;
+typedef __vector float  vfloat;
+#define ENABLED
+#elif defined(__VX__)
+#include <vecintrin.h>
+typedef __vector double vdouble;
+typedef __vector float  vfloat;
+#define ENABLED
 #endif
 
 #ifdef ENABLED


### PR DESCRIPTION
This patch adds s390x and ppc64le support to the benchmarking utility.