### PR TITLE
Extend FMA support to RISC-V

### DIFF
--- a/src/arch/helperpurec_scalar.h
+++ b/src/arch/helperpurec_scalar.h
@@ -54,7 +54,7 @@
 #define ENABLE_FMA_SP
 //@#define ENABLE_FMA_SP
 
-#if defined(__AVX2__) || defined(__aarch64__) || defined(__arm__) || defined(__powerpc64__) || defined(__zarch__) || CONFIG == 3
+#if defined(__AVX2__) || defined(__aarch64__) || defined(__arm__) || defined(__powerpc64__) || defined(__zarch__) || defined(__riscv) || CONFIG == 3
 #ifndef FP_FAST_FMA
 //@#ifndef FP_FAST_FMA
 #define FP_FAST_FMA


### PR DESCRIPTION
At the moment, SLEEF fails to compile on the RISC-V architecture. The problem is that the RISC-V architecture is not listed among those supporting Fused Multiply-Add. This PR just adds the `__riscv` flag to the list of architectures supporting FMA.