### PR TITLE
Add mutex in feature detection code

### DIFF
--- a/src/libm/dispavx.c.org
+++ b/src/libm/dispavx.c.org
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <setjmp.h>
+#include <pthread.h>
 
 #include "misc.h"
 

--- a/src/libm/disppower_128.c.org
+++ b/src/libm/disppower_128.c.org
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <setjmp.h>
+#include <pthread.h>
 
 #include "misc.h"
 

--- a/src/libm/disps390x_128.c.org
+++ b/src/libm/disps390x_128.c.org
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <setjmp.h>
+#include <pthread.h>
 
 #include "misc.h"
 

--- a/src/libm/dispscalar.c.org
+++ b/src/libm/dispscalar.c.org
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <setjmp.h>
+#include <pthread.h>
 
 #include "misc.h"
 

--- a/src/libm/dispsse.c.org
+++ b/src/libm/dispsse.c.org
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <setjmp.h>
+#include <pthread.h>
 
 #include "misc.h"
 


### PR DESCRIPTION
This implements a suggestion from @shibatch for #561. It uses a pthread mutex to prevent multiple threads from accessing the sigjmp variable in the feature detection code simultaneously.

Remaining todos:
1. How to initialize the pthread mutex on MacOX and Windows? The code currently errors out on these platforms
2. With older Glibc's I guess this requires sleef users to link against libpthread. Would that be acceptable? With newer Glibcs libpthread is part of libc already.

Apart from that the code fixes the problems in #561 