### PR TITLE
Fix quad-to-double rounding

### DIFF
--- a/src/quad-tester/qtester4simd.cpp
+++ b/src/quad-tester/qtester4simd.cpp
@@ -13,6 +13,7 @@
 #include <cfloat>
 #include <climits>
 #include <cassert>
+#include <cstring>
 
 #include "misc.h"
 #include "qtesterutil.h"
@@ -1128,6 +1129,50 @@ int main2(int argc, char **argv) {
 
   {
     printf("cast_to_doubleq : ");
+
+    struct {
+      uint64_t high, low, expected;
+    } cases[] = {
+      { UINT64_C(0x3fff000000000000), UINT64_C(0x07ffffffffffffff), UINT64_C(0x3ff0000000000000) },
+      { UINT64_C(0x3fff000000000000), UINT64_C(0x0800000000000000), UINT64_C(0x3ff0000000000000) },
+      { UINT64_C(0x3fff000000000000), UINT64_C(0x0800000000000001), UINT64_C(0x3ff0000000000001) },
+      { UINT64_C(0xbfff000000000000), UINT64_C(0x0800000000000001), UINT64_C(0xbff0000000000001) },
+      { UINT64_C(0x3bcbffffffffffff), UINT64_C(0xffffffffffffffff), UINT64_C(0x0000000000000000) },
+      { UINT64_C(0x3bcc000000000000), UINT64_C(0x0000000000000000), UINT64_C(0x0000000000000000) },
+      { UINT64_C(0x3bcc000000000000), UINT64_C(0x0000000000000001), UINT64_C(0x0000000000000001) },
+      { UINT64_C(0xbbcc000000000000), UINT64_C(0x0000000000000000), UINT64_C(0x8000000000000000) },
+      { UINT64_C(0xbbcc000000000000), UINT64_C(0x0000000000000001), UINT64_C(0x8000000000000001) },
+      { UINT64_C(0x43feffffffffffff), UINT64_C(0xf7ffffffffffffff), UINT64_C(0x7fefffffffffffff) },
+      { UINT64_C(0x43feffffffffffff), UINT64_C(0xf800000000000000), UINT64_C(0x7ff0000000000000) },
+      { UINT64_C(0x43feffffffffffff), UINT64_C(0xf800000000000001), UINT64_C(0x7ff0000000000000) },
+    };
+
+    for(auto c : cases) {
+      Sleef_quad a;
+      uint64_t words[2];
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+      words[0] = c.high; words[1] = c.low;
+#else
+      words[0] = c.low; words[1] = c.high;
+#endif
+      memcpy(&a, words, sizeof(a));
+
+      int idx = xrand() % VECTLENDP;
+      VARGQUAD v0;
+      memrand(&v0, SIZEOF_VARGQUAD);
+      v0 = xsetq(v0, idx, a);
+      vdouble vd = xcast_to_doubleq(v0);
+      double s[VECTLENDP];
+      vstoreu_v_p_vd(s, vd);
+      uint64_t actual;
+      memcpy(&actual, &s[idx], sizeof(actual));
+      if (actual != c.expected) {
+        tlfloat_printf("arg0 = %Qa, t = %a, expected bits = %016llx\n",
+                       a, s[idx], (unsigned long long)c.expected);
+        success = false;
+        break;
+      }
+    }
 
     xsrand(1);
     Sleef_quad min = (Sleef_quad)tlfloat_strtoq("0", nullptr), max = (Sleef_quad)tlfloat_strtoq("1e+20", nullptr);

--- a/src/quad/sleefsimdqp.c
+++ b/src/quad/sleefsimdqp.c
@@ -2601,11 +2601,43 @@ EXPORT CONST vargquad xcast_from_doubleq(vdouble d) {
 }
 
 EXPORT CONST vdouble xcast_to_doubleq(vargquad q) {
-  tdx t = cast_tdx_vq(cast_vq_aq(q));
-  t = tdxsetx_tdx_tdx_vd(t, vadd_vd_vd_vd(vadd_vd_vd_vd(tdxgetd3z_vd_tdx(t), tdxgetd3y_vd_tdx(t)), tdxgetd3x_vd_tdx(t)));
-  t = tdxsety_tdx_tdx_vd(t, vcast_vd_d(0));
-  t = tdxsetz_tdx_tdx_vd(t, vcast_vd_d(0));
-  return cast_vd_tdx(t);
+  vquad f = cast_vq_aq(q);
+  vmask low = vqgetx_vm_vq(f), high = vqgety_vm_vq(f);
+  vmask e = vand_vm_vm_vm(vsrl64_vm_vm_i(high, 48), vcast_vm_i64(0x7fff));
+  vmask sign = vand_vm_vm_vm(high, vcast_vm_u64(UINT64_C(0x8000000000000000)));
+  vmask fraction = vor_vm_vm_vm(vsll64_vm_vm_i(vand_vm_vm_vm(high, vcast_vm_u64(UINT64_C(0xffffffffffff))), 4),
+                                 vsrl64_vm_vm_i(low, 60));
+  vmask remainder = vand_vm_vm_vm(low, vcast_vm_u64(UINT64_C(0x0fffffffffffffff)));
+  vopmask roundUp = vor_vo_vo_vo(vgt64_vo_vm_vm(remainder, vcast_vm_u64(UINT64_C(0x0800000000000000))),
+                                  vand_vo_vo_vo(veq64_vo_vm_vm(remainder, vcast_vm_u64(UINT64_C(0x0800000000000000))),
+                                                vnot_vo64_vo64(veq64_vo_vm_vm(vand_vm_vm_vm(fraction, vcast_vm_i64(1)), vcast_vm_i64(0)))));
+  vmask normalBits = vor_vm_vm_vm(sign, vsll64_vm_vm_i(vsub64_vm_vm_vm(e, vcast_vm_i64(16383 - 1023)), 52));
+  normalBits = vadd64_vm_vm_vm(vor_vm_vm_vm(normalBits, fraction), vand_vm_vo64_vm(roundUp, vcast_vm_i64(1)));
+  vdouble result = vreinterpret_vd_vm(normalBits);
+
+  vopmask subnormal = vlt64_vo_vm_vm(e, vcast_vm_i64(16383 - 1022));
+  if (UNLIKELY(!vtestallzeros_i_vo64(subnormal))) {
+    tdx t = cast_tdx_vq(f);
+    tdx scaled = abs_tdx_tdx(tdxsete_tdx_tdx_vm(t, vadd64_vm_vm_vm(tdxgete_vm_tdx(t), vcast_vm_i64(1074))));
+    tdx integer;
+    tdx fractionPart = modf_tdx_tdx_ptdx(scaled, &integer);
+    vmask comparedToHalf = cmp_vm_tdx_tdx(fractionPart, cast_tdx_d(0.5));
+    vopmask roundSubnormalUp = vor_vo_vo_vo(vgt64_vo_vm_vm(comparedToHalf, vcast_vm_i64(0)),
+                                             vand_vo_vo_vo(veq64_vo_vm_vm(comparedToHalf, vcast_vm_i64(0)), isodd_vo_tdx(integer)));
+    integer = add_tdx_tdx_tdx(integer, sel_tdx_vo_tdx_tdx(roundSubnormalUp, cast_tdx_d(1), cast_tdx_d(0)));
+    vdouble subnormalResult = vmulsign_vd_vd_vd(vldexp2_vd_vd_vm(cast_vd_tdx(integer), vcast_vm_i64(-1074)),
+                                                 tdxgetd3x_vd_tdx(t));
+    result = vsel_vd_vo_vd_vd(subnormal, subnormalResult, result);
+  }
+
+  result = vsel_vd_vo_vd_vd(vgt64_vo_vm_vm(e, vcast_vm_i64(16383 + 1023)),
+                             vreinterpret_vd_vm(vor_vm_vm_vm(sign, vcast_vm_u64(UINT64_C(0x7ff0000000000000)))), result);
+
+  vopmask nonfinite = veq64_vo_vm_vm(e, vcast_vm_i64(0x7fff));
+  vopmask nan = vand_vo_vo_vo(nonfinite, vnot_vo64_vo64(veq64_vo_vm_vm(vor_vm_vm_vm(vand_vm_vm_vm(high, vcast_vm_u64(UINT64_C(0xffffffffffff))), low), vcast_vm_i64(0))));
+  vmask nonfiniteBits = vor_vm_vm_vm(vor_vm_vm_vm(sign, vcast_vm_u64(UINT64_C(0x7ff0000000000000))),
+                                     vand_vm_vo64_vm(nan, vcast_vm_u64(UINT64_C(0x0008000000000000))));
+  return vsel_vd_vo_vd_vd(nonfinite, vreinterpret_vd_vm(nonfiniteBits), result);
 }
 
 EXPORT CONST vint64 xcast_to_int64q(vargquad q) {


### PR DESCRIPTION
Round normal binary128 values directly from their encoded significand and handle binary64 subnormal midpoint ties using the full triple-double expansion. Add exact midpoint-neighbor regression cases for normal, underflow, and overflow boundaries.

