### PR TITLE
Add checks for incompatible changes in GHA

### DIFF
--- a/.github/workflows/check_compatibility.yml
+++ b/.github/workflows/check_compatibility.yml
@@ -1,0 +1,93 @@
+
+name: "Check version compatibility"
+
+on:
+  # allow direct trigger
+  workflow_dispatch:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GCC_VERSION: "11"
+  REF_TAG: "3.6"
+  TEST_TAG: "master"
+  COMMON_CMAKE_FLAGS: >
+    -DSLEEF_SHOW_CONFIG=ON
+    -DBUILD_SHARED_LIBS=ON
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ["3.6", "master"]
+
+    name: build-${{ matrix.tag }}
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+          ref: ${{ matrix.tag }}
+
+      - name: Print host CPU info
+        run: |
+          cat /proc/cpuinfo
+
+      - name: Install dependencies
+        run: |
+          sudo apt update -y -qq
+          sudo apt install -y -qq build-essential cmake ninja-build gcc-${GCC_VERSION}
+
+      - name: Build SLEEF ${{ matrix.tag }}
+        shell: bash -ex -o pipefail {0}
+        run: |
+          cmake -S . -B _build-${{ matrix.tag }} -GNinja \
+            -DCMAKE_TOOLCHAIN_FILE=$(pwd)/toolchains/native-gcc.cmake \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/_install-${{ matrix.tag }} \
+            ${COMMON_CMAKE_FLAGS}
+          cmake --build _build-${{ matrix.tag }} -j
+          cmake --install _build-${{ matrix.tag }}
+
+      - name: Upload build-${{ matrix.tag }} artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ matrix.tag }}
+          path: |
+            _build-*
+            _install-*
+        if: always()
+
+  compare-shared-libs:
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+      fail-fast: false
+
+    name: compare shared libraries
+    steps:
+      - name: install dependencies
+        run: |
+          sudo apt update -y -qq
+          sudo apt install -y -qq abigail-tools
+
+      - name: Download build-${{ env.REF_TAG }} artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-${{ env.REF_TAG }}
+
+      - name: Download build-${{ env.TEST_TAG }} artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-${{ env.TEST_TAG }}
+
+      - name: compare ABIs
+        run: |
+          abidiff _install-${{ env.REF_TAG }}/lib/libsleef.so _install-${{ env.TEST_TAG }}/lib/libsleef.so


### PR DESCRIPTION
Add a new workflow to detect unexpected backward-incompatible changes at precommit, by comparing current version against a reference version, both generated on Linux with gcc. It uses abidiff to compare ELF-format shared libraries. This is the tool used by Fedora to report a recent breach in API #534. Test should fail until it is fixed by #545.