### PR TITLE
Re-schedule GHA workflows

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -2,8 +2,6 @@
 name: "macOS Build & Test"
 
 on:
-  # allow direct trigger
-  workflow_dispatch:
   push:
   pull_request:
 

--- a/.github/workflows/build-and-test-msys2.yml
+++ b/.github/workflows/build-and-test-msys2.yml
@@ -2,8 +2,6 @@
 name: "MSYS2 Build & Test"
 
 on:
-  # allow direct trigger
-  workflow_dispatch:
   push:
   pull_request:
 

--- a/.github/workflows/build-as-subproject.yml
+++ b/.github/workflows/build-as-subproject.yml
@@ -2,8 +2,6 @@
 name: "Build SLEEF as Subproject"
 
 on:
-  # allow direct trigger
-  workflow_dispatch:
   push:
   pull_request:
 

--- a/.github/workflows/build-cross-llvm-mingw.yml
+++ b/.github/workflows/build-cross-llvm-mingw.yml
@@ -2,8 +2,6 @@
 name: "LLVM-MinGW Cross Build"
 
 on:
-  # allow direct trigger
-  workflow_dispatch:
   push:
   pull_request:
 

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -2,8 +2,6 @@
 name: "Build & Test Examples"
 
 on:
-  # allow direct trigger
-  workflow_dispatch:
   push:
   pull_request:
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,9 +1,7 @@
 
-name: "Build & Test"
+name: "Linux Build & Test"
 
 on:
-  # allow direct trigger
-  workflow_dispatch:
   push:
   pull_request:
 
@@ -247,6 +245,7 @@ jobs:
         if: always()
 
   test-cross:
+    if: github.event_name == 'push' && github.ref_name == 'master'
     runs-on: ubuntu-latest
     needs: [build-native, build-cross]
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # SLEEF
 
-![Github Actions](https://github.com/shibatch/sleef/actions/workflows/build_and_test.yml/badge.svg?event=push&branch=master)
 [![DOI:10.1109/TPDS.2019.2960333](http://img.shields.io/badge/DOI-10.1109/TPDS.2019.2960333-blue.svg)](https://ieeexplore.ieee.org/document/8936472)
 [![License](https://img.shields.io/badge/License-Boost_1.0-lightblue.svg)](https://www.boost.org/LICENSE_1_0.txt)
 ![CMake](https://img.shields.io/badge/cmake-v3.18+-yellow.svg)
@@ -36,9 +35,21 @@ Compilation of SLEEF on previously supported environments might still be safe, w
   <th colspan="9">OS/Compiler</th>
 </tr>
 <tr>
-  <th colspan="3">Linux</th>
-  <th colspan="2">macOS</th>
-  <th colspan="4">Windows</th>
+  <th colspan="3">Linux</br></br>
+  <a href="https://github.com/shibatch/sleef/actions/workflows/build_and_test.yml">
+    <img src="https://github.com/shibatch/sleef/actions/workflows/build_and_test.yml/badge.svg?event=push&branch=master"></a>
+  </th>
+  <th colspan="2">macOS</br></br>
+  <a href="https://github.com/shibatch/sleef/actions/workflows/build-and-test-macos.yml">
+    <img src="https://github.com/shibatch/sleef/actions/workflows/build-and-test-macos.yml/badge.svg?event=push&branch=master"></a>
+  </th>
+  <th colspan="4">Windows</br></br>
+  <a href="https://github.com/shibatch/sleef/actions/workflows/build-and-test-msys2.yml">
+    <img src="https://github.com/shibatch/sleef/actions/workflows/build-and-test-msys2.yml/badge.svg?event=push&branch=master"></a>
+  </br>
+  <a href="https://github.com/shibatch/sleef/actions/workflows/build-cross-llvm-mingw.yml">
+    <img src="https://github.com/shibatch/sleef/actions/workflows/build-cross-llvm-mingw.yml/badge.svg?event=push&branch=master"></a>
+  </th>
 </tr>
 <tr>
   <th>Arch.</th>


### PR DESCRIPTION
Disable manual trigger to avoid spamming runners.
Only run slow tests (like test-cross) on post-commit, ie. push events on the main branch.
Display status of main GHA tests in README's test matrix, so test that may fail in post-commit appear clearly in docs.