### PR TITLE
Do not define our own mpfr_sinpi/mpfr_cospi for mpfr 4.2.0 and later

### DIFF
--- a/src/libm-tester/testerutil.c
+++ b/src/libm-tester/testerutil.c
@@ -289,6 +289,7 @@ double countULP2sp(float d, mpfr_t c0) {
 
 //
 
+#if MPFR_VERSION < MPFR_VERSION_NUM(4, 2, 0)
 void mpfr_sinpi(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd) {
   mpfr_t frpi, frd;
   mpfr_inits(frpi, frd, NULL);
@@ -314,6 +315,7 @@ void mpfr_cospi(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd) {
 
   mpfr_clears(frpi, frd, NULL);
 }
+#endif
 
 void mpfr_lgamma_nosign(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd) {
   int s;

--- a/src/libm-tester/testerutil.h
+++ b/src/libm-tester/testerutil.h
@@ -90,7 +90,9 @@ int cmpDenormsp(float x, mpfr_t fry);
 double countULPsp(float d, mpfr_t c);
 double countULP2sp(float d, mpfr_t c);
 
+#if MPFR_VERSION < MPFR_VERSION_NUM(4, 2, 0)
 void mpfr_sinpi(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd);
 void mpfr_cospi(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd);
+#endif
 void mpfr_lgamma_nosign(mpfr_t ret, mpfr_t arg, mpfr_rnd_t rnd);
 #endif


### PR DESCRIPTION
These two functions were added to the MPFR API.

Fixes #458.

This is offered as alternative to https://github.com/shibatch/sleef/pull/462, in case you would like to maintain backwards compatibility with MPFR versions earlier than 4.2.0. I don’t view either PR as better than the other; it’s merely a matter of choice.