### PR TITLE
Add CI on Github Actions for x86_64, aarch64, arm, ppc64 and s390x

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,117 @@
+
+name: "Build & Test"
+
+on:
+  # allow direct trigger
+  workflow_dispatch:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq build-essential clang curl ninja-build libgmp-dev libmpfr-dev cpuinfo
+
+      - name: CPU Info
+        run: isa-info
+
+      - name: Build native
+        run: |
+          cmake -S . -B _build-native -GNinja \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/_install-native \
+            -DBUILD_STATIC_TEST_BINS=ON
+          cmake --build _build-native
+          cmake --install _build-native
+
+      - name: Test native
+        run: |
+          cd _build-native
+          ctest -j$(nproc)
+
+  build-and-test-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # AArch64
+          - arch: aarch64
+            qemu_cpu: "max,sve=off"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve128=on"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve256=on"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve512=on"
+          # Aarch32
+          - arch: armhf
+            binfmt: arm
+            package: -arm-linux-gnueabihf
+          # PPC64
+          - arch: ppc64el
+            binfmt: ppc64le
+            package: -powerpc64le-linux-gnu
+          # IBM Z
+          - arch: s390x
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-qemu-action@v3.0.0
+        with:
+          platforms: ${{ matrix.binfmt || matrix.arch }}
+
+      - name: Install dependencies
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq build-essential clang curl ninja-build libgmp-dev libmpfr-dev gcc${{ matrix.package || format('-{0}-linux-gnu', matrix.arch) }}
+
+      - name: Print host CPU info
+        run: |
+          cat /proc/cpuinfo
+
+      - name: Build native
+        run: |
+          cmake -S . -B _build-native -GNinja \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/_install-native \
+            -DBUILD_STATIC_TEST_BINS=ON \
+            -DENFORCE_TESTER=ON
+          cmake --build _build-native
+          cmake --install _build-native
+
+      - name: Build ${{ matrix.arch }}
+        env:
+          CTEST_OUTPUT_ON_FAILURE: "TRUE"
+          QEMU_CPU: ${{ matrix.qemu_cpu }}
+        run: |
+          cmake -S . -B _build-${{ matrix.arch }} -GNinja \
+            -DCMAKE_TOOLCHAIN_FILE=$(pwd)/travis/toolchain-${{ matrix.arch }}.cmake \
+            -DCMAKE_INSTALL_PREFIX="$(pwd)/_install-${{ matrix.arch }}" \
+            -DNATIVE_BUILD_DIR="$(pwd)/_build-native" \
+            -DSLEEF_SHOW_CONFIG=1 \
+            -DDISABLE_SSL=ON \
+            -DBUILD_DFT=OFF \
+            -DBUILD_GNUABI_LIBS=OFF \
+            -DBUILD_INLINE_HEADERS=OFF \
+            -DBUILD_QUAD=OFF \
+            -DBUILD_SCALAR_LIB=ON \
+            -DBUILD_STATIC_TEST_BINS=ON \
+            ${EXTRA_CMAKE_FLAGS}
+          cmake --build _build-${{ matrix.arch }}
+          cmake --install _build-${{ matrix.arch }}
+
+      - name: Test ${{ matrix.arch }}
+        env:
+          QEMU_CPU: ${{ matrix.qemu_cpu }}
+        run: |
+          cd _build-${{ matrix.arch }}
+          ctest -j$(nproc)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,12 +97,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [aarch64, armhf, ppc64el, s390x]
         include:
+          # AArch64
+          - arch: aarch64
+          # Aarch32
           - arch: armhf
             package: -arm-linux-gnueabihf
+          # PPC64
           - arch: ppc64el
             package: -powerpc64le-linux-gnu
+          # IBM Z
+          - arch: s390x
 
     name: build-${{ matrix.arch }}
     steps:
@@ -164,11 +169,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [aarch64, armhf, ppc64el, s390x]
         include:
           # AArch64
           - arch: aarch64
