### PR TITLE
Fix gcc warnings

### DIFF
--- a/src/arch/helperavx.h
+++ b/src/arch/helperavx.h
@@ -128,20 +128,20 @@ static INLINE vdouble vreinterpret_vd_vm(vmask vm) { return _mm256_castsi256_pd(
 
 //
 
-static vint2 vloadu_vi2_p(int32_t *p) {
+static INLINE vint2 vloadu_vi2_p(int32_t *p) {
   vint2 r;
   r.x = _mm_loadu_si128((__m128i *) p     );
   r.y = _mm_loadu_si128((__m128i *)(p + 4));
   return r;
 }
 
-static void vstoreu_v_p_vi2(int32_t *p, vint2 v) {
+static INLINE void vstoreu_v_p_vi2(int32_t *p, vint2 v) {
   _mm_storeu_si128((__m128i *) p     , v.x);
   _mm_storeu_si128((__m128i *)(p + 4), v.y);  
 }
 
-static vint vloadu_vi_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
-static void vstoreu_v_p_vi(int32_t *p, vint v) { _mm_storeu_si128((__m128i *)p, v); }
+static INLINE vint vloadu_vi_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
+static INLINE void vstoreu_v_p_vi(int32_t *p, vint v) { _mm_storeu_si128((__m128i *)p, v); }
 
 //
 
@@ -570,7 +570,7 @@ static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloa
 
 //
 
-static vquad loadu_vq_p(void *p) {
+static INLINE vquad loadu_vq_p(void *p) {
   vquad vq;
   memcpy(&vq, p, VECTLENDP * 16);
   return vq;

--- a/src/arch/helperavx2.h
+++ b/src/arch/helperavx2.h
@@ -114,10 +114,10 @@ static INLINE vdouble vreinterpret_vd_vm(vmask vm) { return _mm256_castsi256_pd(
 
 //
 
-static vint2 vloadu_vi2_p(int32_t *p) { return _mm256_loadu_si256((__m256i const *)p); }
-static void vstoreu_v_p_vi2(int32_t *p, vint2 v) { _mm256_storeu_si256((__m256i *)p, v); }
-static vint vloadu_vi_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
-static void vstoreu_v_p_vi(int32_t *p, vint v) { _mm_storeu_si128((__m128i *)p, v); }
+static INLINE vint2 vloadu_vi2_p(int32_t *p) { return _mm256_loadu_si256((__m256i const *)p); }
+static INLINE void vstoreu_v_p_vi2(int32_t *p, vint2 v) { _mm256_storeu_si256((__m256i *)p, v); }
+static INLINE vint vloadu_vi_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
+static INLINE void vstoreu_v_p_vi(int32_t *p, vint v) { _mm_storeu_si128((__m128i *)p, v); }
 
 //
 
@@ -440,7 +440,7 @@ static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloa
 
 //
 
-static vquad loadu_vq_p(void *p) {
+static INLINE vquad loadu_vq_p(void *p) {
   vquad vq;
   memcpy(&vq, p, VECTLENDP * 16);
   return vq;

--- a/src/arch/helperavx2_128.h
+++ b/src/arch/helperavx2_128.h
@@ -109,10 +109,10 @@ static INLINE vdouble vreinterpret_vd_vm(vmask vm) { return _mm_castsi128_pd(vm)
 
 //
 
-static vint2 vloadu_vi2_p(int32_t *p) { return _mm_loadu_si128((__m128i const *)p); }
-static void vstoreu_v_p_vi2(int32_t *p, vint2 v) { _mm_storeu_si128((__m128i *)p, v); }
-static vint vloadu_vi_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
-static void vstoreu_v_p_vi(int32_t *p, vint v) { _mm_storeu_si128((__m128i *)p, v); }
+static INLINE vint2 vloadu_vi2_p(int32_t *p) { return _mm_loadu_si128((__m128i const *)p); }
+static INLINE void vstoreu_v_p_vi2(int32_t *p, vint2 v) { _mm_storeu_si128((__m128i *)p, v); }
+static INLINE vint vloadu_vi_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
+static INLINE void vstoreu_v_p_vi(int32_t *p, vint v) { _mm_storeu_si128((__m128i *)p, v); }
 
 //
 
@@ -413,7 +413,7 @@ static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloa
 
 //
 
-static vquad loadu_vq_p(void *p) {
+static INLINE vquad loadu_vq_p(void *p) {
   vquad vq = {
     vloadu_vi2_p((int32_t *)p),
     vloadu_vi2_p((int32_t *)((uint8_t *)p + sizeof(vmask)))
@@ -433,7 +433,7 @@ static INLINE vargquad cast_aq_vq(vquad vq) {
   return aq;
 }
 
-static void vstoreu_v_p_vq(void *p, vquad vq) {
+static INLINE void vstoreu_v_p_vq(void *p, vquad vq) {
   vstoreu_v_p_vi2((int32_t *)p, vcast_vi2_vm(vq.x));
   vstoreu_v_p_vi2((int32_t *)((uint8_t *)p + sizeof(vmask)), vcast_vi2_vm(vq.y));
 }

--- a/src/arch/helpersse2.h
+++ b/src/arch/helpersse2.h
@@ -131,11 +131,11 @@ static INLINE int vtestallones_i_vo64(vopmask g) { return _mm_movemask_epi8(g) =
 
 //
 
-static vint2 vloadu_vi2_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
-static void vstoreu_v_p_vi2(int32_t *p, vint2 v) { _mm_storeu_si128((__m128i *)p, v); }
+static INLINE vint2 vloadu_vi2_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
+static INLINE void vstoreu_v_p_vi2(int32_t *p, vint2 v) { _mm_storeu_si128((__m128i *)p, v); }
 
-static vint vloadu_vi_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
-static void vstoreu_v_p_vi(int32_t *p, vint v) { _mm_storeu_si128((__m128i *)p, v); }
+static INLINE vint vloadu_vi_p(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
+static INLINE void vstoreu_v_p_vi(int32_t *p, vint v) { _mm_storeu_si128((__m128i *)p, v); }
 
 //
 
@@ -466,7 +466,7 @@ static INLINE void vsscatter2_v_p_i_i_vf(float *ptr, int offset, int step, vfloa
 
 //
 
-static vquad loadu_vq_p(void *p) {
+static INLINE vquad loadu_vq_p(void *p) {
   vquad vq;
   memcpy(&vq, p, VECTLENDP * 16);
   return vq;

--- a/src/libm/sleefinline_header.h.org
+++ b/src/libm/sleefinline_header.h.org
@@ -20,7 +20,9 @@
 #pragma fp_contract (off)
 #endif
 
+#if !(defined(__GNUC__) && !defined (__clang__))
 #pragma STDC FP_CONTRACT OFF
+#endif
 
 #ifndef SLEEF_FP_ILOGB0
 #define SLEEF_FP_ILOGB0 ((int)0x80000000)


### PR DESCRIPTION
This fixes warnings that would otherwise be emitted by ``gcc -Wall  test.c -c -Iinclude -mavx2 -O2 -mfma -ffp-contract=off" on the below test.c
```
#include <stdio.h>
#include <stdint.h>
#include <string.h>
#include <x86intrin.h>

#include <sleefinline_sse4.h>
#include <sleefinline_sse2.h>
#include <sleefinline_avx.h>
#include <sleefinline_avx2.h>
#include <sleefinline_avx2128.h>
```

Warnings emitted before this pull request:
```
In file included from test.c:6:
include/sleefinline_sse4.h:23: warning: ignoring #pragma STDC FP_CONTRACT [-Wunknown-pragmas]
   23 | #pragma STDC FP_CONTRACT OFF
      | 
In file included from test.c:7:
include/sleefinline_sse2.h:23: warning: ignoring #pragma STDC FP_CONTRACT [-Wunknown-pragmas]
   23 | #pragma STDC FP_CONTRACT OFF
      | 
In file included from test.c:8:
include/sleefinline_avx.h:23: warning: ignoring #pragma STDC FP_CONTRACT [-Wunknown-pragmas]
   23 | #pragma STDC FP_CONTRACT OFF
      | 
In file included from test.c:9:
include/sleefinline_avx2.h:23: warning: ignoring #pragma STDC FP_CONTRACT [-Wunknown-pragmas]
   23 | #pragma STDC FP_CONTRACT OFF
      | 
In file included from test.c:10:
include/sleefinline_avx2128.h:23: warning: ignoring #pragma STDC FP_CONTRACT [-Wunknown-pragmas]
   23 | #pragma STDC FP_CONTRACT OFF
      | 
In file included from test.c:10:
include/sleefinline_avx2128.h:1452:13: warning: ‘vstoreu_v_p_vq’ defined but not used [-Wunused-function]
 1452 | static void vstoreu_v_p_vq(void *p, vquad_avx2128_sleef vq) {
      |             ^~~~~~~~~~~~~~
include/sleefinline_avx2128.h:1432:28: warning: ‘loadu_vq_p_avx2128_sleef’ defined but not used [-Wunused-function]
 1432 | static vquad_avx2128_sleef loadu_vq_p_avx2128_sleef(void *p) {
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~
include/sleefinline_avx2128.h:1170:13: warning: ‘vstoreu_v_p_vi_avx2128_sleef’ defined but not used [-Wunused-function]
 1170 | static void vstoreu_v_p_vi_avx2128_sleef(int32_t *p, vint_avx2128_sleef v) { _mm_storeu_si128((__m128i *)p, v); }
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/sleefinline_avx2128.h:1169:27: warning: ‘vloadu_vi_p_avx2128_sleef’ defined but not used [-Wunused-function]
 1169 | static vint_avx2128_sleef vloadu_vi_p_avx2128_sleef(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from test.c:9:
include/sleefinline_avx2.h:1457:25: warning: ‘loadu_vq_p_avx2_sleef’ defined but not used [-Wunused-function]
 1457 | static vquad_avx2_sleef loadu_vq_p_avx2_sleef(void *p) {
      |                         ^~~~~~~~~~~~~~~~~~~~~
include/sleefinline_avx2.h:1175:13: warning: ‘vstoreu_v_p_vi_avx2_sleef’ defined but not used [-Wunused-function]
 1175 | static void vstoreu_v_p_vi_avx2_sleef(int32_t *p, vint_avx2_sleef v) { _mm_storeu_si128((__m128i *)p, v); }
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
include/sleefinline_avx2.h:1174:24: warning: ‘vloadu_vi_p_avx2_sleef’ defined but not used [-Wunused-function]
 1174 | static vint_avx2_sleef vloadu_vi_p_avx2_sleef(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
      |                        ^~~~~~~~~~~~~~~~~~~~~~
include/sleefinline_avx2.h:1173:13: warning: ‘vstoreu_v_p_vi2_avx2_sleef’ defined but not used [-Wunused-function]
 1173 | static void vstoreu_v_p_vi2_avx2_sleef(int32_t *p, vint2_avx2_sleef v) { _mm256_storeu_si256((__m256i *)p, v); }
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~
include/sleefinline_avx2.h:1172:25: warning: ‘vloadu_vi2_p_avx2_sleef’ defined but not used [-Wunused-function]
 1172 | static vint2_avx2_sleef vloadu_vi2_p_avx2_sleef(int32_t *p) { return _mm256_loadu_si256((__m256i const *)p); }
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
In file included from test.c:8:
include/sleefinline_avx.h:1546:24: warning: ‘loadu_vq_p_avx_sleef’ defined but not used [-Wunused-function]
 1546 | static vquad_avx_sleef loadu_vq_p_avx_sleef(void *p) {
      |                        ^~~~~~~~~~~~~~~~~~~~
include/sleefinline_avx.h:1184:23: warning: ‘vloadu_vi_p_avx_sleef’ defined but not used [-Wunused-function]
 1184 | static vint_avx_sleef vloadu_vi_p_avx_sleef(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
      |                       ^~~~~~~~~~~~~~~~~~~~~
include/sleefinline_avx.h:1172:24: warning: ‘vloadu_vi2_p_avx_sleef’ defined but not used [-Wunused-function]
 1172 | static vint2_avx_sleef vloadu_vi2_p_avx_sleef(int32_t *p) {
      |                        ^~~~~~~~~~~~~~~~~~~~~~
In file included from test.c:7:
include/sleefinline_sse2.h:1447:25: warning: ‘loadu_vq_p_sse2_sleef’ defined but not used [-Wunused-function]
 1447 | static vquad_sse2_sleef loadu_vq_p_sse2_sleef(void *p) {
      |                         ^~~~~~~~~~~~~~~~~~~~~
include/sleefinline_sse2.h:1166:24: warning: ‘vloadu_vi_p_sse2_sleef’ defined but not used [-Wunused-function]
 1166 | static vint_sse2_sleef vloadu_vi_p_sse2_sleef(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
      |                        ^~~~~~~~~~~~~~~~~~~~~~
include/sleefinline_sse2.h:1163:25: warning: ‘vloadu_vi2_p_sse2_sleef’ defined but not used [-Wunused-function]
 1163 | static vint2_sse2_sleef vloadu_vi2_p_sse2_sleef(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
In file included from test.c:6:
include/sleefinline_sse4.h:1437:25: warning: ‘loadu_vq_p_sse4_sleef’ defined but not used [-Wunused-function]
 1437 | static vquad_sse4_sleef loadu_vq_p_sse4_sleef(void *p) {
      |                         ^~~~~~~~~~~~~~~~~~~~~
include/sleefinline_sse4.h:1166:24: warning: ‘vloadu_vi_p_sse4_sleef’ defined but not used [-Wunused-function]
 1166 | static vint_sse4_sleef vloadu_vi_p_sse4_sleef(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
      |                        ^~~~~~~~~~~~~~~~~~~~~~
include/sleefinline_sse4.h:1163:25: warning: ‘vloadu_vi2_p_sse4_sleef’ defined but not used [-Wunused-function]
 1163 | static vint2_sse4_sleef vloadu_vi2_p_sse4_sleef(int32_t *p) { return _mm_loadu_si128((__m128i *)p); }
      |                         ^~~~~~~~~~~~~~~~~~~~~~~
```