### PR TITLE
S/390: Use getauxval for detecting VXE2 to fix #560

### DIFF
--- a/src/libm/CMakeLists.txt
+++ b/src/libm/CMakeLists.txt
@@ -833,12 +833,6 @@ if (SLEEF_ARCH_S390X)
   add_dependencies(disps390x_128_obj disps390x_128.c_generated renamedsp128.h_generated ${TARGET_HEADERS})
   target_sources(${TARGET_LIBSLEEF} PRIVATE $<TARGET_OBJECTS:disps390x_128_obj>)
 
-  if(COMPILER_SUPPORTS_VXE2)
-    add_library(tryvxe2_obj OBJECT tryvxe2.c)
-    target_compile_options(tryvxe2_obj PRIVATE ${FLAGS_ENABLE_VXE2})
-    set_target_properties(tryvxe2_obj PROPERTIES ${COMMON_TARGET_PROPERTIES})
-    target_sources(${TARGET_LIBSLEEF} PRIVATE $<TARGET_OBJECTS:tryvxe2_obj>)
-  endif()
 endif(SLEEF_ARCH_S390X)
 
 # --------------------------------------------------------------------

--- a/src/libm/disps390x_128.c.org
+++ b/src/libm/disps390x_128.c.org
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <setjmp.h>
+#include <sys/auxv.h>
 
 #include "misc.h"
 
@@ -15,9 +16,15 @@
 
 #include "dispatcher.h"
 
+static int cpuSupportsVXE2() {
+  static int ret = -1;
+  if (ret == -1)
+    ret = !!(getauxval(AT_HWCAP) & HWCAP_S390_VXRS_EXT2);
+  return ret;
+}
+
 #ifdef ENABLE_VXE2
-void sleef_tryVXE2();
-#define SUBST_IF_EXT1(funcvxe2) if (cpuSupportsExt(sleef_tryVXE2)) p = funcvxe2;
+#define SUBST_IF_EXT1(funcvxe2) if (cpuSupportsVXE2()) p = funcvxe2;
 #else
 #define SUBST_IF_EXT1(funcvxe2)
 #endif

--- a/src/libm/tryvxe2.c
+++ b/src/libm/tryvxe2.c
@@ -1,8 +1,0 @@
-#include <vecintrin.h>
-
-__vector float sleef_cpuid_VXE2;
-__vector int sleef_cpuid_VXE1;
-
-void sleef_tryVXE2() {
-  sleef_cpuid_VXE2 = vec_float(sleef_cpuid_VXE1);
-}


### PR DESCRIPTION
Change the detection mechanism for the VXE2 feature from signal handling to getauxval. This is a bit simpler and also helps in multi-threaded uses of the library as in PyTorch:
https://github.com/pytorch/pytorch/issues/128503

In particular it prevents the sigjmp file scope variable from being accessed from multiple threads. This used to cause crashes with the way PyTorch uses Sleef in combination with OpenMP. In that case cpuSupportsExt is executed simultaneously by multiple threads what led to parallel writers to sigjmp. This used to be no problem running on IBM z15 and newer, where there is actually VXE2 available. However, running on IBM z14 the signal handler gets executed what actually makes use of the corrupted sigjmp data structure to get back into cpuSupportsExt.