### PR TITLE
Enable aarch64 llvm-17 cross compilation tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -272,19 +272,18 @@ jobs:
           - arch: aarch64
             compiler: gcc
             qemu_cpu: "max,sve=on,sve512=on"
-          # Some tests fail when compiled with LLVM only
-          # - arch: aarch64
-          #   compiler: llvm
-          #   qemu_cpu: "max,sve=off"
-          # - arch: aarch64
-          #   compiler: llvm
-          #   qemu_cpu: "max,sve=on,sve128=on"
-          # - arch: aarch64
-          #   compiler: llvm
-          #   qemu_cpu: "max,sve=on,sve256=on"
-          # - arch: aarch64
-          #   compiler: llvm
-          #   qemu_cpu: "max,sve=on,sve512=on"
+          - arch: aarch64
+            compiler: llvm
+            qemu_cpu: "max,sve=off"
+          - arch: aarch64
+            compiler: llvm
+            qemu_cpu: "max,sve=on,sve128=on"
+          - arch: aarch64
+            compiler: llvm
+            qemu_cpu: "max,sve=on,sve256=on"
+          - arch: aarch64
+            compiler: llvm
+            qemu_cpu: "max,sve=on,sve512=on"
           # Aarch32
           - arch: armhf
             compiler: gcc


### PR DESCRIPTION
PR #477 pointed out some test failures with qemu.
However, following the discussion on this PR cannot see exactly what these failures were (none of the GHA past builds show runs for these settings). Locally, cross compiling aarch64 on x86 host with llvm-17 and using user-mode qemu emulation environment do not
show failures.
Therefore we try to enable these tests in GHA and check for failures.
Note: This issue is being tracked in #485