### PR TITLE
Add qemu command prefix to testervecabi tests

### DIFF
--- a/src/libm-tester/CMakeLists.txt
+++ b/src/libm-tester/CMakeLists.txt
@@ -462,7 +462,7 @@ if(ENABLE_GNUABI AND COMPILER_SUPPORTS_OMP_SIMD AND NOT SLEEF_TARGET_PROCESSOR M
   target_compile_options(testervecabi PRIVATE ${OpenMP_C_FLAGS})
   target_link_libraries(testervecabi ${TARGET_LIBSLEEF} ${OpenMP_C_FLAGS})
   set_target_properties(testervecabi PROPERTIES C_STANDARD 99)
-  add_test(NAME testervecabi COMMAND testervecabi
+  add_test(NAME testervecabi COMMAND ${EMULATOR} testervecabi
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 endif()
 


### PR DESCRIPTION
This test suite covers the usage of scalar symbols with auto-vectorisation, to test the GNU ABI
symbols generated by SLEEF.
However, some failures are recorded when emulating these tests using user mode QEMU, for a
cross-compile build for AArch64 and s390x.
This is because this test suite does not get called with the EMULATOR command necessary.
This fix adds the emulator to the test command
which makes the tests pass when cross-compiling
and using user mode QEMU emulation.