### PR TITLE
Provide dummy destination in namelink install

### DIFF
--- a/src/dft/CMakeLists.txt
+++ b/src/dft/CMakeLists.txt
@@ -376,6 +376,7 @@ install(
 
 install(
     TARGETS ${TARGET_LIBDFT}
+    DESTINATION dummy # provided above already
     LIBRARY #
     DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     COMPONENT sleef_Development

--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -1033,6 +1033,7 @@ if(BUILD_SCALAR_LIB)
 
   install(
       TARGETS sleefscalar
+      DESTINATION dummy # provided above already
       LIBRARY #
       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
       COMPONENT sleef_Development
@@ -1065,6 +1066,7 @@ install(
 )
 install(
     TARGETS ${TARGET_LIBSLEEF}
+    DESTINATION dummy # provided above already
     LIBRARY #
     DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     COMPONENT sleef_Development
@@ -1095,6 +1097,7 @@ if(ENABLE_GNUABI)
 
   install(
       TARGETS ${TARGET_LIBSLEEF}
+      DESTINATION dummy # provided above already
       LIBRARY #
       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
       COMPONENT sleef_Development

--- a/src/quad/CMakeLists.txt
+++ b/src/quad/CMakeLists.txt
@@ -511,6 +511,7 @@ install(
 
 install(
     TARGETS sleefquad
+    DESTINATION dummy # provided above already
     LIBRARY #
     DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     COMPONENT sleef_Development


### PR DESCRIPTION
> A DESTINATION without a block will provide a default for all blocks,
> because DESTINATION is always required prior to CMake 3.14, even if it's
> already provided in a previous install rule and install rules for
> targets had to be split in two prior to CMake 3.12.

Fixes: #417