### PR TITLE
Use native rounding instructions for floor, ceil and round

### DIFF
--- a/src/arch/helperadvsimd.h
+++ b/src/arch/helperadvsimd.h
@@ -39,6 +39,8 @@
 
 #define FULL_FP_ROUNDING
 //@#define FULL_FP_ROUNDING
+#define NATIVE_ROUND
+//@#define NATIVE_ROUND
 #define ACCURATE_SQRT
 //@#define ACCURATE_SQRT
 
@@ -528,6 +530,16 @@ static INLINE vdouble vsel_vd_vo_vo_d_d_d(vopmask o0, vopmask o1, double d0, dou
 
 static INLINE vdouble vrint_vd_vd(vdouble d) { return vrndnq_f64(d); }
 static INLINE vfloat vrint_vf_vf(vfloat d) { return vrndnq_f32(d); }
+
+static INLINE vdouble vfloor_vd_vd(vdouble v) { return vrndmq_f64(v); }
+static INLINE vfloat vfloor_vf_vf(vfloat v) { return vrndmq_f32(v); }
+
+static INLINE vdouble vceil_vd_vd(vdouble v) { return vrndpq_f64(v); }
+static INLINE vfloat vceil_vf_vf(vfloat v) { return vrndpq_f32(v); }
+
+static INLINE vdouble vround_vd_vd(vdouble v) { return vrndaq_f64(v); }
+static INLINE vfloat vround_vf_vf(vfloat v) { return vrndaq_f32(v); }
+
 
 /****************************************/
 /* int <--> float conversions           */

--- a/src/arch/helperavx2.h
+++ b/src/arch/helperavx2.h
@@ -160,6 +160,14 @@ static INLINE vfloat vtruncate_vf_vf(vfloat vf) { return _mm256_round_ps(vf, _MM
 static INLINE vdouble vcast_vd_vi(vint vi) { return _mm256_cvtepi32_pd(vi); }
 static INLINE vint vcast_vi_i(int i) { return _mm_set1_epi32(i); }
 
+static INLINE vdouble vfloor_vd_vd(vdouble v) { return _mm256_round_pd(v, _MM_FROUND_TO_NEG_INF |_MM_FROUND_NO_EXC); }
+static INLINE vfloat vfloor_vf_vf(vfloat v) { return _mm256_round_ps(v, _MM_FROUND_TO_NEG_INF |_MM_FROUND_NO_EXC); }
+
+static INLINE vdouble vceil_vd_vd(vdouble v) { return _mm256_round_pd(v, _MM_FROUND_TO_POS_INF |_MM_FROUND_NO_EXC); }
+static INLINE vfloat vceil_vf_vf(vfloat v) { return _mm256_round_ps(v, _MM_FROUND_TO_POS_INF |_MM_FROUND_NO_EXC); }
+
+
+
 static INLINE vmask vcastu_vm_vi(vint vi) {
   return _mm256_slli_epi64(_mm256_cvtepi32_epi64(vi), 32);
 }

--- a/src/arch/helperavx2_128.h
+++ b/src/arch/helperavx2_128.h
@@ -150,6 +150,13 @@ static INLINE vfloat vtruncate_vf_vf(vfloat vf) { return _mm_round_ps(vf, _MM_FR
 static INLINE vdouble vcast_vd_vi(vint vi) { return _mm_cvtepi32_pd(vi); }
 static INLINE vint vcast_vi_i(int i) { return _mm_set1_epi32(i); }
 
+static INLINE vdouble vfloor_vd_vd(vdouble v) { return _mm_round_pd(v, _MM_FROUND_TO_NEG_INF |_MM_FROUND_NO_EXC); }
+static INLINE vfloat vfloor_vf_vf(vfloat v) { return _mm_round_ps(v, _MM_FROUND_TO_NEG_INF |_MM_FROUND_NO_EXC); }
+
+static INLINE vdouble vceil_vd_vd(vdouble v) { return _mm_round_pd(v, _MM_FROUND_TO_POS_INF |_MM_FROUND_NO_EXC); }
+static INLINE vfloat vceil_vf_vf(vfloat v) { return _mm_round_ps(v, _MM_FROUND_TO_POS_INF |_MM_FROUND_NO_EXC); }
+
+
 static INLINE vmask vcastu_vm_vi(vint vi) { return _mm_and_si128(_mm_shuffle_epi32(vi, 0x73), _mm_set_epi32(-1, 0, -1, 0)); }
 static INLINE vint vcastu_vi_vm(vmask vi) { return _mm_shuffle_epi32(vi, 0x0d); }
 

--- a/src/arch/helperavx512f.h
+++ b/src/arch/helperavx512f.h
@@ -352,6 +352,12 @@ static INLINE vfloat vtruncate_vf_vf(vfloat vd) {
 static INLINE vfloat vrint_vf_vf(vfloat vd) {
   return _mm512_roundscale_ps(vd, _MM_FROUND_TO_NEAREST_INT |_MM_FROUND_NO_EXC);
 }
+static INLINE vdouble vfloor_vd_vd(vdouble v) { return _mm512_roundscale_pd(v, _MM_FROUND_TO_NEG_INF |_MM_FROUND_NO_EXC); }
+static INLINE vfloat vfloor_vf_vf(vfloat v) { return _mm512_roundscale_ps(v, _MM_FROUND_TO_NEG_INF |_MM_FROUND_NO_EXC); }
+
+static INLINE vdouble vceil_vd_vd(vdouble v) { return _mm512_roundscale_pd(v, _MM_FROUND_TO_POS_INF |_MM_FROUND_NO_EXC); }
+static INLINE vfloat vceil_vf_vf(vfloat v) { return _mm512_roundscale_ps(v, _MM_FROUND_TO_POS_INF |_MM_FROUND_NO_EXC); }
+
 
 static INLINE vfloat vadd_vf_vf_vf(vfloat x, vfloat y) { return _mm512_add_ps(x, y); }
 static INLINE vfloat vsub_vf_vf_vf(vfloat x, vfloat y) { return _mm512_sub_ps(x, y); }

--- a/src/arch/helperpower_128.h
+++ b/src/arch/helperpower_128.h
@@ -430,6 +430,12 @@ static INLINE vdouble vrint_vd_vd(vdouble vd)
 static INLINE vfloat vrint_vf_vf(vfloat vf)
 { return vec_rint(vf); }
 
+static INLINE vdouble vfloor_vd_vd(vdouble v) { return vec_floor(v); }
+static INLINE vfloat vfloor_vf_vf(vfloat v) { return vec_floor(v); }
+
+static INLINE vdouble vceil_vd_vd(vdouble v) { return vec_ceil(v); }
+static INLINE vfloat vceil_vf_vf(vfloat v) { return vec_ceil(v); }
+
 /**********************************************
  ** Logical
  **********************************************/

--- a/src/arch/helperpurec_scalar.h
+++ b/src/arch/helperpurec_scalar.h
@@ -27,6 +27,13 @@
 #define TRUNC trunc
 #define TRUNCF truncf
 
+#define FLOOR floor
+#define FLOORF floorf
+#define CEIL ceil
+#define CEILF ceilf
+#define ROUND round
+#define ROUNDF roundf
+
 #else
 
 #define SQRT __builtin_sqrt
@@ -37,6 +44,14 @@
 #define RINTF __builtin_rintf
 #define TRUNC __builtin_trunc
 #define TRUNCF __builtin_truncf
+
+#define FLOOR __builtin_floor
+#define FLOORF __builtin_floorf
+#define CEIL __builtin_ceil
+#define CEILF __builtin_ceilf
+#define ROUND __builtin_round
+#define ROUNDF __builtin_roundf
+
 
 #endif
 
@@ -91,6 +106,8 @@
 #if defined(__aarch64__) || CONFIG == 3
 #define FULL_FP_ROUNDING
 //@#define FULL_FP_ROUNDING
+#define NATIVE_ROUND
+//@#define NATIVE_ROUND
 #endif
 
 #define DFTPRIORITY LOG2VECTLENDP
@@ -189,6 +206,15 @@ static INLINE vint vrint_vi_vd(vdouble d) { return (int32_t)RINT(d); }
 static INLINE vdouble vrint_vd_vd(vdouble vd) { return RINT(vd); }
 static INLINE vdouble vtruncate_vd_vd(vdouble vd) { return TRUNC(vd); }
 static INLINE vint vtruncate_vi_vd(vdouble vd) { return (int32_t)TRUNC(vd); }
+
+static INLINE vdouble vfloor_vd_vd(vdouble v) { return FLOOR(v); }
+static INLINE vfloat vfloor_vf_vf(vfloat v) { return FLOORF(v); }
+
+static INLINE vdouble vceil_vd_vd(vdouble v) { return CEIL(v); }
+static INLINE vfloat vceil_vf_vf(vfloat v) { return CEILF(v); }
+
+static INLINE vdouble vround_vd_vd(vdouble v) { return ROUND(v); }
+static INLINE vfloat vround_vf_vf(vfloat v) { return ROUNDF(v); }
 #else
 static INLINE vint vrint_vi_vd(vdouble a) {
   a += a > 0 ? 0.5 : -0.5;

--- a/src/arch/helpers390x_128.h
+++ b/src/arch/helpers390x_128.h
@@ -40,6 +40,8 @@
 
 #define ACCURATE_SQRT
 //@#define ACCURATE_SQRT
+#define NATIVE_ROUND
+//@#define NATIVE_ROUND
 #define FULL_FP_ROUNDING
 //@#define FULL_FP_ROUNDING
 
@@ -134,7 +136,14 @@ static INLINE vdouble vcast_vd_d(double d) { return (vdouble) { d, d }; }
 static INLINE vdouble vcast_vd_vi(vint vi) { return (vdouble) { (double)vi[0], (double)vi[1] }; }
 static INLINE vfloat vcast_vf_vi2(vint2 vi) { return (vfloat) { (float)vi[0], (float)vi[1], (float)vi[2], (float)vi[3] }; }
 static INLINE vdouble vtruncate_vd_vd(vdouble vd) { return __builtin_s390_vfidb(vd, 4, 5); }
+
 static INLINE vdouble vrint_vd_vd(vdouble vd) { return __builtin_s390_vfidb(vd, 4, 4); }
+static INLINE vdouble vfloor_vd_vd(vdouble vd) { return __builtin_s390_vfidb(vd, 4, 7); }
+static INLINE vfloat  vfloor_vf_vf(vfloat  vf) { return __builtin_s390_vfisb(vf, 4, 7); }
+static INLINE vdouble vceil_vd_vd (vdouble vd) { return __builtin_s390_vfidb(vd, 4, 6); }
+static INLINE vfloat  vceil_vf_vf (vfloat  vf) { return __builtin_s390_vfisb(vf, 4, 6); }
+static INLINE vdouble vround_vd_vd(vdouble vd) { return __builtin_s390_vfidb(vd, 4, 1); }
+static INLINE vfloat  vround_vf_vf(vfloat  vf) { return __builtin_s390_vfisb(vf, 4, 1); }
 
 static INLINE vint vrint_vi_vd(vdouble vd) {
   vd = vrint_vd_vd(vd);

--- a/src/arch/helpersve.h
+++ b/src/arch/helpersve.h
@@ -90,6 +90,8 @@ static INLINE int vavailability_i(int name) { return 3; }
 
 #define FULL_FP_ROUNDING
 //@#define FULL_FP_ROUNDING
+#define NATIVE_ROUND
+//@#define NATIVE_ROUND
 #define ACCURATE_SQRT
 //@#define ACCURATE_SQRT
 
@@ -750,6 +752,16 @@ static INLINE vint vrint_vi_vd(vdouble vd) {
 static INLINE vdouble vrint_vd_vd(vdouble vd) {
   return svrintn_f64_x(ptrue, vd);
 }
+
+static INLINE vdouble vfloor_vd_vd(vdouble v) { return svrintm_f64_x(ptrue, v); }
+static INLINE vfloat vfloor_vf_vf(vfloat v) { return svrintm_f32_x(ptrue, v); }
+
+static INLINE vdouble vceil_vd_vd(vdouble v) { return svrintp_f64_x(ptrue, v); }
+static INLINE vfloat vceil_vf_vf(vfloat v) { return svrintp_f32_x(ptrue, v); }
+
+static INLINE vdouble vround_vd_vd(vdouble v) { return svrinta_f64_x(ptrue, v); }
+static INLINE vfloat vround_vf_vf(vfloat v) { return svrinta_f32_x(ptrue, v); }
+
 
 // FP math operations
 static INLINE vdouble vadd_vd_vd_vd(vdouble x, vdouble y) {

--- a/src/common/commonfuncs.h
+++ b/src/common/commonfuncs.h
@@ -226,7 +226,7 @@ static INLINE CONST vdouble vorsign_vd_vd_vd(vdouble x, vdouble y) {
 }
 
 static INLINE CONST vdouble vcopysign_vd_vd_vd(vdouble x, vdouble y) {
-  return vreinterpret_vd_vm(vxor_vm_vm_vm(vandnot_vm_vm_vm(vreinterpret_vm_vd(vcast_vd_d(-0.0)), vreinterpret_vm_vd(x)), 
+  return vreinterpret_vd_vm(vxor_vm_vm_vm(vandnot_vm_vm_vm(vreinterpret_vm_vd(vcast_vd_d(-0.0)), vreinterpret_vm_vd(x)),
 					  vand_vm_vm_vm   (vreinterpret_vm_vd(vcast_vd_d(-0.0)), vreinterpret_vm_vd(y))));
 }
 #endif
@@ -242,20 +242,31 @@ static INLINE CONST vdouble vtruncate2_vd_vd(vdouble x) {
 }
 
 static INLINE CONST vdouble vfloor2_vd_vd(vdouble x) {
+#ifdef FULL_FP_ROUNDING
+    return vfloor_vd_vd(x);
+#else
   vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 31)))))));
   fr = vsub_vd_vd_vd(fr, vcast_vd_vi(vtruncate_vi_vd(fr)));
   fr = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(fr, vcast_vd_d(0)), vadd_vd_vd_vd(fr, vcast_vd_d(1.0)), fr);
   return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(x), vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(INT64_C(1) << 52))), x, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), x));
