### PR TITLE
Update GH runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build-as-subproject.yml
+++ b/.github/workflows/build-as-subproject.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build-nested:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
 
@@ -80,7 +80,7 @@ jobs:
         if: always()
 
   build-submodule:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
 

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-native:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
 
@@ -59,7 +59,7 @@ jobs:
         if: always()
 
   examples-native:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build-native]
     strategy:
       fail-fast: false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ah-ubuntu_22_04-c7g_2x-50]
+        os: [ubuntu-24.04, ah-ubuntu_22_04-c7g_2x-50]
         compiler: [gcc, llvm]
 
     name: build-native-${{ matrix.os }}-${{ matrix.compiler }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Set x86_64 config
         shell: bash -ex -o pipefail {0}
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: |
             export EXTRA_CMAKE_FLAGS="\
               -DSLEEF_ENFORCE_SSE2=ON -DSLEEF_ENFORCE_SSE4=ON \
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ah-ubuntu_22_04-c7g_2x-50]
+        os: [ubuntu-24.04, ah-ubuntu_22_04-c7g_2x-50]
         compiler: [gcc, llvm]
 
     name: test-native-${{ matrix.os }}-${{ matrix.compiler }}
@@ -155,7 +155,7 @@ jobs:
         if: always()
 
   build-cross:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build-native]
     strategy:
       fail-fast: false
@@ -224,10 +224,10 @@ jobs:
           rm -rf sysroot/usr/libexec/gcc
         if: steps.check-sysroot-cache.outputs.cache-hit != 'true'
 
-      - name: Download build-native-ubuntu-latest-${{ matrix.compiler }} artifacts
+      - name: Download build-native-ubuntu-24.04-${{ matrix.compiler }} artifacts
         uses: actions/download-artifact@v3
         with:
-          name: build-native-ubuntu-latest-${{ matrix.compiler }}
+          name: build-native-ubuntu-24.04-${{ matrix.compiler }}
 
       - name: Fix _build-native permissions
         run: |
@@ -271,7 +271,7 @@ jobs:
 
   test-cross:
     if: github.event_name == 'push' && github.ref_name == 'master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build-native, build-cross]
     strategy:
       fail-fast: false
@@ -311,9 +311,6 @@ jobs:
           # - arch: riscv64
           #   compiler: gcc
           #   qemu_cpu: "rv64,zba=true,zbb=true,zbs=true,v=true,vlen=256,elen=64,vext_spec=v1.0"
-          # - arch: riscv64
-          #   compiler: gcc
-          #   qemu_cpu: "rv64,zba=true,zbb=true,zbs=true,v=true,vlen=512,elen=64,vext_spec=v1.0"
           - arch: riscv64
             compiler: llvm
             qemu_cpu: "rv64,zba=true,zbb=true,zbs=true,v=false"
@@ -323,9 +320,6 @@ jobs:
           - arch: riscv64
             compiler: llvm
             qemu_cpu: "rv64,zba=true,zbb=true,zbs=true,v=true,vlen=256,elen=64,vext_spec=v1.0"
-          - arch: riscv64
-            compiler: llvm
-            qemu_cpu: "rv64,zba=true,zbb=true,zbs=true,v=true,vlen=512,elen=64,vext_spec=v1.0"
 
     name: "test-${{ matrix.arch }}-${{ matrix.compiler }} (qemu_cpu: \"${{ matrix.qemu_cpu }}\")"
     steps:
@@ -345,10 +339,10 @@ jobs:
         run: |
           cat /proc/cpuinfo
 
-      - name: Download build-native-ubuntu-latest-${{ matrix.compiler }} artifacts
+      - name: Download build-native-ubuntu-24.04-${{ matrix.compiler }} artifacts
         uses: actions/download-artifact@v3
         with:
-          name: build-native-ubuntu-latest-${{ matrix.compiler }}
+          name: build-native-ubuntu-24.04-${{ matrix.compiler }}
 
       - name: Download build-${{ matrix.arch }}-${{ matrix.compiler }} artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/shibatch/sleef/blob/HEAD/CONTRIBUTING.md).
- [x] I have considered portability of my change across platforms and architectures.
- [x] I have self-reviewed my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation accordingly.
- [x] I have added tests that prove my fix is effective or that my feature works.

# What is the purpose of this pull request?

* Modify a job in an existing workflow

# What changes did you make?

This PR consists in updating gh-runners in linux native and cross build/test workflow, to use ubuntu-24.04 instead of ubuntu-latest. The main reasons are
- It is clearer to use explicit version of Ubuntu.
- update of ubuntu-latest to 24.04 is on hold because it disturbs a lot of workflows out there. But it is useful to use and does not create issues. https://github.com/actions/runner-images/issues/10636

PR also removes some expensive tests for RISC-V.

# Does this PR relate to any existing issue?

This will ultimately unlock the use of latest versions of gcc 12, then gcc 13, and finally gcc 14.
Gcc 14 itself will unlock more testing.
So it could relate to #439, and enable #539, ...

This PR does not update the version of gcc yet, just to make sure old version still pass tests.