-            qemu_cpu: "max,sve-max-vq=1"
+            qemu_cpu: "max,sve=off"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve128=on"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve256=on"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve512=on"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve1024=on"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve2048=on"
           # Aarch32
           - arch: armhf
             binfmt: arm

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -136,7 +136,9 @@ jobs:
           elif [[ ${{ matrix.arch }} = "ppc64el" ]]; then
             EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENFORCE_VSX=ON -DENFORCE_VSX3=ON"
           elif [[ ${{ matrix.arch }} = "s390x" ]]; then
-            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENFORCE_VXE=ON -DDISABLE_VXE2=ON"
+            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENFORCE_VXE=ON"
+            # Disable VXE2 support, QEMU doesn't support it
+            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DDISABLE_VXE2=ON"
           fi
           cmake -S . -B _build-${{ matrix.arch }} -GNinja \
             -DCMAKE_INSTALL_PREFIX="$(pwd)/_install-${{ matrix.arch }}" \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,6 +37,15 @@ jobs:
           cd _build-native
           ctest -j$(nproc)
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-native
+          path: |
+            _build-*
+            _install-*
+        if: always()
+
   build-and-test-cross:
     runs-on: ubuntu-latest
     strategy:
@@ -56,12 +65,15 @@ jobs:
           - arch: armhf
             binfmt: arm
             package: -arm-linux-gnueabihf
+            qemu_cpu: "max"
           # PPC64
           - arch: ppc64el
             binfmt: ppc64le
             package: -powerpc64le-linux-gnu
+            qemu_cpu: "power10"
           # IBM Z
           - arch: s390x
+            #TODO: figure out qemu_cpu variable to make tests pass on QEMU
 
     steps:
       - uses: actions/checkout@v4.1.1
@@ -115,3 +127,12 @@ jobs:
         run: |
           cd _build-${{ matrix.arch }}
           ctest -j$(nproc)
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ matrix.arch }}-${{ strategy.job-index }}
+          path: |
+            _build-*
+            _install-*
+        if: always()

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -179,10 +179,6 @@ jobs:
             qemu_cpu: "max,sve=on,sve256=on"
           - arch: aarch64
             qemu_cpu: "max,sve=on,sve512=on"
-          - arch: aarch64
-            qemu_cpu: "max,sve=on,sve1024=on"
-          - arch: aarch64
-            qemu_cpu: "max,sve=on,sve2048=on"
           # Aarch32
           - arch: armhf
             binfmt: arm

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,14 +35,7 @@ jobs:
       - name: Build native
         run: |
           set -x
-          EXTRA_CMAKE_FLAGS=" \
-            -DENFORCE_SSE2=ON \
-            -DENFORCE_SSE4=ON \
-            -DENFORCE_AVX=ON \
-            -DENFORCE_AVX=ON \
-            -DENFORCE_FMA4=ON \
-            -DENFORCE_AVX2=ON \
-            -DENFORCE_AVX512F=ON"
+          EXTRA_CMAKE_FLAGS="-DENFORCE_SSE2=ON -DENFORCE_SSE4=ON -DENFORCE_AVX=ON -DENFORCE_AVX=ON -DENFORCE_AVX2=ON -DENFORCE_AVX512F=ON -DENFORCE_FMA4=ON"
           cmake -S . -B _build-native -GNinja \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/_install-native \
             ${COMMON_CMAKE_FLAGS} \
@@ -104,25 +97,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        arch: [aarch64, armhf, ppc64el, s390x]
         include:
-          # AArch64
-          - arch: aarch64
-          # Aarch32
           - arch: armhf
             package: -arm-linux-gnueabihf
-          # PPC64
           - arch: ppc64el
             package: -powerpc64le-linux-gnu
-          # IBM Z
-          - arch: s390x
 
