### PR TITLE
Add tests for examples and SLEEF as subproject

### DIFF
--- a/.github/workflows/build-as-subproject.yml
+++ b/.github/workflows/build-as-subproject.yml
@@ -1,0 +1,140 @@
+
+name: "Build SLEEF as Subproject"
+
+on:
+  # allow direct trigger
+  workflow_dispatch:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GCC_VERSION: "11"
+  COMMON_CMAKE_FLAGS: >
+    -DSLEEF_SHOW_CONFIG=ON
+    -DSLEEF_BUILD_GNUABI_LIBS=ON
+    -DSLEEF_BUILD_DFT=ON
+    -DSLEEF_BUILD_SCALAR_LIB=ON
+    -DSLEEF_BUILD_TESTS=OFF
+
+jobs:
+  build-nested:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    name: build-nested
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Print host CPU info
+        run: |
+          cat /proc/cpuinfo
+
+      - name: Install dependencies
+        run: |
+          sudo apt update -y -qq
+          sudo apt install -y -qq build-essential cmake ninja-build gcc-${GCC_VERSION}
+
+      - name: Create nested project
+        shell: bash -ex -o pipefail {0}
+        run: |
+          # Create new project
+          mkdir -p ~/project
+          # Move examples to root of project
+          cp docs/CMakeLists.txt.nested ~/project/CMakeLists.txt
+          cp docs/hellox86.c docs/tutorial.c ~/project/
+          # Copy SLEEF sources to project
+          cd .. && cp -r sleef ~/project/
+
+      - name: Build nested project
+        shell: bash -ex -o pipefail {0}
+        run: |
+          cd ~/project
+          # Configure and build project depending on sleef as nested project
+          cmake -S . -B _build-nested -GNinja \
+            -DCMAKE_TOOLCHAIN_FILE=$(pwd)/sleef/toolchains/native-gcc.cmake \
+            ${COMMON_CMAKE_FLAGS}
+          cmake --build _build-nested -j
+
+      - name: Run examples
+        shell: bash -ex -o pipefail {0}
+        run: |
+          cd ~/project/_build-nested
+          ./hellox86
+          ./dfttutorial 4
+          ./dfttutorial 4
+
+      - name: Upload nested artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: nested project
+          path: |
+            ~/project/_build-nested
+        if: always()
+
+  build-submodule:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    name: build-submodule
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Print host CPU info
+        run: |
+          cat /proc/cpuinfo
+
+      - name: Install dependencies
+        run: |
+          sudo apt update -y -qq
+          sudo apt install -y -qq build-essential cmake ninja-build gcc-${GCC_VERSION}
+
+      - name: Create submodule project
+        shell: bash -ex -o pipefail {0}
+        run: |
+          # Create new project
+          mkdir -p ~/project
+          # Move examples to root of project
+          cp docs/CMakeLists.txt ~/project/
+          cp docs/hellox86.c docs/tutorial.c ~/project/
+          # Add some toolchain files
+          cp -r toolchains ~/project/
+
+      - name: Build project with submodule
+        shell: bash -ex -o pipefail {0}
+        run: |
+          cd ~/project
+          # Configure and build project depending on sleef as submodule
+          # Options are passed in CMakeLists.txt directly
+          cmake -S . -B _build-submodule  -GNinja \
+            -DSLEEF_BUILD_DFT_TUTORIAL=ON \
+            -DCMAKE_TOOLCHAIN_FILE=~/project/toolchains/native-gcc.cmake
+          cmake --build _build-submodule -j
+
+      - name: Run examples
+        shell: bash -ex -o pipefail {0}
+        run: |
+          cd ~/project/_build-submodule
+          ./hellox86
+          ./dfttutorial 4
+          ./dfttutorial 4
+
+      - name: Upload submodule artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: submodule project
+          path: |
+            ~/project/_build-submodule
+        if: always()

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,0 +1,106 @@
+
+name: "Build & Test Examples"
+
+on:
+  # allow direct trigger
+  workflow_dispatch:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GCC_VERSION: "11"
+  COMMON_CMAKE_FLAGS: >
+    -DSLEEF_SHOW_CONFIG=ON
+    -DSLEEF_BUILD_GNUABI_LIBS=ON
+    -DSLEEF_BUILD_DFT=ON
+    -DSLEEF_BUILD_QUAD=OFF
+    -DSLEEF_BUILD_SCALAR_LIB=ON
+    -DSLEEF_BUILD_SHARED_LIBS=OFF
+
+jobs:
+  build-native:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    name: build-native
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq build-essential cmake ninja-build gcc-${GCC_VERSION}
+
+      - name: Build native
+        shell: bash -ex -o pipefail {0}
+        run: |
+          cmake -S . -B _build-native -GNinja \
+            -DCMAKE_INSTALL_PREFIX=$(pwd)/_install-native \
+            -DCMAKE_TOOLCHAIN_FILE=$(pwd)/toolchains/native-gcc.cmake \
+            ${COMMON_CMAKE_FLAGS}
+          cmake --build _build-native
+          cmake --install _build-native
+
+      - name: Upload build-native artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-native
+          path: |
+            _build-*
+            _install-*
+        if: always()
+
+  examples-native:
+    runs-on: ubuntu-latest
+    needs: [build-native]
+    strategy:
+      fail-fast: false
+
+    name: examples-native
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Print host CPU info
+        run: |
+          cat /proc/cpuinfo
+
+      - name: Download build-native artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-native
+
+      - name: Create _examples-native directory
+        run: |
+          mkdir -p _examples-native
+
+      - name: Hello example native
+        shell: bash -ex -o pipefail {0}
+        run: |
+          gcc docs/hellox86.c -static -o _examples-native/hellox86 -I_install-native/include -L_install-native/lib -lsleef
+          ./_examples-native/hellox86
+
+      - name: DFT example native
+        shell: bash -ex -o pipefail {0}
+        run: |
+          gcc docs/tutorial.c -static -o _examples-native/dft -I_install-native/include -L_install-native/lib -lsleef -lsleefdft -lsleefscalar -lm -fopenmp
+          ./_examples-native/dft
+          ./_examples-native/dft
+
+      - name: Upload examples-native artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: examples-native
+          path: |
+            _examples-native

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,10 +1,13 @@
 cmake_minimum_required(VERSION 3.4.3)
