### PR TITLE
Add one more mutex to the internal parallel-for framework

### DIFF
--- a/src/dft/dftcommon.cpp
+++ b/src/dft/dftcommon.cpp
@@ -534,7 +534,7 @@ namespace {
     volatile bool shuttingDown = false, running = false;
     vector<shared_ptr<thread>> vth;
     vector<bool> idle;
-    mutex mtx;
+    mutex mtx, mtx2;
     condition_variable condVar;
     unordered_map<thread::id, unsigned> thIdMap;
 
@@ -593,6 +593,7 @@ namespace {
 
     void run(int64_t start, int64_t end, int64_t inc_,
 	     function<void(int64_t, int64_t, int64_t)> func_) {
+      unique_lock lock2(mtx2);
       unique_lock lock(mtx);
       waitUntilAllIdle(lock);
       inc = inc_;


### PR DESCRIPTION
This PR adds one more mutex to the internal parallel-for framework to handle the cases where the dft library is called from multiple threads.