+    name: build-${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
 
       - name: Install dependencies
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq build-essential clang curl ninja-build libgmp-dev libmpfr-dev gcc${{ matrix.package || format('-{0}-linux-gnu', matrix.arch) }}
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq build-essential clang curl ninja-build libgmp-dev libmpfr-dev gcc${{ matrix.package || format('-{0}-linux-gnu', matrix.arch) }}
 
       - name: Download build-native artifacts
         uses: actions/download-artifact@v3
@@ -136,14 +127,15 @@ jobs:
       - name: Build ${{ matrix.arch }}
         run: |
           set -x
+          EXTRA_CMAKE_FLAGS=""
           if [[ ${{ matrix.arch }} = "aarch64" ]]; then
-            EXTRA_CMAKE_FLAGS="-DENFORCE_SVE=ON"
+            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENFORCE_SVE=ON"
           elif [[ ${{ matrix.arch }} = "armhf" ]]; then
-            EXTRA_CMAKE_FLAGS=""
+            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} "
           elif [[ ${{ matrix.arch }} = "ppc64el" ]]; then
-            EXTRA_CMAKE_FLAGS="-DENFORCE_VSX=ON -DENFORCE_VSX3=ON"
+            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENFORCE_VSX=ON -DENFORCE_VSX3=ON"
           elif [[ ${{ matrix.arch }} = "s390x" ]]; then
-            EXTRA_CMAKE_FLAGS="-DENFORCE_VXE=ON -DENFORCE_VXE2=ON"
+            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENFORCE_VXE=ON -DDISABLE_VXE2=ON"
           fi
           cmake -S . -B _build-${{ matrix.arch }} -GNinja \
             -DCMAKE_INSTALL_PREFIX="$(pwd)/_install-${{ matrix.arch }}" \
@@ -165,20 +157,14 @@ jobs:
 
   test-cross:
     runs-on: ubuntu-latest
-    needs: [build-cross]
+    needs: [build-native, build-cross]
     strategy:
       fail-fast: false
       matrix:
         include:
           # AArch64
           - arch: aarch64
-            qemu_cpu: "max,sve=off"
-          - arch: aarch64
-            qemu_cpu: "max,sve=on,sve128=on"
-          - arch: aarch64
-            qemu_cpu: "max,sve=on,sve256=on"
-          - arch: aarch64
-            qemu_cpu: "max,sve=on,sve512=on"
+            qemu_cpu: "max,sve-max-vq=1"
           # Aarch32
           - arch: armhf
             binfmt: arm
@@ -188,9 +174,10 @@ jobs:
             binfmt: ppc64le
             qemu_cpu: "power10"
           # IBM Z
+          # TODO: figure out qemu_cpu variable to make tests pass on QEMU
           - arch: s390x
-            #TODO: figure out qemu_cpu variable to make tests pass on QEMU
 
+    name: "test-${{ matrix.arch }} (qemu_cpu: \"${{ matrix.qemu_cpu }}\")"
     steps:
       - uses: actions/checkout@v4.1.1
         with:
@@ -207,6 +194,11 @@ jobs:
         run: |
           cat /proc/cpuinfo
 
+      - name: Download build-native artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-native
+
       - name: Download build-${{ matrix.arch }} artifacts
         uses: actions/download-artifact@v3
         with:
@@ -215,8 +207,10 @@ jobs:
       - name: Test ${{ matrix.arch }}
         env:
           CTEST_OUTPUT_ON_FAILURE: "TRUE"
-          QEMU_CPU: ${{ matrix.qemu_cpu }}
         run: |
+          if [[ -n "${{ matrix.qemu_cpu }}" ]]; then
+            export QEMU_CPU="${{ matrix.qemu_cpu }}"
+          fi
           cd _build-${{ matrix.arch }}
           ctest -j$(nproc)
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,17 @@ on:
 permissions:
   contents: read
 
