### PR TITLE
Work around removal of some PowerPC intrinsics in GCC 15

### DIFF
--- a/src/arch/helperpower_128.h
+++ b/src/arch/helperpower_128.h
@@ -371,7 +371,7 @@ static INLINE vdouble vcast_vd_vi(vint vi)
 {
   vdouble ret;
   vint swap = vec_mergeh(vi, vi);
-#if defined(__clang__) || __GNUC__ >= 7
+#if defined(__clang__) || (__GNUC__ >= 7 && __GNUC__ < 15)
   ret = __builtin_vsx_xvcvsxwdp(swap);
 #else
   __asm__ __volatile__("xvcvsxwdp %x0,%x1" : "=wa" (ret) : "wa" (swap));
@@ -406,7 +406,7 @@ static INLINE vint2 vtruncate_vi2_vf(vfloat vf)
 static INLINE vint vtruncate_vi_vd(vdouble vd)
 {
   vint ret;
-#if defined(__clang__) || __GNUC__ >= 7
+#if defined(__clang__) || (__GNUC__ >= 7 && __GNUC__ < 15)
   ret = __builtin_vsx_xvcvdpsxws(vd);
 #else
   __asm__ __volatile__("xvcvdpsxws %x0,%x1" : "=wa" (ret) : "wa" (vd));


### PR DESCRIPTION
Fixes #611.

<!-- Thank you for contributing! -->

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/shibatch/sleef/blob/HEAD/CONTRIBUTING.md).
- [x] I have considered portability of my change across platforms and architectures.
- [x] I have self-reviewed my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation accordingly. **N/A**
- [ ] I have added tests that prove my fix is effective or that my feature works. **N/A**

# What is the purpose of this pull request?

<!-- Keep only the lines that apply. -->

* Fix a bug

# What changes did you make?

On GCC 15 and later, fall back to inline assembly instead of using removed intrinsics `__builtin_vsx_xvcvsxwdp()` and `__builtin_vsx_xvcvdpsxws()`.

<!-- Give an overview of the change. -->

This PR works around the removal of PowerPC intrinsics `__builtin_vsx_xvcvsxwdp()` and `__builtin_vsx_xvcvdpsxws()` in GCC 15.

# Does this PR relate to any existing issue?

Relates to/Fixes #611 

# Is there anything you would like reviewers to focus on?

Consider whether it would be better to replace `__builtin_vsx_xvcvsxwdp()` with `vec_doublee`/`vec_doubleo` as suggested in https://github.com/gcc-mirror/gcc/commit/fd9fdb33ae252ec34cc33675433eb56637905257, and to replace `__builtin_vsx_xvcvdpsxws()` with `vec_signede`/`vec_signedo` as suggested in https://github.com/gcc-mirror/gcc/commit/224cc560a6ac19c9454038efe6230096b46f4806. As noted in https://github.com/shibatch/sleef/issues/611, I’m not prepared to contribute that approach, but I would be happy to help test it.
