### PR TITLE
Switch to gcc14 in GHA

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  GCC_VERSION: "11"
+  GCC_VERSION: "14"
   LLVM_VERSION: "17"
   COMMON_CMAKE_FLAGS: >
     -DSLEEF_SHOW_CONFIG=1


### PR DESCRIPTION
In GCC12 and GCC13 latest versions, the bug which was causing test failures in this project has been fixed. In GCC14 release series, the bug is not present. Hence we transition our testing into the latest compilers.