+env:
+  COMMON_CMAKE_FLAGS: |
+    -DSLEEF_SHOW_CONFIG=1
+    -DDISABLE_SSL=ON
+    -DBUILD_GNUABI_LIBS=ON
+    -DBUILD_INLINE_HEADERS=ON
+    -DBUILD_DFT=ON
+    -DBUILD_QUAD=ON
+    -DBUILD_SCALAR_LIB=ON
+    -DBUILD_STATIC_TEST_BINS=ON
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -26,9 +37,19 @@ jobs:
 
       - name: Build native
         run: |
+          set -x
+          EXTRA_CMAKE_FLAGS=" \
+            -DENFORCE_SSE2=ON \
+            -DENFORCE_SSE4=ON \
+            -DENFORCE_AVX=ON \
+            -DENFORCE_AVX=ON \
+            -DENFORCE_FMA4=ON \
+            -DENFORCE_AVX2=ON \
+            -DENFORCE_AVX512F=ON"
           cmake -S . -B _build-native -GNinja \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/_install-native \
-            -DBUILD_STATIC_TEST_BINS=ON
+            ${COMMON_CMAKE_FLAGS} \
+            ${EXTRA_CMAKE_FLAGS}
           cmake --build _build-native
           cmake --install _build-native
 
@@ -95,7 +116,7 @@ jobs:
         run: |
           cmake -S . -B _build-native -GNinja \
             -DCMAKE_INSTALL_PREFIX=$(pwd)/_install-native \
-            -DBUILD_STATIC_TEST_BINS=ON \
+            ${COMMON_CMAKE_FLAGS} \
             -DENFORCE_TESTER=ON
           cmake --build _build-native
           cmake --install _build-native
@@ -105,18 +126,21 @@ jobs:
           CTEST_OUTPUT_ON_FAILURE: "TRUE"
           QEMU_CPU: ${{ matrix.qemu_cpu }}
         run: |
+          set -x
+          if [[ ${{ matrix.arch }} = "aarch64" ]]; then
+            EXTRA_CMAKE_FLAGS="-DENFORCE_SVE=ON"
+          elif [[ ${{ matrix.arch }} = "armhf" ]]; then
+            EXTRA_CMAKE_FLAGS=""
+          elif [[ ${{ matrix.arch }} = "ppc64el" ]]; then
+            EXTRA_CMAKE_FLAGS="-DENFORCE_VSX=ON -DENFORCE_VSX3=ON"
+          elif [[ ${{ matrix.arch }} = "s390x" ]]; then
+            EXTRA_CMAKE_FLAGS="-DENFORCE_VXE=ON -DENFORCE_VXE2=ON"
+          fi
           cmake -S . -B _build-${{ matrix.arch }} -GNinja \
-            -DCMAKE_TOOLCHAIN_FILE=$(pwd)/travis/toolchain-${{ matrix.arch }}.cmake \
             -DCMAKE_INSTALL_PREFIX="$(pwd)/_install-${{ matrix.arch }}" \
+            -DCMAKE_TOOLCHAIN_FILE=$(pwd)/travis/toolchain-${{ matrix.arch }}.cmake \
             -DNATIVE_BUILD_DIR="$(pwd)/_build-native" \
