### PR TITLE
Rename global variable to avoid duplicate definitions

### DIFF
--- a/src/libm/tryvsx3.c
+++ b/src/libm/tryvsx3.c
@@ -1,8 +1,8 @@
 #include <altivec.h>
 
 __vector double sleef_cpuidtmp0;
-__vector unsigned long long sleef_cpuidtmp1, sleef_cpuidtmp2;
+__vector unsigned long long sleef_cpuidtmp1, sleef_cpuidtmp3;
 
 void sleef_tryVSX3() {
-  sleef_cpuidtmp0 = vec_insert_exp(sleef_cpuidtmp1, sleef_cpuidtmp2);
+  sleef_cpuidtmp0 = vec_insert_exp(sleef_cpuidtmp1, sleef_cpuidtmp3);
 }


### PR DESCRIPTION
The vairable sleef_cpuidtmp2 is already defined in the common code (src/libm/dispscalar.c.org) in the global scope.
Its redefinition in Power specific code (src/libm/tryvsx3.c) in global scope was causing compilation error on Power10. It is fixed now by renaming the variable in Power specific code.

There are test failures still present on Power10, that need to be fixed.