### PR TITLE
Fix disable fp contractions warning on msvc

### DIFF
--- a/src/libm/sleefdp.c
+++ b/src/libm/sleefdp.c
@@ -28,9 +28,9 @@ extern const double Sleef_rempitabdp[];
 
 #if defined(_MSC_VER) && !defined (__clang__)
 #pragma fp_contract (off)
-#endif
-
+#else
 #pragma STDC FP_CONTRACT OFF
+#endif
 
 #define MLA mla
 #define C2V(x) (x)

--- a/src/libm/sleefinline_header.h.org
+++ b/src/libm/sleefinline_header.h.org
@@ -18,9 +18,9 @@
 
 #if defined(_MSC_VER) && !defined (__clang__)
 #pragma fp_contract (off)
-#endif
-
+#else
 #pragma STDC FP_CONTRACT OFF
+#endif
 
 #ifndef SLEEF_FP_ILOGB0
 #define SLEEF_FP_ILOGB0 ((int)0x80000000)

--- a/src/libm/sleefsimddp.c
+++ b/src/libm/sleefsimddp.c
@@ -23,9 +23,9 @@ extern const double Sleef_rempitabdp[];
 
 #if defined(_MSC_VER) && !defined (__clang__)
 #pragma fp_contract (off)
-#endif
-
+#else
 #pragma STDC FP_CONTRACT OFF
+#endif
 
 // Intel
 

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -23,9 +23,9 @@ extern const float Sleef_rempitabsp[];
 
 #if defined(_MSC_VER) && !defined (__clang__)
 #pragma fp_contract (off)
-#endif
-
+#else
 #pragma STDC FP_CONTRACT OFF
+#endif
 
 // Intel
 

--- a/src/libm/sleefsp.c
+++ b/src/libm/sleefsp.c
@@ -28,9 +28,9 @@ extern const float Sleef_rempitabsp[];
 
 #if defined(_MSC_VER) && !defined (__clang__)
 #pragma fp_contract (off)
-#endif
-
+#else
 #pragma STDC FP_CONTRACT OFF
+#endif
 
 #define MLA mlaf
 #define C2V(x) (x)

--- a/src/quad/sleefquadinline_cuda_header.h.org
+++ b/src/quad/sleefquadinline_cuda_header.h.org
@@ -17,6 +17,8 @@
 
 #if defined(_MSC_VER) && !defined (__clang__)
 #pragma fp_contract (off)
+#else
+#pragma STDC FP_CONTRACT OFF
 #endif
 
 __device__ const double Sleef_rempitabqp[] = {

--- a/src/quad/sleefquadinline_header.h.org
+++ b/src/quad/sleefquadinline_header.h.org
@@ -18,9 +18,9 @@
 
 #if defined(_MSC_VER) && !defined (__clang__)
 #pragma fp_contract (off)
-#endif
-
+#else
 #pragma STDC FP_CONTRACT OFF
+#endif
 
 #ifndef SLEEF_FP_ILOGB0
 #define SLEEF_FP_ILOGB0 ((int)0x80000000)

--- a/src/quad/sleefsimdqp.c
+++ b/src/quad/sleefsimdqp.c
@@ -23,9 +23,9 @@ extern const double Sleef_rempitabqp[];
 
 #if defined(_MSC_VER) && !defined (__clang__)
 #pragma fp_contract (off)
-#endif
-
+#else
 #pragma STDC FP_CONTRACT OFF
+#endif
 
 #ifdef ENABLE_PUREC_SCALAR
 #define CONFIG 1


### PR DESCRIPTION
Warning message on MSVC:
```cmd
28>D:\xu_github\sleef\src\libm\sleefsimddp.c(28,9): warning C4068: unknown pragma 'STDC'
28>sleefsimdsp.c
28>D:\xu_github\sleef\src\libm\sleefsimdsp.c(28,9): warning C4068: unknown pragma 'STDC'
28>Generating Code...
```

Fix it by conditional defination for disable fp contractions.