### PR TITLE
[CMake] add a switch for libm.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ option(SLEEF_DISABLE_SSL "Disable testing with the SSL library" OFF)
 option(SLEEF_ENABLE_CUDA "Enable CUDA" OFF)
 option(SLEEF_ENABLE_CXX "Enable C++" OFF)
 
+option(SLEEF_BUILD_WITH_LIBM "build libsleef with libm, can turn off on Windows to solve mutiple math functions issue." ON)
+
 #
 
 if (SLEEF_BUILD_BENCH)

--- a/Configure.cmake
+++ b/Configure.cmake
@@ -48,7 +48,9 @@ endif()
 
 # Some toolchains require explicit linking of the libraries following.
 find_library(LIB_MPFR mpfr)
-find_library(LIBM m)
+if(SLEEF_BUILD_WITH_LIBM)
+  find_library(LIBM m)
+endif()
 find_library(LIBGMP gmp)
 find_library(LIBRT rt)
 find_library(LIBFFTW3 fftw3)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/shibatch/sleef/blob/HEAD/CONTRIBUTING.md).
- [x] I have considered portability of my change across platforms and architectures.
- [x] I have self-reviewed my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation accordingly.
- [x] I have added tests that prove my fix is effective or that my feature works.

# What is the purpose of this pull request?

<!-- Keep only the lines that apply. -->

* Improve code quality or performance

# What changes did you make?

Add a switch to turn off involve `libm`. It will bring duplicate math function on Windows.
1. `libm` is special library, it is usually appeared on Linux, but we not use it on Windows.
2. On Windows, Microsoft provided math functions on its runtime libraries, such as ucrt.lib.
3. In some case, such as Intel compiler environment, Intel provided a `libm` for high performance purpose. `Sleef`'s `find_library(libm m)` will involve the `libm` into project. So, we would occur the symbol conflict issue on math functions.

My solution is add a switch(option) to let upper CMake project turn off `libm` involvement. It default value is on, and keep compatible to original logical.

# Does this PR relate to any existing issue?

Relates to/Fixes [([Intel GPU] Symbol conflict between libm.lib and ucrt.lib for Intel GPU on Windows)](https://github.com/pytorch/pytorch/issues/134989)

# Is there anything you would like reviewers to focus on?

Please on focus on...