+#endif
 }
 
 static INLINE CONST vdouble vceil2_vd_vd(vdouble x) {
+#ifdef FULL_FP_ROUNDING
+    return vceil_vd_vd(x);
+#else
   vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 31)))))));
   fr = vsub_vd_vd_vd(fr, vcast_vd_vi(vtruncate_vi_vd(fr)));
   fr = vsel_vd_vo_vd_vd(vle_vo_vd_vd(fr, vcast_vd_d(0)), fr, vsub_vd_vd_vd(fr, vcast_vd_d(1.0)));
   return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(x), vge_vo_vd_vd(vabs_vd_vd(x), vcast_vd_d(INT64_C(1) << 52))), x, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), x));
+#endif
 }
 
 static INLINE CONST vdouble vround2_vd_vd(vdouble d) {
+#ifdef NATIVE_ROUND
+    return vround_vd_vd(d);
+#else
   vdouble x = vadd_vd_vd_vd(d, vcast_vd_d(0.5));
   vdouble fr = vsub_vd_vd_vd(x, vmul_vd_vd_vd(vcast_vd_d(INT64_C(1) << 31), vcast_vd_vi(vtruncate_vi_vd(vmul_vd_vd_vd(x, vcast_vd_d(1.0 / (INT64_C(1) << 31)))))));
   fr = vsub_vd_vd_vd(fr, vcast_vd_vi(vtruncate_vi_vd(fr)));
@@ -263,6 +274,7 @@ static INLINE CONST vdouble vround2_vd_vd(vdouble d) {
   fr = vsel_vd_vo_vd_vd(vlt_vo_vd_vd(fr, vcast_vd_d(0)), vadd_vd_vd_vd(fr, vcast_vd_d(1.0)), fr);
   x = vsel_vd_vo_vd_vd(veq_vo_vd_vd(d, vcast_vd_d(0.49999999999999994449)), vcast_vd_d(0), x);
   return vsel_vd_vo_vd_vd(vor_vo_vo_vo(visinf_vo_vd(d), vge_vo_vd_vd(vabs_vd_vd(d), vcast_vd_d(INT64_C(1) << 52))), d, vcopysign_vd_vd_vd(vsub_vd_vd_vd(x, fr), d));
+#endif
 }
 
 static INLINE  CONST vdouble vrint2_vd_vd(vdouble d) {

--- a/src/common/keywords.txt
+++ b/src/common/keywords.txt
@@ -386,6 +386,12 @@ vrev21_vf_vf
 vreva2_vd_vd
 vreva2_vf_vf
 vrint_vd_vd
+vfloor_vd_vd
+vfloor_vf_vf
+vceil_vd_vd
+vceil_vf_vf
+vround_vd_vd
+vround_vf_vf
 vrint2_vd_vd
 vrint_vf_vf
 vrint_vi2_vf

--- a/src/libm/sleefsimdsp.c
+++ b/src/libm/sleefsimdsp.c
@@ -2163,24 +2163,36 @@ EXPORT CONST vfloat xtruncf(vfloat x) {
 }
 
 EXPORT CONST vfloat xfloorf(vfloat x) {
+#ifdef FULL_FP_ROUNDING
+    return vfloor_vf_vf(x);
+#else
   vfloat fr = vsub_vf_vf_vf(x, vcast_vf_vi2(vtruncate_vi2_vf(x)));
   fr = vsel_vf_vo_vf_vf(vlt_vo_vf_vf(fr, vcast_vf_f(0)), vadd_vf_vf_vf(fr, vcast_vf_f(1.0f)), fr);
   return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(x), vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(INT64_C(1) << 23))), x, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), x));