+project(MyProject)
 include(ExternalProject)
 find_package(Git REQUIRED)
 
+option(SLEEF_BUILD_DFT_TUTORIAL "Build DFT tutorial" OFF)
+
 ExternalProject_Add(libsleef
   GIT_REPOSITORY https://github.com/shibatch/sleef
-  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/contrib
+  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/contrib -DSLEEF_BUILD_DFT=${SLEEF_BUILD_DFT_TUTORIAL} -DSLEEF_BUILD_SCALAR_LIB=ON -DSLEEF_BUILD_TESTS=OFF
 )
 
 include_directories(${CMAKE_BINARY_DIR}/contrib/include)
@@ -16,10 +19,9 @@ target_link_libraries(hellox86 sleef)
 
 #
 
-option(SLEEF_BUILD_DFT_TUTORIAL "Build DFT tutorial" OFF)
 if (SLEEF_BUILD_DFT_TUTORIAL)
   add_executable(dfttutorial tutorial.c)
   add_dependencies(dfttutorial libsleef)
   find_library(LIBM m)
-  target_link_libraries(dfttutorial sleef sleefdft ${LIBM})
+  target_link_libraries(dfttutorial sleef sleefdft sleefscalar ${LIBM} -fopenmp)
 endif()

--- a/docs/CMakeLists.txt.nested
+++ b/docs/CMakeLists.txt.nested
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.4.3)
 
+project(MyProject)
+
 set(sleef_SOURCE_DIR ${CMAKE_SOURCE_DIR}/sleef)
 set(sleef_BINARY_DIR ${CMAKE_BINARY_DIR}/sleef)
 
@@ -21,5 +23,5 @@ if (SLEEF_BUILD_DFT)
   set_target_properties(dfttutorial PROPERTIES C_STANDARD 99)
   add_dependencies(dfttutorial sleef)
   find_library(LIBM m)
-  target_link_libraries(dfttutorial sleef sleefdft ${LIBM})
+  target_link_libraries(dfttutorial sleef sleefdft sleefscalar ${LIBM} -fopenmp)
 endif()

--- a/docs/tutorial.c
+++ b/docs/tutorial.c
@@ -71,5 +71,5 @@ int main(int argc, char **argv) {
 
   SleefDFT_dispose(p);
 
-  exit(success);
+  exit(success ? EXIT_SUCCESS : EXIT_FAILURE);
 }


### PR DESCRIPTION
We only want to check if examples are working and documented use of SLEEF as subproject is not broken.
No need to complicate with different compilers, ... 

Add a new workflow to run examples.
Add a new workflow for nested project and submodule. Only works for x86 runners for now.
Fix exit error code in dft tutorial.c
Add project names to top-level CMakeLists to remove CMake warning.