### PR TITLE
This patch updates helpers for ppc64el, s390x and purec_scalar.

### DIFF
--- a/src/arch/helperpower_128.h
+++ b/src/arch/helperpower_128.h
@@ -103,16 +103,16 @@ typedef vquad vargquad;
 #define vset__s64(...) ((v__i64) {__VA_ARGS__})
 #define vset__u64(...) ((v__u64) {__VA_ARGS__})
 
-#define vsetall__vi(v)  vset__vi(v, v)
-#define vsetall__vi2(v) vset__vi2(v, v, v, v)
+#define vsetall__vi(v)  vset__vi((int)v, (int)v)
+#define vsetall__vi2(v) vset__vi2((int)v, (int)v, (int)v, (int)v)
 #define vsetall__vm(v)  vset__vm(v, v, v, v)
 #define vsetall__vo(v)  vset__vo(v, v, v, v)
-#define vsetall__vf(v)  vset__vf(v, v, v, v)
-#define vsetall__vd(v)  vset__vd(v, v)
-#define vsetall__u8(v)  vset__u8(v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v)
-#define vsetall__u32(v) vset__u32(v, v, v, v)
-#define vsetall__s64(v) vset__s64(v, v)
-#define vsetall__u64(v) vset__u64(v, v)
+#define vsetall__vf(v)  vset__vf((float)v, (float)v, (float)v, (float)v)
+#define vsetall__vd(v)  vset__vd((double)v, (double)v)
+#define vsetall__u8(v)  vset__u8((uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v, (uint8_t)v)
+#define vsetall__u32(v) vset__u32((uint32_t)v, (uint32_t)v, (uint32_t)v, (uint32_t)v)
+#define vsetall__s64(v) vset__s64((int64_t)v, (int64_t)v)
+#define vsetall__u64(v) vset__u64((uint64_t)v, (uint64_t)v)
 
 #define vzero__vi()  vsetall__vi(0)
 #define vzero__vi2() vsetall__vi2(0)
@@ -351,7 +351,7 @@ static INLINE vmask vcastu_vm_vi(vint vi)
 
 static INLINE vopmask vcast_vo_i(int i) {
   i = i ? -1 : 0;
-  return (vopmask) { i, i, i, i };
+  return (vopmask) { (unsigned int)i, (unsigned int)i, (unsigned int)i, (unsigned int)i };
 }
 
 // signed int to single-precision