+#endif
 }
 
 EXPORT CONST vfloat xceilf(vfloat x) {
+#ifdef FULL_FP_ROUNDING
+    return vceil_vf_vf(x);
+#else
   vfloat fr = vsub_vf_vf_vf(x, vcast_vf_vi2(vtruncate_vi2_vf(x)));
   fr = vsel_vf_vo_vf_vf(vle_vo_vf_vf(fr, vcast_vf_f(0)), fr, vsub_vf_vf_vf(fr, vcast_vf_f(1.0f)));
   return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(x), vge_vo_vf_vf(vabs_vf_vf(x), vcast_vf_f(INT64_C(1) << 23))), x, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), x));
+#endif
 }
 
 EXPORT CONST vfloat xroundf(vfloat d) {
+#ifdef NATIVE_ROUND
+    return vround_vf_vf(d);
+#else
   vfloat x = vadd_vf_vf_vf(d, vcast_vf_f(0.5f));
   vfloat fr = vsub_vf_vf_vf(x, vcast_vf_vi2(vtruncate_vi2_vf(x)));
   x = vsel_vf_vo_vf_vf(vand_vo_vo_vo(vle_vo_vf_vf(x, vcast_vf_f(0)), veq_vo_vf_vf(fr, vcast_vf_f(0))), vsub_vf_vf_vf(x, vcast_vf_f(1.0f)), x);
   fr = vsel_vf_vo_vf_vf(vlt_vo_vf_vf(fr, vcast_vf_f(0)), vadd_vf_vf_vf(fr, vcast_vf_f(1.0f)), fr);
   x = vsel_vf_vo_vf_vf(veq_vo_vf_vf(d, vcast_vf_f(0.4999999701976776123f)), vcast_vf_f(0), x);
   return vsel_vf_vo_vf_vf(vor_vo_vo_vo(visinf_vo_vf(d), vge_vo_vf_vf(vabs_vf_vf(d), vcast_vf_f(INT64_C(1) << 23))), d, vcopysign_vf_vf_vf(vsub_vf_vf_vf(x, fr), d));
+#endif
 }
 
 EXPORT CONST vfloat xrintf(vfloat d) {


### PR DESCRIPTION
These operations used generic conversion paths even on ISAs that have an instruction for them.
Adds vfloor_, vceil_, vround_ helpers and uses them in commonfuncs.h and sleefsimdsp.c

round added to advsimd, purec_scalar, s390x_128, sve. It is gated on a new macro NATIVE_ROUND, defined only where the ISA has that operation.

ceil,floor added to advsimd, avx2, avx2_128, avx512f, power, purec_scalar, s390x_128, sve.

On aarch64: Sleef_ceilf4_advsimd goes from 19 instructions to 1.

Ctest passes on macos aarch64.