-            -DSLEEF_SHOW_CONFIG=1 \
-            -DDISABLE_SSL=ON \
-            -DBUILD_DFT=OFF \
-            -DBUILD_GNUABI_LIBS=OFF \
-            -DBUILD_INLINE_HEADERS=OFF \
-            -DBUILD_QUAD=OFF \
-            -DBUILD_SCALAR_LIB=ON \
-            -DBUILD_STATIC_TEST_BINS=ON \
+            ${COMMON_CMAKE_FLAGS} \
             ${EXTRA_CMAKE_FLAGS}
           cmake --build _build-${{ matrix.arch }}
           cmake --install _build-${{ matrix.arch }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ env:
     -DBUILD_STATIC_TEST_BINS=ON
 
 jobs:
-  build-and-test:
+  build-native:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -30,10 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq build-essential clang curl ninja-build libgmp-dev libmpfr-dev cpuinfo
-
-      - name: CPU Info
-        run: isa-info
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq build-essential clang curl ninja-build libgmp-dev libmpfr-dev
 
       - name: Build native
         run: |
@@ -53,12 +50,7 @@ jobs:
           cmake --build _build-native
           cmake --install _build-native
 
-      - name: Test native
-        run: |
-          cd _build-native
-          ctest -j$(nproc)
-
-      - name: Upload build artifacts
+      - name: Upload build-native artifacts
         uses: actions/upload-artifact@v3
         with:
           name: build-native
@@ -67,64 +59,81 @@ jobs:
             _install-*
         if: always()
 
-  build-and-test-cross:
+  test-native:
     runs-on: ubuntu-latest
+    needs: [build-native]
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq libgmp-dev libmpfr-dev
+
+      - name: Print host CPU info
+        run: |
+          cat /proc/cpuinfo
+
+      - name: Download build-native artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-native
+
+      - name: Fix build-native persmissions
+        run: |
+          chmod +x _build-native/bin/*
+
+      - name: Test native
+        env:
+          CTEST_OUTPUT_ON_FAILURE: "TRUE"
+        run: |
+          cd _build-native
+          ctest -j$(nproc)
+
+      - name: Upload test-native artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-native
+          path: |
+            _build-native/Testing
+        if: always()
+
+  build-cross:
+    runs-on: ubuntu-latest
+    needs: [build-native]
     strategy:
       fail-fast: false
       matrix:
         include:
           # AArch64
           - arch: aarch64
-            qemu_cpu: "max,sve=off"
-          - arch: aarch64
-            qemu_cpu: "max,sve=on,sve128=on"
-          - arch: aarch64
-            qemu_cpu: "max,sve=on,sve256=on"
-          - arch: aarch64
-            qemu_cpu: "max,sve=on,sve512=on"
           # Aarch32
           - arch: armhf
-            binfmt: arm
             package: -arm-linux-gnueabihf
-            qemu_cpu: "max"
           # PPC64
           - arch: ppc64el
-            binfmt: ppc64le
             package: -powerpc64le-linux-gnu
-            qemu_cpu: "power10"
           # IBM Z
           - arch: s390x
-            #TODO: figure out qemu_cpu variable to make tests pass on QEMU
 
     steps:
       - uses: actions/checkout@v4.1.1
         with:
           persist-credentials: false
 
-      - uses: docker/setup-qemu-action@v3.0.0
-        with:
-          platforms: ${{ matrix.binfmt || matrix.arch }}
-
       - name: Install dependencies
         run: sudo apt-get update -y -qq && sudo apt-get install -y -qq build-essential clang curl ninja-build libgmp-dev libmpfr-dev gcc${{ matrix.package || format('-{0}-linux-gnu', matrix.arch) }}
 
-      - name: Print host CPU info
-        run: |
-          cat /proc/cpuinfo
+      - name: Download build-native artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-native
 
-      - name: Build native
+      - name: Fix build-native persmissions
         run: |
-          cmake -S . -B _build-native -GNinja \
-            -DCMAKE_INSTALL_PREFIX=$(pwd)/_install-native \
-            ${COMMON_CMAKE_FLAGS} \
-            -DENFORCE_TESTER=ON
-          cmake --build _build-native
-          cmake --install _build-native
+          chmod +x _build-native/bin/*
 
       - name: Build ${{ matrix.arch }}
-        env:
-          CTEST_OUTPUT_ON_FAILURE: "TRUE"
-          QEMU_CPU: ${{ matrix.qemu_cpu }}
         run: |
           set -x
           if [[ ${{ matrix.arch }} = "aarch64" ]]; then
@@ -145,18 +154,76 @@ jobs:
           cmake --build _build-${{ matrix.arch }}
           cmake --install _build-${{ matrix.arch }}
 
+      - name: Upload build-${{ matrix.arch }} artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ matrix.arch }}
+          path: |
+            _build-${{ matrix.arch }}
+            _install-${{ matrix.arch }}
+        if: always()
+
+  test-cross:
+    runs-on: ubuntu-latest
+    needs: [build-cross]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # AArch64
+          - arch: aarch64
+            qemu_cpu: "max,sve=off"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve128=on"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve256=on"
+          - arch: aarch64
+            qemu_cpu: "max,sve=on,sve512=on"
+          # Aarch32
+          - arch: armhf
+            binfmt: arm
+            qemu_cpu: "max"
+          # PPC64
+          - arch: ppc64el
+            binfmt: ppc64le
+            qemu_cpu: "power10"
+          # IBM Z
+          - arch: s390x
+            #TODO: figure out qemu_cpu variable to make tests pass on QEMU
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-qemu-action@v3.0.0
+        with:
+          platforms: ${{ matrix.binfmt || matrix.arch }}
+
+      - name: Install dependencies
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq libgmp-dev libmpfr-dev
+
+      - name: Print host CPU info
+        run: |
+          cat /proc/cpuinfo
+
+      - name: Download build-${{ matrix.arch }} artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-${{ matrix.arch }}
+
       - name: Test ${{ matrix.arch }}
         env:
+          CTEST_OUTPUT_ON_FAILURE: "TRUE"
           QEMU_CPU: ${{ matrix.qemu_cpu }}
         run: |
           cd _build-${{ matrix.arch }}
           ctest -j$(nproc)
 
-      - name: Upload build artifacts
+      - name: Upload test-${{ matrix.arch }}-${{ strategy.job-index }} artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: build-${{ matrix.arch }}-${{ strategy.job-index }}
+          name: test-${{ matrix.arch }}-${{ strategy.job-index }}
           path: |
-            _build-*
-            _install-*
+            _build-${{ matrix.arch }}/Testing
         if: always()

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,10 +97,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [aarch64, armhf, ppc64el, s390x]
+        # arch: [aarch64, armhf, ppc64el, s390x]
+        arch: [aarch64, ppc64el, s390x]
         include:
-          - arch: armhf
-            package: -arm-linux-gnueabihf
+          # - arch: armhf
+          #   package: -arm-linux-gnueabihf
           - arch: ppc64el
             package: -powerpc64le-linux-gnu
 
@@ -161,14 +162,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # arch: [aarch64, armhf, ppc64el, s390x]
+        arch: [aarch64, ppc64el, s390x]
         include:
           # AArch64
           - arch: aarch64
             qemu_cpu: "max,sve-max-vq=1"
           # Aarch32
-          - arch: armhf
-            binfmt: arm
-            qemu_cpu: "max"
+          # - arch: armhf
+          #   binfmt: arm
+          #   qemu_cpu: "max"
           # PPC64
           - arch: ppc64el
             binfmt: ppc64le

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           name: build-native
 
-      - name: Fix build-native persmissions
+      - name: Fix build-native permissions
         run: |
           chmod +x _build-native/bin/*
 
@@ -120,7 +120,7 @@ jobs:
         with:
           name: build-native
 
-      - name: Fix build-native persmissions
+      - name: Fix build-native permissions
         run: |
           chmod +x _build-native/bin/*
 
@@ -203,6 +203,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: build-${{ matrix.arch }}
+
+      - name: Fix build-native and _build-${{ matrix.arch }} permissions
+        run: |
+          chmod +x _build-native/bin/*
+          chmod +x _build-${{ matrix.arch }}/bin/*
 
       - name: Test ${{ matrix.arch }}
         env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,11 +97,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # arch: [aarch64, armhf, ppc64el, s390x]
-        arch: [aarch64, ppc64el, s390x]
+        arch: [aarch64, armhf, ppc64el, s390x]
         include:
-          # - arch: armhf
-          #   package: -arm-linux-gnueabihf
+          - arch: armhf
+            package: -arm-linux-gnueabihf
           - arch: ppc64el
             package: -powerpc64le-linux-gnu
 
@@ -132,7 +131,8 @@ jobs:
           if [[ ${{ matrix.arch }} = "aarch64" ]]; then
             EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENFORCE_SVE=ON"
           elif [[ ${{ matrix.arch }} = "armhf" ]]; then
-            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} "
+            # Disable inline headers, they just don't compile on armhf
+            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DBUILD_INLINE_HEADERS=OFF"
           elif [[ ${{ matrix.arch }} = "ppc64el" ]]; then
             EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENFORCE_VSX=ON -DENFORCE_VSX3=ON"
           elif [[ ${{ matrix.arch }} = "s390x" ]]; then
@@ -162,16 +162,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # arch: [aarch64, armhf, ppc64el, s390x]
-        arch: [aarch64, ppc64el, s390x]
+        arch: [aarch64, armhf, ppc64el, s390x]
         include:
           # AArch64
           - arch: aarch64
             qemu_cpu: "max,sve-max-vq=1"
           # Aarch32
-          # - arch: armhf
-          #   binfmt: arm
-          #   qemu_cpu: "max"
+          - arch: armhf
+            binfmt: arm
+            qemu_cpu: "max"
           # PPC64
           - arch: ppc64el
             binfmt: ppc64le

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -165,7 +165,6 @@ set(CLANG_FLAGS_ENABLE_VXE2 "-march=z15;-mzvector")
 set(CLANG_FLAGS_ENABLE_VXE2NOFMA "-march=z15;-mzvector")
 
 set(FLAGS_OTHERS "")
-set(FLAGS_ARCH_NATIVE "")
 
 # All variables storing compiler flags should be prefixed with FLAGS_
 if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)")
@@ -177,10 +176,6 @@ if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)")
   if (SLEEF_ARCH_X86 AND SLEEF_ARCH_32BIT)
     string(CONCAT FLAGS_STRICTMATH ${FLAGS_STRICTMATH} " -msse2 -mfpmath=sse")
     string(CONCAT FLAGS_FASTMATH ${FLAGS_FASTMATH} " -msse2 -mfpmath=sse")
-  endif()
-
-  if (SLEEF_ARCH_X86)
-    set(FLAGS_ARCH_NATIVE "-march=native")
   endif()
   
   # Without the options below, gcc generates calls to libm

--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -452,7 +452,6 @@ if(ENABLE_GNUABI AND COMPILER_SUPPORTS_OMP_SIMD AND NOT SLEEF_TARGET_PROCESSOR M
   add_executable(testervecabi testervecabi.c)
   target_compile_definitions(testervecabi PRIVATE ${COMMON_TARGET_DEFINITIONS})
   target_compile_options(testervecabi PRIVATE ${OpenMP_C_FLAGS})
-  target_compile_options(testervecabi PRIVATE ${FLAGS_ARCH_NATIVE})
   target_link_libraries(testervecabi ${TARGET_LIBSLEEF} ${OpenMP_C_FLAGS})
   set_target_properties(testervecabi PROPERTIES C_STANDARD 99)
   add_test(NAME testervecabi COMMAND testervecabi

--- a/travis/toolchain-ppc64el.cmake
+++ b/travis/toolchain-ppc64el.cmake
@@ -4,7 +4,7 @@ SET (CMAKE_SYSTEM_PROCESSOR "ppc64")
 
 SET(CMAKE_FIND_ROOT_PATH  /usr/powerpc64le-linux-gnu /usr/include/powerpc64le-linux-gnu /usr/lib/powerpc64le-linux-gnu)
 
-find_program(CMAKE_C_COMPILER ppc64el-cc)
+find_program(CMAKE_C_COMPILER powerpc64le-linux-gnu-gcc ppc64el-cc)
 
 SET(CMAKE_AR /usr/powerpc64le-linux-gnu/bin/ar)
 


### PR DESCRIPTION
As discussed offline, this PR adds some CI on GitHub Actions. That's expected to facilitate contribution by having smoke testing on any changes that would be integrating, facilitating the work of maintainers by making sure a change will not completely break all supported architectures (aarch64, arm, ppc64, s390x, and x86_64).