### PR TITLE
fix intel compiler args.

### DIFF
--- a/Configure.cmake
+++ b/Configure.cmake
@@ -271,8 +271,8 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "Intel")
   set(FLAGS_ENABLE_AVX512FNOFMA "-xCOMMON-AVX512")
   set(FLAGS_ENABLE_PURECFMA_SCALAR "-march=core-avx2;-fno-strict-aliasing")
   set(FLAGS_ENABLE_FMA4 "-msse2")  # This is a dummy flag
-  set(FLAGS_STRICTMATH "-fp-model strict -Qoption,cpp,--extended_float_type")
-  set(FLAGS_FASTMATH "-fp-model fast=2 -Qoption,cpp,--extended_float_type")
+  set(FLAGS_STRICTMATH "-fp-model strict -Qoption,cpp,--extended_float_types")
+  set(FLAGS_FASTMATH "-fp-model fast=2 -Qoption,cpp,--extended_float_types")
   set(FLAGS_NOSTRICTALIASING "-fno-strict-aliasing")
   set(FLAGS_WALL "-fmax-errors=3 -Wall -Wno-unused -Wno-attributes")
 


### PR DESCRIPTION
<img width="1072" alt="image" src="https://github.com/shibatch/sleef/assets/8433590/0e2a8959-3f92-4dd2-8563-28499cda44cc">
Intel compiler build failed.

<img width="701" alt="image" src="https://github.com/shibatch/sleef/assets/8433590/627b51b8-4bd5-40e5-8657-267fc1e55984">

Intel compiler only support "--extended_float_types" but not "--extended_float_type".

<img width="1640" alt="image" src="https://github.com/shibatch/sleef/assets/8433590/bdde4025-0d37-48cc-ac7f-575136266ce5">
After fixed, it works.