### PR TITLE
Support for RiscV architecture

### DIFF
--- a/src/arch/helperpurec_scalar.h
+++ b/src/arch/helperpurec_scalar.h
@@ -54,7 +54,7 @@
 #define ENABLE_FMA_SP
 //@#define ENABLE_FMA_SP
 
-#if defined(__AVX2__) || defined(__aarch64__) || defined(__arm__) || defined(__powerpc64__) || defined(__zarch__) || CONFIG == 3
+#if defined(__AVX2__) || defined(__aarch64__) || defined(__arm__) || defined(__powerpc64__) || defined(__zarch__) || defined(__riscv) || CONFIG == 3
 #ifndef FP_FAST_FMA
 //@#ifndef FP_FAST_FMA
 #define FP_FAST_FMA


### PR DESCRIPTION
Hi,

I am working to port Pytorch to RiscV. 

**Platform details:**
OS: Ubuntu 
Image: SiFive HiFive unmatched RiscV64
Booted on Qemu

**Application details:**
Pytorch, Sleef

The build fails with error as shown below.

[ 29%] Building C object sleef/src/libm/CMakeFiles/sleefpurecfma_scalar.dir/sleefsimdsp.c.o
In file included from /home/ubuntu/pytorch/third_party/sleef/src/libm/sleefsimdsp.c:358:
/home/ubuntu/pytorch/third_party/sleef/src/arch/helperpurec_scalar.h:69:2: error: #error FP_FAST_FMA or FP_FAST_FMAF not defined
   69 | #error FP_FAST_FMA or FP_FAST_FMAF not defined
        |  ^~~~~
gmake[2]: *** [sleef/src/libm/CMakeFiles/sleefpurecfma_scalar.dir/build.make:81: sleef/src/libm/CMakeFiles/sleefpurecfma_scalar.dir/sleefsimdsp.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:6565: sleef/src/libm/CMakeFiles/sleefpurecfma_scalar.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
gmake: *** [Makefile:146: all] Error 2

I edited the file "sleef/src/arch/helperpurec_scalar.h" and updated the architecture "__riscv" after which the issue was resolved and build proceeded.

Regards,
Anup