### PR TITLE
Fix RVV intrinsic version detection.

### DIFF
--- a/src/arch/helperrvv.h
+++ b/src/arch/helperrvv.h
@@ -70,7 +70,7 @@
 #endif
 #endif
 
-#if __riscv_v_intrinsic <= 12000
+#if __riscv_v_intrinsic < 1000000 && !(defined(__clang_major__) && __clang_major__ >= 18)
 // __riscv_vcreate* intrinsics only showed up in v1.0-rc0 of the RVV intrinsics
 // spec and have already been implemented in clang-18, but are useful for
 // eliminating issues with uninitialised data because they are explicit that


### PR DESCRIPTION
__riscv_vcreate* appear after RVV intrinsics v0.12, and the next version after that is v1.0 which is not yet ratified.

Nevertheless, clang-18 and up already have the support we need.