### PR TITLE
Use Arm-hosted runners

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [aarch64, armhf, ppc64el, s390x, riscv64]
+        arch: [armhf, ppc64el, s390x, riscv64]
         compiler: [gcc, llvm]
         include:
           - arch: armhf
@@ -169,8 +169,6 @@ jobs:
           - arch: ppc64el
             binfmt: ppc64le
             gnupkg: -powerpc64le-linux-gnu
-          - arch: aarch64
-            debarch: arm64
         exclude:
           # Only GCC trunk supports the RISC-V V intrinsics and https://github.com/riscv-collab/riscv-gnu-toolchain
           # doesn't track a recent enough version yet
@@ -239,9 +237,7 @@ jobs:
         shell: bash -ex -o pipefail {0}
         run: |
           EXTRA_CMAKE_FLAGS=""
-          if [[ ${{ matrix.arch }} = "aarch64" ]]; then
-            EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DSLEEF_ENFORCE_SVE=ON"
-          elif [[ ${{ matrix.arch }} = "armhf" ]]; then
+          if [[ ${{ matrix.arch }} = "armhf" ]]; then
             # Disable inline headers, they just don't compile on armhf
             EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DSLEEF_BUILD_INLINE_HEADERS=OFF"
           elif [[ ${{ matrix.arch }} = "ppc64el" ]]; then
@@ -281,31 +277,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # AArch64
-          - arch: aarch64
-            compiler: gcc
-            qemu_cpu: "max,sve=off"
-          - arch: aarch64
-            compiler: gcc
-            qemu_cpu: "max,sve=on,sve128=on"
-          - arch: aarch64
-            compiler: gcc
-            qemu_cpu: "max,sve=on,sve256=on"
-          - arch: aarch64
-            compiler: gcc
-            qemu_cpu: "max,sve=on,sve512=on"
-          - arch: aarch64
-            compiler: llvm
-            qemu_cpu: "max,sve=off"
-          - arch: aarch64
-            compiler: llvm
-            qemu_cpu: "max,sve=on,sve128=on"
-          - arch: aarch64
-            compiler: llvm
-            qemu_cpu: "max,sve=on,sve256=on"
-          - arch: aarch64
-            compiler: llvm
-            qemu_cpu: "max,sve=on,sve512=on"
           # Aarch32
           - arch: armhf
             compiler: gcc

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Toolchain files provide some information on supported compiler versions.
 
 Only Linux distributions and macOS are fully tested in CI and thus officially supported.
 
+Only AArch64 and x86_64 vector extensions are built and tested natively on Linux and macOS.
+Other architectures/vector extensions are cross-compiled on Linux.
+
 Building SLEEF for Windows on x86 machines was officially supported ( :white_circle: ), as of 3.5.1,
 however it is only partially tested due to [known limitations of the test suite with MinGW or MSYS2](https://github.com/shibatch/sleef/issues/544).
 As a result tests for Windows on x86 only include DFT for now (other tests are disabled in build system),


### PR DESCRIPTION
Documentation for these runners here https://gitlab.arm.com/tooling/gha-runner-docs

Only SLEEF upstream repo is allowed to use these runners.

Integrate runners via strategy.matrix.os, in order to facilitate customisation of step (e.g. config) based on runner label.

<!-- Thank you for contributing! -->

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/shibatch/sleef/blob/HEAD/CONTRIBUTING.md).
- [x] I have considered portability of my change across platforms and architectures.
- [x] I have self-reviewed my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation accordingly.
- [x] I have added tests that prove my fix is effective or that my feature works.

# What is the purpose of this pull request?

<!-- Keep only the lines that apply. -->

* Add a workflow to GitHub Actions or add/modify a job in an existing workflow

# What changes did you make?

<!-- Give an overview of the change. -->

This PR consists in adding self-hosted AArch64 runners.

# Does this PR relate to any existing issue?

Relates to #481

# Is there anything you would like reviewers to focus on?

Please on focus on workflow syntax.
