### PR TITLE
Switch from old to new MD5 API in tester3.

### DIFF
--- a/Configure.cmake
+++ b/Configure.cmake
@@ -16,6 +16,9 @@ if (NOT CMAKE_CROSSCOMPILING AND NOT SLEEF_FORCE_FIND_PACKAGE_SSL)
   if (OPENSSL_FOUND)
     set(SLEEF_OPENSSL_FOUND TRUE)
     set(SLEEF_OPENSSL_LIBRARIES ${OPENSSL_LIBRARIES})
+    # Work around for tester3 sig segv, when linking versions of openssl (1.1.1) statically.
+    # This is a known issue https://github.com/openssl/openssl/issues/13872.
+    string(REGEX REPLACE "-lpthread" "-Wl,--whole-archive -lpthread -Wl,--no-whole-archive" SLEEF_OPENSSL_LIBRARIES "${OPENSSL_LIBRARIES}")
     set(SLEEF_OPENSSL_VERSION ${OPENSSL_VERSION})
     set(SLEEF_OPENSSL_INCLUDE_DIR ${OPENSSL_INCLUDE_DIR})
   endif()

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -18,7 +18,11 @@ if (NOT CMAKE_CROSSCOMPILING AND NOT SLEEF_FORCE_FIND_PACKAGE_SSL)
     set(SLEEF_OPENSSL_LIBRARIES ${OPENSSL_LIBRARIES})
     # Work around for tester3 sig segv, when linking versions of openssl (1.1.1) statically.
     # This is a known issue https://github.com/openssl/openssl/issues/13872.
-    string(REGEX REPLACE "-lpthread" "-Wl,--whole-archive -lpthread -Wl,--no-whole-archive" SLEEF_OPENSSL_LIBRARIES "${OPENSSL_LIBRARIES}")
+    if (BUILD_STATIC_TEST_BINS)
+      string(REGEX REPLACE
+             "-lpthread" "-Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
+             SLEEF_OPENSSL_LIBRARIES "${OPENSSL_LIBRARIES}")
+    endif()
     set(SLEEF_OPENSSL_VERSION ${OPENSSL_VERSION})
     set(SLEEF_OPENSSL_INCLUDE_DIR ${OPENSSL_INCLUDE_DIR})
   endif()


### PR DESCRIPTION
Removes warnings about deprecation of old API for versions of OpenSSL above 3.0.
Needed to amend openssl link line to avoid a crash in tester3 with old openssl.
Fixes #486.