### PR TITLE
Use `addSuffix` in place of cat/type

### DIFF
--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -182,12 +182,7 @@ foreach(SIMD ${SLEEF_HEADER_LIST})
   list(APPEND SLEEF_HEADER_COMMANDS COMMAND $<TARGET_FILE:${TARGET_MKRENAME}> ${HEADER_PARAMS_${SIMD}} >> ${SLEEF_INCLUDE_HEADER})
 endforeach()
 
-if((MSVC OR MINGW AND WIN32) OR SLEEF_CLANG_ON_WINDOWS)
-  string(REPLACE "/" "\\" sleef_footer_input_file "${SLEEF_ORG_FOOTER}")
-  list(APPEND SLEEF_HEADER_COMMANDS COMMAND type ${sleef_footer_input_file} >> ${SLEEF_INCLUDE_HEADER})
-else()
-  list(APPEND SLEEF_HEADER_COMMANDS COMMAND cat ${SLEEF_ORG_FOOTER} >> ${SLEEF_INCLUDE_HEADER})
-endif()
+list(APPEND SLEEF_HEADER_COMMANDS COMMAND $<TARGET_FILE:addSuffix> ${SLEEF_ORG_FOOTER} >> ${SLEEF_INCLUDE_HEADER})
 
 add_custom_command(OUTPUT ${SLEEF_INCLUDE_HEADER}
   ${SLEEF_HEADER_COMMANDS}
@@ -195,6 +190,7 @@ add_custom_command(OUTPUT ${SLEEF_INCLUDE_HEADER}
     ${SLEEF_ORG_HEADER}
     ${SLEEF_ORG_FOOTER}
     ${TARGET_MKRENAME}
+    addSuffix
 )
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
Similar to 75b62aafe98279b1df636b1aaa330189ef637e53 (#396) for better support of MinGW.

This fixes the regression caused by #266 when building for mingw under msys2.

Seem that the solution from https://github.com/shibatch/sleef/pull/266#issuecomment-552765599 is implemented.