@@ -860,11 +860,11 @@ static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) {
 #define vsrl64_vm_vm_i(x, c) ((vmask)vec_sr((__vector signed long long)x, (__vector unsigned long long)vsetall__vm(c)))
 
 static INLINE vint vcast_vi_vm(vmask vm) {
-  return (vint) { vm[0], vm[2] };
+  return (vint) { (int)vm[0], (int)vm[2] };
 }
 
 static INLINE vmask vcast_vm_vi(vint vi) {
-  return (vmask) (__vector signed long long) { vi[0], vi[1] };
+  return (vmask) (__vector signed long long) { (signed long long)vi[0], (signed long long)vi[1] };
 }
 
 static INLINE vmask vreinterpret_vm_vi64(vint64 v) { return (vmask)v; }

--- a/src/arch/helperpurec_scalar.h
+++ b/src/arch/helperpurec_scalar.h
@@ -426,7 +426,7 @@ static INLINE void vstream_v_p_vf(float *ptr, vfloat v) { *ptr = v; }
 static vquad loadu_vq_p(void *p) {
   vquad vq;
   memcpy(8 + (char *)&vq, p, 8);
-  memcpy((char *)&vq, 8 + p, 8);
+  memcpy((char *)&vq, 8 + (char *)p, 8);
   return vq;
 }
 

--- a/src/arch/helpers390x_128.h
+++ b/src/arch/helpers390x_128.h
@@ -78,7 +78,7 @@ typedef vquad vargquad;
 
 static INLINE int vavailability_i(int n) {
   if (n == 1 || n == 2) {
-    return vec_max((vdouble) {n, n}, (vdouble) {n, n})[0] != 0;
+    return vec_max((vdouble) {(double)n, (double)n}, (vdouble) {(double)n, (double)n})[0] != 0;
   }
   return 0;
 }
@@ -127,23 +127,23 @@ static INLINE vfloat vgather_vf_p_vi2(const float *p, vint2 vi2) {
   return ((vfloat) { p[vi2[0]], p[vi2[1]], p[vi2[2]], p[vi2[3]] });
 }
 
-static INLINE vopmask vcast_vo_i(int i) { return (vopmask) { i ? (long long)-1 : 0, i ? (long long)-1 : 0 }; }
+static INLINE vopmask vcast_vo_i(int i) { return (vopmask) { i ? (unsigned long long)-1 : 0, i ? (unsigned long long)-1 : 0 }; }
 static INLINE vint vcast_vi_i(int i) { return (vint) { i, i }; }
 static INLINE vint2 vcast_vi2_i(int i) { return (vint2) { i, i, i, i }; }
 static INLINE vfloat vcast_vf_f(float f) { return (vfloat) { f, f, f, f }; }
 static INLINE vdouble vcast_vd_d(double d) { return (vdouble) { d, d }; }
 
-static INLINE vdouble vcast_vd_vi(vint vi) { return (vdouble) { vi[0], vi[1] }; }
-static INLINE vfloat vcast_vf_vi2(vint2 vi) { return (vfloat) { vi[0], vi[1], vi[2], vi[3] }; }
+static INLINE vdouble vcast_vd_vi(vint vi) { return (vdouble) { (double)vi[0], (double)vi[1] }; }
+static INLINE vfloat vcast_vf_vi2(vint2 vi) { return (vfloat) { (float)vi[0], (float)vi[1], (float)vi[2], (float)vi[3] }; }
 static INLINE vdouble vtruncate_vd_vd(vdouble vd) { return __builtin_s390_vfidb(vd, 4, 5); }
 static INLINE vdouble vrint_vd_vd(vdouble vd) { return __builtin_s390_vfidb(vd, 4, 4); }
 
 static INLINE vint vrint_vi_vd(vdouble vd) {
   vd = vrint_vd_vd(vd);
-  return (vint) { vd[0], vd[1] };
+  return (vint) { (int)vd[0], (int)vd[1] };
 }
-static INLINE vint vtruncate_vi_vd(vdouble vd) { return (vint) { vd[0], vd[1] }; }
-static INLINE vint2 vtruncate_vi2_vf(vfloat vf) { return (vint) { vf[0], vf[1], vf[2], vf[3] }; }
+static INLINE vint vtruncate_vi_vd(vdouble vd) { return (vint) { (int)vd[0], (int)vd[1] }; }
+static INLINE vint2 vtruncate_vi2_vf(vfloat vf) { return (vint) { (int)vf[0], (int)vf[1], (int)vf[2], (int)vf[3] }; }
 
 static INLINE vmask vreinterpret_vm_vd(vdouble vd) { return (vmask)vd; }
 static INLINE vdouble vreinterpret_vd_vm(vmask vm) { return (vdouble)vm; }
@@ -202,7 +202,7 @@ static INLINE vmask vcast_vm_i64(int64_t i) { return (vmask)(vint64){ i, i }; }
 static INLINE vmask vcast_vm_u64(uint64_t i) { return (vmask)(vuint64){ i, i }; }
 
 static INLINE vmask vcastu_vm_vi(vint vi) { return (vmask)(vint2){ vi[0], 0, vi[1], 0 }; }
-static INLINE vint vcastu_vi_vm(vmask vi2) { return (vint){ vi2[0] >> 32, vi2[1] >> 32 }; }
+static INLINE vint vcastu_vi_vm(vmask vi2) { return (vint){ (int)(vi2[0] >> 32), (int)(vi2[1] >> 32) }; }
 
 static INLINE vint vreinterpretFirstHalf_vi_vi2(vint2 vi2) { return (vint){ vi2[0], vi2[1] }; }
 static INLINE vint2 vreinterpretFirstHalf_vi2_vi(vint vi) { return (vint2){ vi[0], vi[1], 0, 0 }; }
@@ -309,8 +309,8 @@ static INLINE vint vxor_vi_vi_vi(vint x, vint y) { return x ^ y; }
 static INLINE vint vand_vi_vo_vi(vopmask x, vint y) { return vreinterpretFirstHalf_vi_vi2((vint2)x) & y; }
 static INLINE vint vandnot_vi_vo_vi(vopmask x, vint y) { return vec_andc(y, vreinterpretFirstHalf_vi_vi2((vint2)x)); }
 
-static INLINE vint vsll_vi_vi_i(vint x, int c) { return (vint)(((__vector unsigned int)x) << (__vector unsigned int){c, c, c, c}); }
-static INLINE vint vsrl_vi_vi_i(vint x, int c) { return (vint)(((__vector unsigned int)x) >> (__vector unsigned int){c, c, c, c}); }
+static INLINE vint vsll_vi_vi_i(vint x, int c) { return (vint)(((__vector unsigned int)x) << (__vector unsigned int){(unsigned int)c, (unsigned int)c, (unsigned int)c, (unsigned int)c}); }
+static INLINE vint vsrl_vi_vi_i(vint x, int c) { return (vint)(((__vector unsigned int)x) >> (__vector unsigned int){(unsigned int)c, (unsigned int)c, (unsigned int)c, (unsigned int)c}); }
 static INLINE vint vsra_vi_vi_i(vint x, int c) { return x >> (__vector int){c, c, c, c}; }
 
 static INLINE vint veq_vi_vi_vi(vint x, vint y) { return vec_cmpeq(x, y); }
@@ -364,8 +364,8 @@ static INLINE vint2 vxor_vi2_vi2_vi2(vint2 x, vint2 y) { return x ^ y; }
 static INLINE vint2 vand_vi2_vo_vi2(vopmask x, vint2 y) { return (vint2)x & y; }
 static INLINE vint2 vandnot_vi2_vo_vi2(vopmask x, vint2 y) { return y & ~(vint2)x; }
 
-static INLINE vint2 vsll_vi2_vi2_i(vint2 x, int c) { return (vint2)(((__vector unsigned int)x) << (__vector unsigned int){c, c, c, c}); }
-static INLINE vint2 vsrl_vi2_vi2_i(vint2 x, int c) { return (vint2)(((__vector unsigned int)x) >> (__vector unsigned int){c, c, c, c}); }
+static INLINE vint2 vsll_vi2_vi2_i(vint2 x, int c) { return (vint2)(((__vector unsigned int)x) << (__vector unsigned int){(unsigned int)c, (unsigned int)c, (unsigned int)c, (unsigned int)c}); }
+static INLINE vint2 vsrl_vi2_vi2_i(vint2 x, int c) { return (vint2)(((__vector unsigned int)x) >> (__vector unsigned int){(unsigned int)c, (unsigned int)c, (unsigned int)c, (unsigned int)c}); }
 static INLINE vint2 vsra_vi2_vi2_i(vint2 x, int c) { return x >> (__vector int){c, c, c, c}; }
 
 static INLINE vopmask veq_vo_vi2_vi2(vint2 x, vint2 y) { return (vopmask)vec_cmpeq(x, y); }
@@ -405,7 +405,7 @@ static INLINE vopmask visnan_vo_vf (vfloat d) { return vneq_vo_vf_vf(d, d); }
 
 static INLINE vint2 vrint_vi2_vf(vfloat vf) {
   vf = vrint_vf_vf(vf);
-  return (vint) { vf[0], vf[1], vf[2], vf[3] };
+  return (vint) { (int)vf[0], (int)vf[1], (int)vf[2], (int)vf[3] };
 }
 
 //
@@ -445,11 +445,11 @@ static INLINE vopmask vgt64_vo_vm_vm(vmask x, vmask y) {
   return (vopmask)vec_cmpgt((__vector signed long long)x, (__vector signed long long)y);
 }
 
-#define vsll64_vm_vm_i(x, c) ((vmask)((__vector unsigned long long)x << (__vector unsigned long long) { c, c }))
-#define vsrl64_vm_vm_i(x, c) ((vmask)((__vector unsigned long long)x >> (__vector unsigned long long) { c, c }))
+#define vsll64_vm_vm_i(x, c) ((vmask)((__vector unsigned long long)x << (__vector unsigned long long) { (unsigned long long)c, (unsigned long long)c }))
+#define vsrl64_vm_vm_i(x, c) ((vmask)((__vector unsigned long long)x >> (__vector unsigned long long) { (unsigned long long)c, (unsigned long long)c }))
 
 static INLINE vint vcast_vi_vm(vmask vm) {
-  return (vint) { vm[0], vm[1] };
+  return (vint) { (int)vm[0], (int)vm[1] };
 }
 
 static INLINE vmask vcast_vm_vi(vint vi) {


### PR DESCRIPTION
It adds explicit typecasting so that C++ compilers can compile the inline headers generated from these helpers.

<!-- Thank you for contributing! -->

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/shibatch/sleef/blob/HEAD/CONTRIBUTING.md).
- [x] I have considered portability of my change across platforms and architectures.
- [x] I have self-reviewed my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation accordingly.
- [x] I have added tests that prove my fix is effective or that my feature works.

# What is the purpose of this pull request?

* This patch addresses the problem where the inline headers for ppc64el, s390x and purec_scalar cannot be compiled with C++ compilers.

# What changes did you make?

This patch updates helpers for ppc64el, s390x and purec_scalar.
It adds explicit typecasting so that C++ compilers can compile the inline headers generated from these helpers.

# Does this PR relate to any existing issue?

This is part of the patches that implements https://github.com/shibatch/sleef/issues/574.
