### PR TITLE
Remove warning about M_PIf redefinition

### DIFF
--- a/src/libm-tester/testerutil.h
+++ b/src/libm-tester/testerutil.h
@@ -11,7 +11,9 @@
 #define POSITIVE_INFINITYf ((float)INFINITY)
 #define NEGATIVE_INFINITYf (-(float)INFINITY)
 
-#define M_PIf ((float)M_PI)
+#ifndef M_PIf
+# define M_PIf ((float)M_PI)
+#endif
 
 extern int enableFlushToZero;
 double flushToZero(double y);


### PR DESCRIPTION
Missed of the previous patch - this may already be provided by math.h.