### PR TITLE
Add matching mpfr_clear statements for mpfr_init

### DIFF
--- a/src/gencoef/gencoef.c
+++ b/src/gencoef/gencoef.c
@@ -121,6 +121,7 @@ int main(int argc, char **argv)
     mpfr_set_d(b, x, GMP_RNDN);
 
     printf("%g\n", countULP(b, a));
+    mpfr_clears(a, b, NULL);
     exit(0);
   }
 #endif
@@ -138,6 +139,7 @@ int main(int argc, char **argv)
     mpfr_set_d(b, x, GMP_RNDN);
 
     printf("%g\n", countULP(b, a));
+    mpfr_clears(a, b, NULL);
     exit(0);
   }
 #endif
@@ -155,6 +157,7 @@ int main(int argc, char **argv)
     mpfr_set_ld(b, x, GMP_RNDN);
 
     printf("%g\n", countULP(b, a));
+    mpfr_clears(a, b, NULL);
     exit(0);
   }
 #endif
@@ -172,6 +175,7 @@ int main(int argc, char **argv)
     mpfr_set_f128(b, x, GMP_RNDN);
 
     printf("%g\n", countULP(b, a));
+    mpfr_clears(a, b, NULL);
     exit(0);
   }
 #endif
@@ -285,6 +289,7 @@ int main(int argc, char **argv)
     mpfr_pow(am[i], a[i], frb, GMP_RNDN);
     mpfr_set_d(frb, PADD, GMP_RNDN);
     mpfr_pow(aa[i], a[i], frb, GMP_RNDN);
+    mpfr_clears(a[i], v[i], am[i], aa[i], NULL);
   }
 
   double best = 1e+100, bestsum = 1e+100, bestworstx;

--- a/src/libm-tester/tester.c
+++ b/src/libm-tester/tester.c
@@ -5038,6 +5038,7 @@ void do_test() {
     for(d = -1;d < 8 && success;d += 0.001) checkAccuracy_f(mpfr_erfc, child_erfcf_u15, d, 1.5);
     showResult(success);
   }
+  mpfr_clears(frc, frt, frx, fry, frz, NULL);
 }
 
 int main(int argc, char **argv) {

--- a/src/libm-tester/tester2dp.c
+++ b/src/libm-tester/tester2dp.c
@@ -986,6 +986,6 @@ int main(int argc,char **argv)
       }
     }
   }
-
+  mpfr_clears(frw, frx, fry, frz, NULL);
   exit(0);
 }

--- a/src/libm-tester/tester2simddp.c
+++ b/src/libm-tester/tester2simddp.c
@@ -1294,4 +1294,5 @@ int main(int argc,char **argv)
       }
     }
   }
+  mpfr_clears(frw, frx, fry, frz, NULL);
 }

--- a/src/libm-tester/tester2simdsp.c
+++ b/src/libm-tester/tester2simdsp.c
@@ -1294,4 +1294,5 @@ int main(int argc,char **argv)
     }
 #endif
   }
+  mpfr_clears(frw, frx, fry, frz, NULL);
 }

--- a/src/libm-tester/tester2sp.c
+++ b/src/libm-tester/tester2sp.c
@@ -1031,6 +1031,7 @@ int main(int argc,char **argv)
       }
     }
   }
+  mpfr_clears(frw, frx, fry, frz, NULL);
 
   exit(0);
 }

--- a/src/quad-tester/qtester.c
+++ b/src/quad-tester/qtester.c
@@ -1491,6 +1491,7 @@ void do_test(int options) {
     }
     checkResult(success, maxError);
   }
+  mpfr_clears(frw, frx, fry, frz, NULL);
 }
 
 int main(int argc, char **argv) {

--- a/src/quad/sleefsimdqp.c
+++ b/src/quad/sleefsimdqp.c
@@ -4515,6 +4515,7 @@ int main(int argc, char **argv) {
   mpfr_set_f128(fr3, xgetq(a3, lane), GMP_RNDN);
   printf("test : %s\n", sprintfr(fr3));
 #endif
+  mpfr_clears(fr0, fr1, fr2, fr3, NULL);
 }
 #endif
 #endif


### PR DESCRIPTION
This fixes some of the messages coming up in asan test output, but not all of them. Same number of test suites failing after this change.